### PR TITLE
Removed the usage of qt5_use_modules in the CMake build configuration.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,11 +2,13 @@ cmake_minimum_required(VERSION 2.8.11)
 project(mCRL2)
   
 if(NOT ${CMAKE_VERSION} VERSION_LESS 3.0)
-  # Do not implicitly dereference variables or keywords when quoted in an if() command. 
-  cmake_policy(SET CMP0054 OLD)
-  
   # Ignore variable COMPILE_DEFINITIONS_<CONFIG>
   cmake_policy(SET CMP0043 NEW)
+endif()
+
+if (NOT ${CMAKE_VERSION} VERSION_LESS 3.1)
+  # Do not implicitly dereference variables or keywords when quoted in an if() command. 
+  cmake_policy(SET CMP0054 OLD)
 endif()
 
 if(NOT ${CMAKE_VERSION} VERSION_LESS 3.10)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,12 +1,18 @@
 cmake_minimum_required(VERSION 2.8.11)
 project(mCRL2)
-
-if("${CMAKE_MAJOR_VERSION}" GREATER 2)
+  
+if(NOT ${CMAKE_VERSION} VERSION_LESS 3.0)
+  # Do not implicitly dereference variables or keywords when quoted in an if() command. 
+  cmake_policy(SET CMP0054 OLD)
+  
+  # Ignore variable COMPILE_DEFINITIONS_<CONFIG>
   cmake_policy(SET CMP0043 NEW)
-  if("${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION}" GREATER 3.0)
-    cmake_policy(SET CMP0054 OLD)
-  endif()
 endif()
+
+if(NOT ${CMAKE_VERSION} VERSION_LESS 3.10)
+  # From CMake 3.10 onwards the AUTOMOC and AUTOUIC properties apply to GENERATED files.
+  cmake_policy(SET CMP0071 OLD)
+endif()  
 
 set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/build/cmake)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
@@ -46,14 +52,12 @@ if(MCRL2_ENABLE_GUI_TOOLS)
   find_package(GL2PS      QUIET REQUIRED)
   find_package(TR         QUIET REQUIRED)
   find_package(CVC3       QUIET)
-  find_package(Qt5Core    QUIET REQUIRED)
-  find_package(Qt5OpenGL  QUIET REQUIRED)
-  find_package(Qt5Widgets QUIET REQUIRED)
-  find_package(Qt5Xml     QUIET REQUIRED)
-  find_package(Qt5Gui     QUIET REQUIRED)
+  find_package(Qt5 COMPONENTS Core OpenGL Widgets Xml Gui QUIET REQUIRED)
+
   set_target_properties(Qt5::Core Qt5::OpenGL Qt5::Widgets Qt5::Xml Qt5::Gui
                         PROPERTIES MAP_IMPORTED_CONFIG_MAINTAINER "RELEASE")
 endif()
+
 find_package(Boost ${MCRL2_MIN_BOOST_VERSION} QUIET REQUIRED)
 include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
 

--- a/libraries/gui/CMakeLists.txt
+++ b/libraries/gui/CMakeLists.txt
@@ -11,10 +11,10 @@ if(Qt5Core_FOUND AND Qt5Widgets_FOUND)
       workarounds.cpp
     DEPENDS
       mcrl2_utilities
-      QtCore
-      QtGui
-      QtWidgets
-      QtOpenGL
+      Qt5::Core
+      Qt5::Gui
+      Qt5::Widgets
+      Qt5::OpenGL
       ${OPENGL_LIBRARIES}
     INCLUDE
       ${OPENGL_INCLUDE_DIR}

--- a/tools/experimental/mcrl2ide/CMakeLists.txt
+++ b/tools/experimental/mcrl2ide/CMakeLists.txt
@@ -20,8 +20,8 @@ add_mcrl2_tool(mcrl2ide
     solvedock.cpp
   DEPENDS
     mcrl2_gui
-    QtCore
-    QtGui
-    QtWidgets
-    QtXml
+    Qt5::Core
+    Qt5::Gui
+    Qt5::Widgets
+    Qt5::Xml
 )

