### PR TITLE
Enumerate only enumerable variables in the rewriter

### DIFF
--- a/libraries/data/include/mcrl2/data/enumerator.h
+++ b/libraries/data/include/mcrl2/data/enumerator.h
@@ -163,7 +163,64 @@ bool compute_finite_function_sorts(const function_sort& sort,
   return true;
 }
 
+template <typename Rewriter>
+bool is_enumerable(const data_specification& dataspec, const Rewriter& rewr, const sort_expression& sort, std::list<sort_expression>& parents)
+{
+  if(sort_bag::is_bag(sort) || sort_fbag::is_fbag(sort))
+  {
+    return false;
+  }
+  else if(is_function_sort(sort))
+  {
+    const function_sort& func = atermpp::down_cast<function_sort>(sort);
+    enumerator_identifier_generator id_gen;
+    data_expression_vector expr_vec;
+    variable_list var_list;
+    return dataspec.is_certainly_finite(func) &&
+      detail::compute_finite_function_sorts(func, id_gen, dataspec, rewr, expr_vec, var_list);
+  }
+  else if(sort_set::is_set(sort) || sort_fset::is_fset(sort))
+  {
+    enumerator_identifier_generator id_gen;
+    data_expression_vector expr_vec;
+    mutable_indexed_substitution<> mut_sub;
+    return dataspec.is_certainly_finite(atermpp::down_cast<container_sort>(sort).element_sort()) &&
+      (!sort_fset::is_fset(sort) || detail::compute_finite_set_elements(atermpp::down_cast<container_sort>(sort), dataspec, rewr, mut_sub, expr_vec, id_gen));
+  }
+  else
+  {
+    const function_symbol_vector& constructors = dataspec.constructors(sort);
+    if(constructors.empty())
+    {
+      return false;
+    }
+    else
+    {
+      if(std::find(parents.begin(), parents.end(), sort) != parents.end())
+      {
+        return true;
+      }
+      parents.push_back(sort);
+      bool result = std::all_of(constructors.begin(), constructors.end(), [&](const function_symbol& constructor)
+        {
+          return !is_function_sort(constructor.sort()) ||
+            std::all_of(atermpp::down_cast<function_sort>(constructor.sort()).domain().begin(), atermpp::down_cast<function_sort>(constructor.sort()).domain().end(),
+              [&](const sort_expression& arg_sort){ return is_enumerable(dataspec, rewr, arg_sort, parents); });
+        });
+      parents.pop_back();
+      return result;
+    }
+  }
+}
+
 } // namespace detail
+
+template <typename Rewriter>
+static bool is_enumerable(const data_specification& dataspec, const Rewriter& rewr, const sort_expression& sort)
+{
+  std::list<sort_expression> parentstack;
+  return detail::is_enumerable(dataspec, rewr, sort, parentstack);
+}
 
 struct is_not_false
 {
@@ -430,55 +487,6 @@ class enumerator_algorithm
       }
     }
 