--- a/tools/release/diagraphica/CMakeLists.txt
+++ b/tools/release/diagraphica/CMakeLists.txt
@@ -43,11 +43,11 @@ add_mcrl2_tool(diagraphica
     mcrl2_lts
     mcrl2_utilities
     mcrl2_gui
-    QtWidgets
-    QtCore
-    QtOpenGL
-    QtXml
-    QtGui
+    Qt5::Widgets
+    Qt5::Core
+    Qt5::OpenGL
+    Qt5::Xml
+    Qt5::Gui
     ${OPENGL_LIBRARIES}
   INCLUDE
     ${OPENGL_INCLUDE_DIR}

--- a/tools/release/lpsxsim/CMakeLists.txt
+++ b/tools/release/lpsxsim/CMakeLists.txt
@@ -11,7 +11,7 @@ add_mcrl2_tool(lpsxsim
   DEPENDS
     mcrl2_lps
     mcrl2_gui
-    QtCore
-    QtGui
-    QtWidgets
+    Qt5::Core
+    Qt5::Gui
+    Qt5::Widgets
 )

--- a/tools/release/ltsgraph/CMakeLists.txt
+++ b/tools/release/ltsgraph/CMakeLists.txt
@@ -24,11 +24,11 @@ add_mcrl2_tool(ltsgraph
   DEPENDS
     mcrl2_lts
     mcrl2_gui
-    QtCore
-    QtGui
-    QtOpenGL
-    QtWidgets
-    QtXml
+    Qt5::Core
+    Qt5::Gui
+    Qt5::OpenGL
+    Qt5::Widgets
+    Qt5::Xml
     ${OPENGL_LIBRARIES}
     ${GL2PS_LIBRARIES}
   INCLUDE

--- a/tools/release/ltsview/CMakeLists.txt
+++ b/tools/release/ltsview/CMakeLists.txt
@@ -47,11 +47,11 @@ add_mcrl2_tool(ltsview
   DEPENDS
     mcrl2_lts
     mcrl2_gui
-    QtCore
-    QtGui
-    QtOpenGL
-    QtWidgets
-    QtXml
+    Qt5::Core
+    Qt5::Gui
+    Qt5::OpenGL
+    Qt5::Widgets
+    Qt5::Xml
     ${OPENGL_LIBRARIES}
     ${GL2PS_LIBRARIES}
     ${TR_LIBRARIES}

--- a/tools/release/mcrl2-gui/CMakeLists.txt
+++ b/tools/release/mcrl2-gui/CMakeLists.txt
@@ -24,10 +24,10 @@ add_mcrl2_tool(mcrl2-gui
   DEPENDS
     mcrl2_utilities
     mcrl2_gui
-    QtCore
-    QtGui
-    QtWidgets
-    QtXml
+    Qt5::Core
+    Qt5::Gui
+    Qt5::Widgets
+    Qt5::Xml
 )
 add_custom_target(mcrl2-gui-shared
   SOURCES

--- a/tools/release/mcrl2xi/CMakeLists.txt
+++ b/tools/release/mcrl2xi/CMakeLists.txt
@@ -19,7 +19,7 @@ add_mcrl2_tool(mcrl2xi
   DEPENDS
     mcrl2_lps
     mcrl2_gui
-    QtCore
-    QtGui
-    QtWidgets
+    Qt5::Core
+    Qt5::Gui
+    Qt5::Widgets
 )


### PR DESCRIPTION
From Qt version 5.11 the CMake function qt5_use_modules is removed and as such it is not possible to compile the mCRL2 GUI tools with this new version. This pull request modifies the CMake configuration such that this function is replaced by target_link_libraries. It also uses find_libraries with the COMPONENTS argument such that these can be found after setting the Qt5_DIR.