-    static bool is_enumerable(const data_specification& dataspec, const Rewriter& rewr, const sort_expression& sort, std::list<sort_expression>& parents)
-    {
-      if(sort_bag::is_bag(sort) || sort_fbag::is_fbag(sort))
-      {
-        return false;
-      }
-      else if(is_function_sort(sort))
-      {
-        const function_sort& func = atermpp::down_cast<function_sort>(sort);
-        enumerator_identifier_generator id_gen;
-        data_expression_vector expr_vec;
-        variable_list var_list;
-        return dataspec.is_certainly_finite(func) &&
-          detail::compute_finite_function_sorts(func, id_gen, dataspec, rewr, expr_vec, var_list);
-      }
-      else if(sort_set::is_set(sort) || sort_fset::is_fset(sort))
-      {
-        enumerator_identifier_generator id_gen;
-        data_expression_vector expr_vec;
-        mutable_indexed_substitution<> mut_sub;
-        return dataspec.is_certainly_finite(atermpp::down_cast<container_sort>(sort).element_sort()) &&
-          (!sort_fset::is_fset(sort) || detail::compute_finite_set_elements(atermpp::down_cast<container_sort>(sort), dataspec, rewr, mut_sub, expr_vec, id_gen));
-      }
-      else
-      {
-        const function_symbol_vector& constructors = dataspec.constructors(sort);
-        if(constructors.empty())
-        {
-          return false;
-        }
-        else
-        {
-          if(std::find(parents.begin(), parents.end(), sort) != parents.end())
-          {
-            return true;
-          }
-          parents.push_back(sort);
-          bool result = std::all_of(constructors.begin(), constructors.end(), [&](const function_symbol& constructor)
-            {
-              return !is_function_sort(constructor.sort()) ||
-                std::all_of(atermpp::down_cast<function_sort>(constructor.sort()).domain().begin(), atermpp::down_cast<function_sort>(constructor.sort()).domain().end(),
-                  [&](const sort_expression& arg_sort){ return is_enumerable(dataspec, rewr, arg_sort, parents); });
-            });
-          parents.pop_back();
-          return result;
-        }
-      }
-    }
-
   public:
     enumerator_algorithm(const Rewriter& R_,
                          const data::data_specification& dataspec_,
@@ -496,13 +504,6 @@ class enumerator_algorithm
     {}
 
   public:
-
-    static bool is_enumerable(const data_specification& dataspec, const Rewriter& rewr, const sort_expression& sort)
-    {
-      std::list<sort_expression> parentstack;
-      return is_enumerable(dataspec, rewr, sort, parentstack);
-    }
-
     /// \brief Enumerates the front element of the todo list P.
     /// \param P The todo list of the algorithm.
     /// \param sigma A mutable substitution that is applied by the rewriter.

--- a/libraries/data/source/detail/rewrite/rewrite.cpp
+++ b/libraries/data/source/detail/rewrite/rewrite.cpp
@@ -369,7 +369,7 @@ data_expression Rewriter::quantifier_enumeration(
     const variable v = *i;
     if (free_variables.count(v)>0)
     {
-      if(enumerator_algorithm<rewriter_wrapper>::is_enumerable(m_data_specification_for_enumeration, rewriter_wrapper(this), v.sort()))
+      if(is_enumerable(m_data_specification_for_enumeration, rewriter_wrapper(this), v.sort()))
       {
         vl_new_l_enum.push_front(v);
         sorts_are_finite = sorts_are_finite && m_data_specification_for_enumeration.is_certainly_finite(v.sort());

--- a/libraries/data/test/quantifier_test.cpp
+++ b/libraries/data/test/quantifier_test.cpp
@@ -54,7 +54,7 @@ void quantifier_expression_test(mcrl2::data::rewrite_strategy s)
   quantifier_expression_test("exists x: Bool. x == true || x==false", "true", dataspec, r);
   quantifier_expression_test("forall x:Bool.exists y: Bool. x == y", "true", dataspec, r);
   quantifier_expression_test("exists x: Bool.forall y:Bool.x == y", "false", dataspec, r);
-  quantifier_expression_test("forall b: Bool. b", "false", dataspec, r); 
+  quantifier_expression_test("forall b: Bool. b", "false", dataspec, r);
 
   // tests for Pos / Nat
   dataspec.add_context_sort(sort_nat::nat());
@@ -78,7 +78,7 @@ void quantifier_expression_test(mcrl2::data::rewrite_strategy s)
   /* Test 15. Test whether elimination of quantifiers also happens inside a term. */
   quantifier_expression_test("(exists x_0: Bool. false) && (forall x_0: Nat. true)", "false", dataspec, r);
   quantifier_expression_test("(forall x_0: Pos. true) || (exists x_0: Bool. false)", "true", dataspec, r);
-  
+
   // The four tests below may need to be changed when the implementation of the
   // rewriter/enumerator is improved to deal with them
   // The test below is too complex for the enumerator to solve.
@@ -176,6 +176,12 @@ void quantifier_in_rewrite_rules_test(mcrl2::data::rewrite_strategy s)
   quantifier_expression_test("f", "true", dataspec, r);
 }
 
+void test_mixed_enumeration()
+{
+  quantifier_expression_test("exists x:Real, p:Pos . p == 1 && x > 4", "exists x:Real . x > 4", data_specification(), data::rewriter(data_specification()));
+  quantifier_expression_test("exists x:Real, p:Pos . p == 1", "true", data_specification(), data::rewriter(data_specification()));
+  quantifier_expression_test("exists x:Real, p:Pos . x > 4", "exists x:Real . x > 4", data_specification(), data::rewriter(data_specification()));
+}
 
 int test_main(int argc, char** argv)
 {
@@ -186,6 +192,8 @@ int test_main(int argc, char** argv)
     quantifier_expression_test(strategy);
     quantifier_in_rewrite_rules_test(strategy);
   }
+
+  test_mixed_enumeration();
 
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
With these changes, the rewriter can separate enumerable variables from non-enumerable variables. This information is obtained from the enumerator. This helps to rewrite expression such as `exists x:Real, p:Pos . p == 1 && x > 4`. See issue #1420.