### PR TITLE
Added a new much faster substitution: replace_variables_capture_avoid…

### DIFF
--- a/build/code_generation/generate_traverser_functions.py
+++ b/build/code_generation/generate_traverser_functions.py
@@ -230,6 +230,45 @@ T replace_variables_capture_avoiding(const T& x,
 }
 '''
 
+REPLACE_CAPTURE_AVOIDING_WITH_IDENTIFIER_GENERATOR_FUNCTION_TEXT = ''' /// \\\\brief Applies sigma as a capture avoiding substitution to x using an identifier generator.
+/// \\\\details This substitution function is much faster than replace_variables_capture_avoiding, but
+///          it requires an identifier generator that generates strings for fresh variables. These 
+///          strings must be unique in the sense that they have not been used for other variables.
+/// \\\\param x The object to which the subsitution is applied.
+/// \\\\param sigma A mutable substitution of which it can efficiently be checked whether a variable occurs in its 
+///              right hand side. The class maintain_variables_in_rhs is useful for this purpose. 
+/// \\\\param id_generator A generator that generates unique strings, not yet used as variable names.
+
+template <typename T, typename Substitution, typename IdentifierGenerator>
+void replace_variables_capture_avoiding_with_an_identifier_generator(T& x,
+                       Substitution& sigma,
+                       IdentifierGenerator& id_generator,
+                       typename std::enable_if<!std::is_base_of<atermpp::aterm, T>::value>::type* = nullptr
+                      )
+{
+  data::detail::apply_replace_capture_avoiding_variables_builder_with_an_identifier_generator<NAMESPACE::data_expression_builder, NAMESPACE::detail::add_capture_avoiding_replacement_with_an_identifier_generator>(sigma, id_generator).update(x);
+}
+
+/// \\\\brief Applies sigma as a capture avoiding substitution to x using an identifier generator..
+/// \\\\details This substitution function is much faster than replace_variables_capture_avoiding, but
+///          it requires an identifier generator that generates strings for fresh variables. These 
+///          strings must be unique in the sense that they have not been used for other variables.
+/// \\\\param x The object to which the substiution is applied.
+/// \\\\param sigma A mutable substitution of which it can efficiently be checked whether a variable occurs in its 
+///              right hand side. The class maintain_variables_in_rhs is useful for this purpose. 
+/// \\\\param id_generator A generator that generates unique strings, not yet used as variable names.
+/// \\\\return The result is the term x to which sigma has been applied. 
+template <typename T, typename Substitution, typename IdentifierGenerator>
+T replace_variables_capture_avoiding_with_an_identifier_generator(const T& x,
+                    Substitution& sigma,
+                    IdentifierGenerator& id_generator,
+                    typename std::enable_if<std::is_base_of<atermpp::aterm, T>::value>::type* = nullptr
+                   )
+{
+  return data::detail::apply_replace_capture_avoiding_variables_builder_with_an_identifier_generator<NAMESPACE::data_expression_builder, NAMESPACE::detail::add_capture_avoiding_replacement_with_an_identifier_generator>(sigma, id_generator).apply(x);
+}
+'''
+
 FIND_VARIABLES_FUNCTION_TEXT = '''/// \\\\brief Returns all variables that occur in an object
 /// \param[in] x an object containing variables
 /// \param[in,out] o an output iterator to which all variables occurring in x are written.
@@ -396,6 +435,17 @@ def generate_replace_capture_avoiding_functions():
     result = generate_code(MCRL2_ROOT + 'libraries/process/include/mcrl2/process/replace.h'            , 'process'         , 'replace_capture_avoiding', REPLACE_CAPTURE_AVOIDING_FUNCTION_TEXT) and result
     return result
 
+def generate_replace_capture_avoiding_with_identifier_generator_functions():
+    result = True
+    result = generate_code(MCRL2_ROOT + 'libraries/data/include/mcrl2/data/replace.h'                  , 'data'            , 'replace_capture_avoiding_with_identifier_generator', REPLACE_CAPTURE_AVOIDING_WITH_IDENTIFIER_GENERATOR_FUNCTION_TEXT) and result
+    result = generate_code(MCRL2_ROOT + 'libraries/lps/include/mcrl2/lps/replace.h'                    , 'lps'             , 'replace_capture_avoiding_with_identifier_generator', REPLACE_CAPTURE_AVOIDING_WITH_IDENTIFIER_GENERATOR_FUNCTION_TEXT) and result
+    result = generate_code(MCRL2_ROOT + 'libraries/modal_formula/include/mcrl2/modal_formula/replace.h', 'action_formulas' , 'replace_capture_avoiding_with_identifier_generator', REPLACE_CAPTURE_AVOIDING_WITH_IDENTIFIER_GENERATOR_FUNCTION_TEXT) and result
+    result = generate_code(MCRL2_ROOT + 'libraries/modal_formula/include/mcrl2/modal_formula/replace.h', 'regular_formulas', 'replace_capture_avoiding_with_identifier_generator', REPLACE_CAPTURE_AVOIDING_WITH_IDENTIFIER_GENERATOR_FUNCTION_TEXT) and result
+    result = generate_code(MCRL2_ROOT + 'libraries/modal_formula/include/mcrl2/modal_formula/replace.h', 'state_formulas'  , 'replace_capture_avoiding_with_identifier_generator', REPLACE_CAPTURE_AVOIDING_WITH_IDENTIFIER_GENERATOR_FUNCTION_TEXT) and result
+    result = generate_code(MCRL2_ROOT + 'libraries/pbes/include/mcrl2/pbes/replace.h'                  , 'pbes_system'     , 'replace_capture_avoiding_with_identifier_generator', REPLACE_CAPTURE_AVOIDING_WITH_IDENTIFIER_GENERATOR_FUNCTION_TEXT) and result
+    result = generate_code(MCRL2_ROOT + 'libraries/process/include/mcrl2/process/replace.h'            , 'process'         , 'replace_capture_avoiding_with_identifier_generator', REPLACE_CAPTURE_AVOIDING_WITH_IDENTIFIER_GENERATOR_FUNCTION_TEXT) and result
+    return result
+
 def generate_find_functions():
     result = True
     result = generate_code(MCRL2_ROOT + 'libraries/data/include/mcrl2/data/find.h'                  , 'data'            , 'find', FIND_VARIABLES_FUNCTION_TEXT) and result
@@ -412,5 +462,6 @@ if __name__ == "__main__":
     result = generate_rewrite_functions() and result
     result = generate_replace_functions() and result
     result = generate_replace_capture_avoiding_functions() and result
+    result = generate_replace_capture_avoiding_with_identifier_generator_functions() and result
     result = generate_find_functions() and result
     sys.exit(not result) # 0 result indicates successful execution

--- a/doc/sphinx/source/developer_manual/libraries/data/latex/substitutions.tex
+++ b/doc/sphinx/source/developer_manual/libraries/data/latex/substitutions.tex
@@ -36,6 +36,8 @@
 \newtheorem{summary}[theorem]{Summary}
 \newenvironment{proof}[1][Proof]{\noindent\textbf{#1.} }{\ \rule{0.5em}{0.5em}}
 \input{include/tcilatex}
+\newcommand{\Bool}{\mathbb{B}}
+
 
 \begin{document}
 
@@ -73,6 +75,7 @@ v^{\prime }\text{ if }w=v \\
 \]
 
 \subsection{Capture avoiding substitutions}
+\label{captavoid}
 
 Let $\sigma $ be a substitution that maps variables to data expressions, and
 let $x$ be an arbitrary data expression. Let $FV(x)$ be the free variables
@@ -112,7 +115,9 @@ otherwise,}%
 where $\Lambda \in \{\forall ,\exists ,\lambda \}$, where $v^{\prime }$ is
 an arbitrary variable such that $\sigma (v^{\prime })=v^{\prime }$ and $%
 v^{\prime }\notin V$, and where $\sigma ^{\prime }=\sigma \lbrack
-v:=v^{\prime }]$. The function $C$ can be extended to assignments as follows:%
+v:=v^{\prime }]$. The function $C$ can be extended to assignments as follows\footnote{The 
+definition of $C$ to assignments is not correct and not how they have been implemented.}:
+%
 \[
 \begin{array}{lll}
 C(v=x,\sigma ,V) & = & \left\{
@@ -126,10 +131,74 @@ v^{\prime }=C(x,\sigma ^{\prime },V\cup \{v^{\prime }\})\text{ otherwise}%
 
 \paragraph{Example}
 
-\newcommand{\ap}{{:}}
-Let $x=\forall b\ap\mathbb{B}. b\Rightarrow \forall c\ap\mathbb{B}.c\Rightarrow d$
+Let $x=\forall b{:}\mathbb{B}. b\Rightarrow \forall c{:}\mathbb{B}.c\Rightarrow d$
 and let $\sigma =[d:=b]$. Then $C(x,\sigma ,FV(x)\cup FV(\sigma ))=\forall
-b^{\prime }\ap\mathbb{B}.b^{\prime }\Rightarrow \forall c\ap\mathbb{B}%
+b^{\prime }{:}\mathbb{B}.b^{\prime }\Rightarrow \forall c{:}\mathbb{B}%
 .c\Rightarrow b$.
 
+\subsubsection{Capture avoiding substitutions with an identifier generator}
+Let $\sigma$ be a subsitution that maps variables to data expressions.
+In this section a substitution is defined that is more efficient than the capture avoiding substitution
+of section \ref{captavoid} because it does not require the calculation of a set $V$ of variables.
+
+It does require that $\sigma$ can indicate efficiently whether a variable occurs in the $\sigma(y)$
+(with $\sigma(y)\not=y$) for some variable $y$. Furthermore, it requires a identifier generator, that
+can generate variable names that are guaranteed to be fresh in the sense that they do not occur in any
+term. 
+
+This substitution has been implemented as \texttt{replace\_variables\_capture\_avoiding\_with\_an\_identifier\_generator}.
+We use $\mathit{FV}(x)$, $\mathit{FV}(\sigma)$ and $\sigma[v:=v']$ as defined in the previous section. 
+\vspace{2ex}\\
+The substitution is defined as $\hat{C}$ that calculates $\sigma(x)$ using $\hat{C}(x,\sigma)$ recursively 
+as follows:
+\[
+\begin{array}{lll}
+\hat{C}(v,\sigma) & = & \sigma (v) \\
+\hat{C}(f,\sigma) & = & f \\
+\hat{C}(x(x_{1}),\sigma) & = & \hat{C}(x,\sigma)(\hat{C}(x_{1},\sigma)) \\
+&  &  \\
+\hat{C}(x\text{ whr }v=x_{1},\sigma) & = & \left\{
+\begin{array}{ll}
+\hat{C}(x,\sigma[v:=v])\text{ whr }v=\hat{C}(x_{1},\sigma)&\text{if }%
+v\notin \mathit{FV}(\sigma), \\
+\hat{C}(x,\sigma[v:=v'] )\text{ whr }v'=\hat{C}(x_{1},\sigma'\})&\text{otherwise}.%
+\end{array}%
+\right.  \\
+&  &  \\
+\hat{C}(\Lambda v.x,\sigma ,V) & = & \left\{
+\begin{array}{ll}
+\Lambda v.\hat{C}(x,\sigma[v:=v] )&\text{if }v\notin \mathit{FV}(\sigma), \\
+\Lambda v'.\hat{C}(x,\sigma',V\cup \{v'\})&\text{otherwise,}%
+\end{array}%
+\right.
+\end{array}%
+\]%
+where $\Lambda \in \{\forall ,\exists ,\lambda \}$, where $v'$ is
+a fresh variable such that $\sigma (v')=v'$ and $%
+v'\notin \mathit{FV}(\sigma)\cup\mathit{FV}(x)$. The identifier generator is
+used to generate the name for $v'$.
+
+In the examples below $[]$ is the substitution mapping each variable onto itself and $[w:=v']$ is the subsitution
+mapping all variables onto itself, except that $w$ is mapped to $v'$.
+
+\paragraph{Example}
+Let $x=\forall b{:} \Bool.b\Rightarrow \forall c{:}\Bool.c\Rightarrow d$ and let $\sigma=[d:=b]$. Then
+$\hat{C}(x,\sigma)=\forall b'{:}\Bool.b'\Rightarrow\forall c{:}\Bool.c\Rightarrow b$ where $b'$ is a fresh 
+variable.
+
+\paragraph{Example}
+It is necessary that $v'$ above is chosen such that $v'\notin \mathit{FV}(\sigma)\cup\mathit{FV}(x)$.
+We provide two examples to show what goes wrong if this condition is not satisfied. 
+\begin{enumerate}
+\item
+If $v'\notin \mathit{FV}(\sigma)$ is not required, the following is possible: $\hat{C}(\forall v.w,[w:=v'])=\forall
+v'.\hat{C}(w,[w:=v'])=\forall v'.v'$.
+\item
+If $v'\notin \mathit{FV}(x)$ is not required, it is possible that: $\hat{C}(\forall v,v',[])=\forall v'.\hat{C}(v',[])=\forall v'.v$. 
+\end{enumerate}
+\paragraph{Example}
+In a where clause the substitutions applied to the equations after the where can remain unchanged.
+E.g., $\hat{C}(f(u,v)\text{ whr }v=v,[u:=v])=\hat{C}(f(u,v),[u:=v,v:=v'])\text{ whr }v'=\hat{C}(v,[u:=v])=f(v,v')\text{ whr }
+v'=v$. In an expression $f(u,v)\text{ whr }v=v$ the variable $v$ at the lhs of the `$=$' is a local variable,
+whereas the $v$ at the rhs is globally bound. 
 \end{document}

--- a/libraries/bes/include/mcrl2/bes/builder.h
+++ b/libraries/bes/include/mcrl2/bes/builder.h
@@ -145,6 +145,10 @@ template <typename Derived>
 struct boolean_expression_builder: public add_boolean_expressions<core::builder, Derived>
 {
   typedef add_boolean_expressions<core::builder, Derived> super;
+  using super::enter;
+  using super::leave;
+  using super::update;
+  using super::apply;
 };
 //--- end generated add_boolean_expressions code ---//
 
@@ -273,6 +277,10 @@ template <typename Derived>
 struct boolean_variable_builder: public add_boolean_variables<core::builder, Derived>
 {
   typedef add_boolean_variables<core::builder, Derived> super;
+  using super::enter;
+  using super::leave;
+  using super::update;
+  using super::apply;
 };
 //--- end generated add_boolean_variables code ---//
 

--- a/libraries/data/include/mcrl2/data/builder.h
+++ b/libraries/data/include/mcrl2/data/builder.h
@@ -390,6 +390,10 @@ template <typename Derived>
 struct sort_expression_builder: public add_sort_expressions<core::builder, Derived>
 {
   typedef add_sort_expressions<core::builder, Derived> super;
+  using super::enter;
+  using super::leave;
+  using super::update;
+  using super::apply;
 };
 //--- end generated add_sort_expressions code ---//
 
@@ -618,6 +622,10 @@ template <typename Derived>
 struct data_expression_builder: public add_data_expressions<core::builder, Derived>
 {
   typedef add_data_expressions<core::builder, Derived> super;
+  using super::enter;
+  using super::leave;
+  using super::update;
+  using super::apply;
 };
 //--- end generated add_data_expressions code ---//
 
@@ -845,6 +853,10 @@ template <typename Derived>
 struct variable_builder: public add_variables<core::builder, Derived>
 {
   typedef add_variables<core::builder, Derived> super;
+  using super::enter;
+  using super::leave;
+  using super::update;
+  using super::apply;
 };
 //--- end generated add_variables code ---//
 

--- a/libraries/data/include/mcrl2/data/replace.h
+++ b/libraries/data/include/mcrl2/data/replace.h
@@ -206,7 +206,9 @@ struct substitution_updater
   VariableContainer push(const VariableContainer& v)
   {
     undo_sizes.push_back(undo.size());
-    std::vector<data::variable> result; for (typename VariableContainer::const_iterator i = v.begin(); i != v.end(); ++i) {
+    std::vector<data::variable> result; 
+    for (typename VariableContainer::const_iterator i = v.begin(); i != v.end(); ++i) 
+    {
       data::variable w = bind(*i);
       V.insert(w);
       result.push_back(w);
@@ -231,6 +233,75 @@ struct substitution_updater
     }
   }
 };
+
+
+template <typename Substitution, typename IdentifierGenerator>
+class substitution_updater_with_an_identifier_generator
+{
+  protected:
+    Substitution& m_sigma;
+    IdentifierGenerator& m_id_generator;
+    std::vector<data::assignment> m_undo; // why not a stack datatype?
+
+  public:
+    substitution_updater_with_an_identifier_generator(Substitution& sigma, IdentifierGenerator& id_generator)
+      : m_sigma(sigma), m_id_generator(id_generator)
+    {}
+
+    Substitution& substitution()
+    {
+      return m_sigma;
+    }
+
+    data::variable bind(const data::variable& v)
+    {
+      m_undo.push_back(data::assignment(v, m_sigma(v))); // save the old assignment of m_sigma. 
+      if (m_sigma.occurs_in_a_rhs(v))                    // v notin FV(m_sigma).
+      {
+        m_sigma[v] = v;                                  // Clear sigma[v].
+        return v;
+      }
+      else
+      {
+        data::variable w(m_id_generator(v.name()), v.sort());
+        m_sigma[v] = w;
+        return w;
+      }
+    }
+
+    data::variable push(const data::variable& v)
+    {
+      return bind(v);
+    }
+
+    void pop(const data::variable& )
+    {
+      const data::assignment& a = m_undo.back();
+      m_sigma[a.lhs()] = a.rhs();
+      m_undo.pop_back();
+    }
+
+    template <typename VariableContainer>
+    VariableContainer push(const VariableContainer& container)
+    {
+      std::vector<data::variable> result; 
+      for (const variable& v: container)
+      {
+        result.push_back(bind(v));
+      }
+      return VariableContainer(result.begin(), result.end());
+    }
+
+    template <typename VariableContainer>
+    void pop(const VariableContainer& container)
+    {
+      for (const variable& v: container)
+      {
+        pop(v);
+      }
+    }
+};
+
 
 template <typename Substitution, typename IdentifierGenerator>
 data::variable update_substitution(Substitution& sigma, const data::variable& v, const std::multiset<data::variable>& V, IdentifierGenerator& id_generator)
@@ -363,6 +434,111 @@ struct add_capture_avoiding_replacement: public Builder<Derived>
     throw mcrl2::runtime_error("not implemented yet");
   }
 };
+
+// Helper code for replace_capture_avoiding_variables_with_an_identifier_generator.
+template <template <class> class Builder, template <template <class> class, class, class, class> class Binder, class Substitution, class IdentifierGenerator>
+struct replace_capture_avoiding_variables_builder_with_an_identifier_generator: public Binder<Builder, replace_capture_avoiding_variables_builder_with_an_identifier_generator<Builder, Binder, Substitution, IdentifierGenerator>, Substitution, IdentifierGenerator>
+{
+  typedef Binder<Builder, replace_capture_avoiding_variables_builder_with_an_identifier_generator<Builder, Binder, Substitution, IdentifierGenerator>, Substitution, IdentifierGenerator> super;
+  using super::enter;
+  using super::leave;
+  using super::apply;
+  using super::update;
+
+  replace_capture_avoiding_variables_builder_with_an_identifier_generator(Substitution& sigma, IdentifierGenerator& id_generator)
+    : super(sigma, id_generator)
+  { }
+};
+
+template <template <class> class Builder, template <template <class> class, class, class, class> class Binder, class Substitution, class IdentifierGenerator>
+replace_capture_avoiding_variables_builder_with_an_identifier_generator<Builder, Binder, Substitution, IdentifierGenerator>
+apply_replace_capture_avoiding_variables_builder_with_an_identifier_generator(Substitution& sigma, IdentifierGenerator& id_generator)
+{
+  return replace_capture_avoiding_variables_builder_with_an_identifier_generator<Builder, Binder, Substitution, IdentifierGenerator>(sigma, id_generator);
+}
+
+// In the class below, the IdentifierGenerator is expected to generate fresh identifiers, not 
+// occurring anywhere using the operator (). The enumerator_identifier_generator can do this.
+// The substitution has as property that it provides a method "variables_in_rhs" yielding the
+// variables occurring in the right hand side of assignments. The mutable_indexed_substitution has this
+// method. 
+template <template <class> class Builder, class Derived, class Substitution, class IdentifierGenerator>
+struct add_capture_avoiding_replacement_with_an_identifier_generator: public Builder<Derived>
+{
+  typedef Builder<Derived> super;
+  using super::enter;
+  using super::leave;
+  using super::apply;
+  using super::update;
+
+  protected:
+    substitution_updater_with_an_identifier_generator<Substitution, IdentifierGenerator> update_sigma;
+
+  public:
+    add_capture_avoiding_replacement_with_an_identifier_generator(Substitution& sigma_, IdentifierGenerator& id_generator_)
+      : update_sigma(sigma_, id_generator_)
+    { }
+
+    data_expression apply(const variable& v)
+    {
+      return update_sigma.substitution()(v);
+    }
+
+    data_expression apply(const data::where_clause& x)
+    {
+      const data::assignment_list& assignments = atermpp::container_cast<data::assignment_list>(x.declarations());
+      std::vector<data::variable> tmp;
+      for (const data::assignment& a: assignments)
+      {
+        tmp.push_back(a.lhs());
+      }
+      std::vector<data::variable> v = update_sigma.push(tmp);
+
+      // The updated substitution should be applied to the body.
+      const data::data_expression new_body = apply(x.body());
+      update_sigma.pop(v);
+
+      // The original substitution should be applied to the right hand sides of the assignments.
+      std::vector<data::assignment> a;
+      std::vector<data::variable>::const_iterator j = v.begin();
+      for (data::assignment_list::const_iterator i = assignments.begin(); i != assignments.end(); ++i, ++j)
+      {
+        a.push_back(data::assignment(*j, apply(i->rhs())));
+      }
+      return data::where_clause(new_body, assignment_list(a.begin(), a.end()));
+    }
+
+    data_expression apply(const data::forall& x)
+    {
+      data::variable_list v = update_sigma.push(x.variables());
+      data_expression result = data::forall(v, apply(x.body()));
+      update_sigma.pop(v);
+      return result;
+    }
+
+    data_expression apply(const data::exists& x)
+    {
+      data::variable_list v = update_sigma.push(x.variables());
+      data_expression result = data::exists(v, apply(x.body()));
+      update_sigma.pop(v);
+      return result;
+    }
+
+    data_expression apply(const data::lambda& x)
+    {
+      data::variable_list v = update_sigma.push(x.variables());
+      data_expression result = data::lambda(v, apply(x.body()));
+      update_sigma.pop(v);
+      return result;
+    }
+
+    data_equation apply(data_equation& /* x */)
+    {
+      throw mcrl2::runtime_error("not implemented yet");
+    }
+};
+
+
 /// \endcond
 
 } // namespace detail
@@ -532,6 +708,46 @@ T replace_variables_capture_avoiding(const T& x,
   return data::detail::apply_replace_capture_avoiding_variables_builder<data::data_expression_builder, data::detail::add_capture_avoiding_replacement>(sigma, V).apply(x);
 }
 //--- end generated data replace_capture_avoiding code ---//
+
+//--- start generated data replace_capture_avoiding_with_identifier_generator code ---//
+/// \brief Applies sigma as a capture avoiding substitution to x using an identifier generator.
+/// \details This substitution function is much faster than replace_variables_capture_avoiding, but
+///          it requires an identifier generator that generates strings for fresh variables. These 
+///          strings must be unique in the sense that they have not been used for other variables.
+/// \param x The object to which the subsitution is applied.
+/// \param sigma A mutable substitution of which it can efficiently be checked whether a variable occurs in its 
+///              right hand side. The class maintain_variables_in_rhs is useful for this purpose. 
+/// \param id_generator A generator that generates unique strings, not yet used as variable names.
+
+template <typename T, typename Substitution, typename IdentifierGenerator>
+void replace_variables_capture_avoiding_with_an_identifier_generator(T& x,
+                       Substitution& sigma,
+                       IdentifierGenerator& id_generator,
+                       typename std::enable_if<!std::is_base_of<atermpp::aterm, T>::value>::type* = nullptr
+                      )
+{
+  data::detail::apply_replace_capture_avoiding_variables_builder_with_an_identifier_generator<data::data_expression_builder, data::detail::add_capture_avoiding_replacement_with_an_identifier_generator>(sigma, id_generator).update(x);
+}
+
+/// \brief Applies sigma as a capture avoiding substitution to x using an identifier generator..
+/// \details This substitution function is much faster than replace_variables_capture_avoiding, but
+///          it requires an identifier generator that generates strings for fresh variables. These 
+///          strings must be unique in the sense that they have not been used for other variables.
+/// \param x The object to which the substiution is applied.
+/// \param sigma A mutable substitution of which it can efficiently be checked whether a variable occurs in its 
+///              right hand side. The class maintain_variables_in_rhs is useful for this purpose. 
+/// \param id_generator A generator that generates unique strings, not yet used as variable names.
+/// \return The result is the term x to which sigma has been applied. 
+template <typename T, typename Substitution, typename IdentifierGenerator>
+T replace_variables_capture_avoiding_with_an_identifier_generator(const T& x,
+                    Substitution& sigma,
+                    IdentifierGenerator& id_generator,
+                    typename std::enable_if<std::is_base_of<atermpp::aterm, T>::value>::type* = nullptr
+                   )
+{
+  return data::detail::apply_replace_capture_avoiding_variables_builder_with_an_identifier_generator<data::data_expression_builder, data::detail::add_capture_avoiding_replacement_with_an_identifier_generator>(sigma, id_generator).apply(x);
+}
+//--- end generated data replace_capture_avoiding_with_identifier_generator code ---//
 
 template <typename T, typename Substitution>
 void substitute_sorts(T& x,

--- a/libraries/data/include/mcrl2/data/substitutions/maintain_variables_in_rhs.h
+++ b/libraries/data/include/mcrl2/data/substitutions/maintain_variables_in_rhs.h
@@ -1,0 +1,141 @@
+// Author(s): Jan Friso Groote
+// Copyright: see the accompanying file COPYING or copy at
+// https://github.com/mCRL2org/mCRL2/blob/master/COPYING
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+/// \file mcrl2/data/substitutions/maintain_variables_in_rhs.h
+/// \brief This class extends a substitution to recall the variables that occur in its right hand side. 
+///        It assumes the presence of an operation sigma[x]=v to set values of a variable. 
+///        If sigma[x]=x, this is seen as clearing the variable, and x is not recalled. 
+///        The variables recalled are an overapproximation. By regular garbage collection the 
+
+
+#ifndef MCRL2_DATA_SUBSTITUTIONS_MAINTAIN_VARIABLES_IN_RHS_H
+#define MCRL2_DATA_SUBSTITUTIONS_MAINTAIN_VARIABLES_IN_RHS_H
+
+#include "mcrl2/data/is_simple_substitution.h"
+#include "mcrl2/data/undefined.h"
+#include "mcrl2/utilities/exception.h"
+#include <functional>
+#include <iostream>
+#include <sstream>
+#include <string>
+
+namespace mcrl2 {
+
+namespace data {
+
+
+/// \brief Wrapper that extends any substitution to a substitution maintaining the vars in its rhs. 
+/// \details This substitution assumes a function variable -> std::size_t, that, for
+///          each variable gives a unique index. The substitutions are stored
+///          internally as a vector, mapping std::size_t to expression.
+///          Provided that, given a variable, its index can be computed in O(1)
+///          time, insertion is O(1) amortized, and lookup is O(1).
+///          Memory required is O(n) where n is the largest index used.
+template <typename Substitution>
+class maintain_variables_in_rhs: public Substitution
+{
+  public:
+    typedef Substitution super;
+    typedef typename super::variable_type variable_type;
+    typedef typename super::expression_type expression_type;
+  
+  protected:
+    std::multiset<variable_type> m_variables_in_rhs;
+    std::set<variable_type> m_scratch_set;
+  
+  public:
+    /// \brief Default constructor
+    maintain_variables_in_rhs() 
+    {
+    }
+  
+    /// \brief Wrapper class for internal storage and substitution updates using operator()
+    class assignment
+    {
+      protected: 
+        const variable_type& m_variable;
+        Substitution& m_sigma; 
+        std::multiset<variable_type>& m_variables_in_rhs;
+        std::set<variable_type>& m_scratch_set;
+  
+      public:
+        /// \brief Constructor.
+        /// \param[in] v a reference to the variable.
+        /// \param[in] vars Variables in the rhs of the assignments. 
+        assignment(const variable_type& v,
+                   Substitution& sigma,
+                   std::multiset<variable_type>& variables_in_rhs,
+                   std::set<variable_type>& scratch_set) :
+          m_variable(v),
+          m_sigma(sigma),
+          m_variables_in_rhs(variables_in_rhs),
+          m_scratch_set(scratch_set)
+        { }
+  
+        /// \brief Actual assignment
+        void operator=(const expression_type& e)
+        {
+          assert(e.defined());
+
+          const expression_type& e_old=m_sigma(m_variable);
+          if (e_old!=m_variable)
+          {
+            // Remove the free variables in the old rhs.
+            m_scratch_set=find_free_variables(e_old);
+            for(const variable_type& v: m_scratch_set) 
+            {
+              m_variables_in_rhs.erase(v);
+            }
+            m_scratch_set.clear();
+          }
+          if (e != m_variable)
+          {
+            // Add the free variables in the new rhs.
+            m_scratch_set=find_free_variables(e);
+            m_variables_in_rhs.insert(m_scratch_set.begin(),m_scratch_set.end());
+            m_scratch_set.clear();
+          }
+          // Set the new variable;
+          m_sigma.operator[](m_variable)=e; 
+        }
+    };
+  
+    /// \brief Assigment operator.
+    /// \param v The variable to which the assignment is carried out. 
+    assignment operator[](variable_type const& v)
+    {
+      return assignment(v, *this, m_variables_in_rhs, m_scratch_set);
+    }
+  
+    /// \brief Clear substitutions.
+    void clear()
+    {
+      m_variables_in_rhs().clear();
+      super::clear();
+    }
+  
+    /// \brief Provides a set of variables that occur in the right hand sides of the assignments.
+    const std::multiset<variable>& variables_in_rhs()
+    {
+      return m_variables_in_rhs;
+    }
+
+    /// \brief Indicates whether a variable occurs in some rhs of this substitution. 
+    /// \param v The variable for which occurrence in a rhs is checked.
+    bool occurs_in_a_rhs(const variable_type& v)
+    {
+      return m_variables_in_rhs.find(v)!=m_variables_in_rhs.end();
+    }
+
+};
+
+} // namespace data
+
+} // namespace mcrl2
+
+#endif // MCRL2_DATA_SUBSTITUTIONS_MAINTAIN_VARIABLES_IN_RHS_H

--- a/libraries/lps/include/mcrl2/lps/builder.h
+++ b/libraries/lps/include/mcrl2/lps/builder.h
@@ -156,6 +156,10 @@ template <typename Derived>
 struct sort_expression_builder: public add_sort_expressions<process::sort_expression_builder, Derived>
 {
   typedef add_sort_expressions<process::sort_expression_builder, Derived> super;
+  using super::enter;
+  using super::leave;
+  using super::update;
+  using super::apply;
 };
 //--- end generated add_sort_expressions code ---//
 
@@ -281,6 +285,10 @@ template <typename Derived>
 struct data_expression_builder: public add_data_expressions<process::data_expression_builder, Derived>
 {
   typedef add_data_expressions<process::data_expression_builder, Derived> super;
+  using super::enter;
+  using super::leave;
+  using super::update;
+  using super::apply;
 };
 //--- end generated add_data_expressions code ---//
 
@@ -412,6 +420,10 @@ template <typename Derived>
 struct variable_builder: public add_variables<process::data_expression_builder, Derived>
 {
   typedef add_variables<process::data_expression_builder, Derived> super;
+  using super::enter;
+  using super::leave;
+  using super::update;
+  using super::apply;
 };
 //--- end generated add_variables code ---//
 

--- a/libraries/lps/include/mcrl2/lps/replace.h
+++ b/libraries/lps/include/mcrl2/lps/replace.h
@@ -126,6 +126,109 @@ struct add_capture_avoiding_replacement: public process::detail::add_capture_avo
   }
 };
 
+// Below code for capture avoiding subsitutions with an identifier generator are provided.
+
+template <template <class> class Builder, class Derived, class Substitution, class IdentifierGenerator>
+struct add_capture_avoiding_replacement_with_an_identifier_generator: public process::detail::add_capture_avoiding_replacement_with_an_identifier_generator<Builder, Derived, Substitution, IdentifierGenerator>
+{
+  typedef process::detail::add_capture_avoiding_replacement_with_an_identifier_generator<Builder, Derived, Substitution, IdentifierGenerator> super;
+  using super::enter;
+  using super::leave;
+  using super::apply;
+  using super::update;
+  using super::update_sigma;
+
+  add_capture_avoiding_replacement_with_an_identifier_generator(Substitution& sigma, IdentifierGenerator& id_generator)
+    : super(sigma, id_generator)
+  { }
+
+  template <typename ActionSummand>
+  void do_action_summand(ActionSummand& x, const data::variable_list& v)
+  {
+    x.summation_variables() = v;
+    x.condition() = apply(x.condition());
+    apply(x.multi_action());
+    x.assignments() = apply(x.assignments());
+  }
+
+  void apply(action_summand& x)
+  {
+    data::variable_list v = update_sigma.push(x.summation_variables());
+    do_action_summand(x, v);
+    update_sigma.pop(v);
+  }
+
+  void apply(stochastic_action_summand& x)
+  {
+    data::variable_list v = update_sigma.push(x.summation_variables());
+    do_action_summand(x, v);
+    x.distribution() = apply(x.distribution());
+    update_sigma.pop(v);
+  }
+
+  void apply(deadlock_summand& x)
+  {
+    data::variable_list v = update_sigma.push(x.summation_variables());
+    x.summation_variables() = v;
+    x.condition() = apply(x.condition());
+    apply(x.deadlock());
+    update_sigma.pop(v);
+  }
+
+  template <typename LinearProcess>
+  void do_linear_process(const LinearProcess& x)
+  {
+    data::variable_list v = update_sigma.push(x.process_parameters());
+    x.process_parameters() = v;
+    apply(x.action_summands());
+    apply(x.deadlock_summands());
+    update_sigma.pop(v);
+  }
+
+  void apply(linear_process& x)
+  {
+    do_linear_process(x);
+  }
+
+  void apply(stochastic_linear_process& x)
+  {
+    do_linear_process(x);
+  }
+
+  template <typename Specification>
+  void do_specification(Specification& x)
+  {
+    std::set<data::variable> v = update_sigma(x.global_variables());
+    x.global_variables() = v;
+    apply(x.process());
+    x.action_labels() = apply(x.action_labels());
+    x.initial_process() = apply(x.initial_process());
+    update_sigma.pop(v);
+  }
+
+  void operator()(specification& x)
+  {
+    do_specification(x);
+  }
+
+  void operator()(stochastic_specification& x)
+  {
+    do_specification(x);
+  }
+
+  stochastic_distribution operator()(stochastic_distribution& x)
+  {
+    data::variable_list v = update_sigma.push(x.variables());
+    stochastic_distribution result(x.variables(), apply(x.distribution()));
+    update_sigma.pop(v);
+    return result;
+  }
+};
+
+
+
+
+
 } // namespace detail
 
 //--- start generated lps replace code ---//
@@ -294,6 +397,45 @@ T replace_variables_capture_avoiding(const T& x,
 }
 //--- end generated lps replace_capture_avoiding code ---//
 
+//--- start generated lps replace_capture_avoiding_with_identifier_generator code ---//
+/// \brief Applies sigma as a capture avoiding substitution to x using an identifier generator.
+/// \details This substitution function is much faster than replace_variables_capture_avoiding, but
+///          it requires an identifier generator that generates strings for fresh variables. These 
+///          strings must be unique in the sense that they have not been used for other variables.
+/// \param x The object to which the subsitution is applied.
+/// \param sigma A mutable substitution of which it can efficiently be checked whether a variable occurs in its 
+///              right hand side. The class maintain_variables_in_rhs is useful for this purpose. 
+/// \param id_generator A generator that generates unique strings, not yet used as variable names.
+
+template <typename T, typename Substitution, typename IdentifierGenerator>
+void replace_variables_capture_avoiding_with_an_identifier_generator(T& x,
+                       Substitution& sigma,
+                       IdentifierGenerator& id_generator,
+                       typename std::enable_if<!std::is_base_of<atermpp::aterm, T>::value>::type* = nullptr
+                      )
+{
+  data::detail::apply_replace_capture_avoiding_variables_builder_with_an_identifier_generator<lps::data_expression_builder, lps::detail::add_capture_avoiding_replacement_with_an_identifier_generator>(sigma, id_generator).update(x);
+}
+
+/// \brief Applies sigma as a capture avoiding substitution to x using an identifier generator..
+/// \details This substitution function is much faster than replace_variables_capture_avoiding, but
+///          it requires an identifier generator that generates strings for fresh variables. These 
+///          strings must be unique in the sense that they have not been used for other variables.
+/// \param x The object to which the substiution is applied.
+/// \param sigma A mutable substitution of which it can efficiently be checked whether a variable occurs in its 
+///              right hand side. The class maintain_variables_in_rhs is useful for this purpose. 
+/// \param id_generator A generator that generates unique strings, not yet used as variable names.
+/// \return The result is the term x to which sigma has been applied. 
+template <typename T, typename Substitution, typename IdentifierGenerator>
+T replace_variables_capture_avoiding_with_an_identifier_generator(const T& x,
+                    Substitution& sigma,
+                    IdentifierGenerator& id_generator,
+                    typename std::enable_if<std::is_base_of<atermpp::aterm, T>::value>::type* = nullptr
+                   )
+{
+  return data::detail::apply_replace_capture_avoiding_variables_builder_with_an_identifier_generator<lps::data_expression_builder, lps::detail::add_capture_avoiding_replacement_with_an_identifier_generator>(sigma, id_generator).apply(x);
+}
+//--- end generated lps replace_capture_avoiding_with_identifier_generator code ---//
 namespace detail {
 
 /// \cond INTERNAL_DOCS

--- a/libraries/modal_formula/include/mcrl2/modal_formula/builder.h
+++ b/libraries/modal_formula/include/mcrl2/modal_formula/builder.h
@@ -198,6 +198,10 @@ template <typename Derived>
 struct sort_expression_builder: public add_sort_expressions<lps::sort_expression_builder, Derived>
 {
   typedef add_sort_expressions<lps::sort_expression_builder, Derived> super;
+  using super::enter;
+  using super::leave;
+  using super::update;
+  using super::apply;
 };
 //--- end generated action_formulas::add_sort_expressions code ---//
 
@@ -358,6 +362,10 @@ template <typename Derived>
 struct data_expression_builder: public add_data_expressions<lps::data_expression_builder, Derived>
 {
   typedef add_data_expressions<lps::data_expression_builder, Derived> super;
+  using super::enter;
+  using super::leave;
+  using super::update;
+  using super::apply;
 };
 //--- end generated action_formulas::add_data_expressions code ---//
 
@@ -518,6 +526,10 @@ template <typename Derived>
 struct variable_builder: public add_variables<lps::data_expression_builder, Derived>
 {
   typedef add_variables<lps::data_expression_builder, Derived> super;
+  using super::enter;
+  using super::leave;
+  using super::update;
+  using super::apply;
 };
 //--- end generated action_formulas::add_variables code ---//
 
@@ -678,6 +690,10 @@ template <typename Derived>
 struct action_formula_builder: public add_action_formula_expressions<action_formulas::action_formula_builder_base, Derived>
 {
   typedef add_action_formula_expressions<action_formulas::action_formula_builder_base, Derived> super;
+  using super::enter;
+  using super::leave;
+  using super::update;
+  using super::apply;
 };
 //--- end generated action_formulas::add_action_formula_expressions code ---//
 
@@ -795,6 +811,10 @@ template <typename Derived>
 struct sort_expression_builder: public add_sort_expressions<action_formulas::sort_expression_builder, Derived>
 {
   typedef add_sort_expressions<action_formulas::sort_expression_builder, Derived> super;
+  using super::enter;
+  using super::leave;
+  using super::update;
+  using super::apply;
 };
 //--- end generated regular_formulas::add_sort_expressions code ---//
 
@@ -891,6 +911,10 @@ template <typename Derived>
 struct data_expression_builder: public add_data_expressions<action_formulas::data_expression_builder, Derived>
 {
   typedef add_data_expressions<action_formulas::data_expression_builder, Derived> super;
+  using super::enter;
+  using super::leave;
+  using super::update;
+  using super::apply;
 };
 //--- end generated regular_formulas::add_data_expressions code ---//
 
@@ -987,6 +1011,10 @@ template <typename Derived>
 struct variable_builder: public add_variables<action_formulas::data_expression_builder, Derived>
 {
   typedef add_variables<action_formulas::data_expression_builder, Derived> super;
+  using super::enter;
+  using super::leave;
+  using super::update;
+  using super::apply;
 };
 //--- end generated regular_formulas::add_variables code ---//
 
@@ -1083,6 +1111,10 @@ template <typename Derived>
 struct regular_formula_builder: public add_regular_formula_expressions<regular_formulas::regular_formula_builder_base, Derived>
 {
   typedef add_regular_formula_expressions<regular_formulas::regular_formula_builder_base, Derived> super;
+  using super::enter;
+  using super::leave;
+  using super::update;
+  using super::apply;
 };
 //--- end generated regular_formulas::add_regular_formula_expressions code ---//
 
@@ -1352,6 +1384,10 @@ template <typename Derived>
 struct sort_expression_builder: public add_sort_expressions<regular_formulas::sort_expression_builder, Derived>
 {
   typedef add_sort_expressions<regular_formulas::sort_expression_builder, Derived> super;
+  using super::enter;
+  using super::leave;
+  using super::update;
+  using super::apply;
 };
 //--- end generated state_formulas::add_sort_expressions code ---//
 
@@ -1599,6 +1635,10 @@ template <typename Derived>
 struct data_expression_builder: public add_data_expressions<regular_formulas::data_expression_builder, Derived>
 {
   typedef add_data_expressions<regular_formulas::data_expression_builder, Derived> super;
+  using super::enter;
+  using super::leave;
+  using super::update;
+  using super::apply;
 };
 //--- end generated state_formulas::add_data_expressions code ---//
 
@@ -1846,6 +1886,10 @@ template <typename Derived>
 struct variable_builder: public add_variables<regular_formulas::data_expression_builder, Derived>
 {
   typedef add_variables<regular_formulas::data_expression_builder, Derived> super;
+  using super::enter;
+  using super::leave;
+  using super::update;
+  using super::apply;
 };
 //--- end generated state_formulas::add_variables code ---//
 
@@ -2093,6 +2137,10 @@ template <typename Derived>
 struct state_formula_builder: public add_state_formula_expressions<state_formulas::state_formula_builder_base, Derived>
 {
   typedef add_state_formula_expressions<state_formulas::state_formula_builder_base, Derived> super;
+  using super::enter;
+  using super::leave;
+  using super::update;
+  using super::apply;
 };
 //--- end generated state_formulas::add_state_formula_expressions code ---//
 

--- a/libraries/modal_formula/include/mcrl2/modal_formula/replace.h
+++ b/libraries/modal_formula/include/mcrl2/modal_formula/replace.h
@@ -57,6 +57,38 @@ struct add_capture_avoiding_replacement: public lps::detail::add_capture_avoidin
     : super(sigma, V)
   { }
 };
+
+// Below the functions to do a capture avoiding replacement with an identifier generator are given. 
+template <template <class> class Builder, class Derived, class Substitution, class IdentifierGenerator>
+struct add_capture_avoiding_replacement_with_an_identifier_generator: public lps::detail::add_capture_avoiding_replacement_with_an_identifier_generator<Builder, Derived, Substitution, IdentifierGenerator>
+{
+  typedef lps::detail::add_capture_avoiding_replacement_with_an_identifier_generator<Builder, Derived, Substitution, IdentifierGenerator> super;
+  using super::enter;
+  using super::leave;
+  using super::update;
+  using super::apply;
+  using super::update_sigma;
+
+  action_formula apply(const forall& x)
+  {
+    data::variable_list v = update_sigma.push(x.variables());
+    action_formula result = forall(v, apply(x.body()));
+    update_sigma.pop(v);
+    return result;
+  }
+
+  action_formula apply(const exists& x)
+  {
+    data::variable_list v = update_sigma.push(x.variables());
+    action_formula result = exists(v, apply(x.body()));
+    update_sigma.pop(v);
+    return result;
+  }
+
+  add_capture_avoiding_replacement_with_an_identifier_generator(Substitution& sigma, IdentifierGenerator& id_generator)
+    : super(sigma, id_generator)
+  { }
+};
 /// \endcond
 
 } // namespace detail
@@ -227,6 +259,46 @@ T replace_variables_capture_avoiding(const T& x,
 }
 //--- end generated action_formulas replace_capture_avoiding code ---//
 
+//--- start generated action_formulas replace_capture_avoiding_with_identifier_generator code ---//
+/// \brief Applies sigma as a capture avoiding substitution to x using an identifier generator.
+/// \details This substitution function is much faster than replace_variables_capture_avoiding, but
+///          it requires an identifier generator that generates strings for fresh variables. These 
+///          strings must be unique in the sense that they have not been used for other variables.
+/// \param x The object to which the subsitution is applied.
+/// \param sigma A mutable substitution of which it can efficiently be checked whether a variable occurs in its 
+///              right hand side. The class maintain_variables_in_rhs is useful for this purpose. 
+/// \param id_generator A generator that generates unique strings, not yet used as variable names.
+
+template <typename T, typename Substitution, typename IdentifierGenerator>
+void replace_variables_capture_avoiding_with_an_identifier_generator(T& x,
+                       Substitution& sigma,
+                       IdentifierGenerator& id_generator,
+                       typename std::enable_if<!std::is_base_of<atermpp::aterm, T>::value>::type* = nullptr
+                      )
+{
+  data::detail::apply_replace_capture_avoiding_variables_builder_with_an_identifier_generator<action_formulas::data_expression_builder, action_formulas::detail::add_capture_avoiding_replacement_with_an_identifier_generator>(sigma, id_generator).update(x);
+}
+
+/// \brief Applies sigma as a capture avoiding substitution to x using an identifier generator..
+/// \details This substitution function is much faster than replace_variables_capture_avoiding, but
+///          it requires an identifier generator that generates strings for fresh variables. These 
+///          strings must be unique in the sense that they have not been used for other variables.
+/// \param x The object to which the substiution is applied.
+/// \param sigma A mutable substitution of which it can efficiently be checked whether a variable occurs in its 
+///              right hand side. The class maintain_variables_in_rhs is useful for this purpose. 
+/// \param id_generator A generator that generates unique strings, not yet used as variable names.
+/// \return The result is the term x to which sigma has been applied. 
+template <typename T, typename Substitution, typename IdentifierGenerator>
+T replace_variables_capture_avoiding_with_an_identifier_generator(const T& x,
+                    Substitution& sigma,
+                    IdentifierGenerator& id_generator,
+                    typename std::enable_if<std::is_base_of<atermpp::aterm, T>::value>::type* = nullptr
+                   )
+{
+  return data::detail::apply_replace_capture_avoiding_variables_builder_with_an_identifier_generator<action_formulas::data_expression_builder, action_formulas::detail::add_capture_avoiding_replacement_with_an_identifier_generator>(sigma, id_generator).apply(x);
+}
+//--- end generated action_formulas replace_capture_avoiding_with_identifier_generator code ---//
+
 } // namespace action_formulas
 
 namespace regular_formulas
@@ -258,6 +330,31 @@ make_add_capture_avoiding_replacement(Substitution& sigma, std::multiset<data::v
 {
   return add_capture_avoiding_replacement<Builder, Derived, Substitution>(sigma, V);
 }
+
+// Below the code is provided for a capture avoiding replacement with an identifier generator.
+template <template <class> class Builder, class Derived, class Substitution, class IdentifierGenerator>
+struct add_capture_avoiding_replacement_with_an_identifier_generator: public action_formulas::detail::add_capture_avoiding_replacement_with_an_identifier_generator<Builder, Derived, Substitution, IdentifierGenerator>
+{
+  typedef action_formulas::detail::add_capture_avoiding_replacement_with_an_identifier_generator<Builder, Derived, Substitution, IdentifierGenerator> super;
+  using super::enter;
+  using super::leave;
+  using super::update;
+  using super::apply;
+  using super::update_sigma;
+
+  add_capture_avoiding_replacement_with_an_identifier_generator(Substitution& sigma, IdentifierGenerator& id_generator)
+    : super(sigma, id_generator)
+  { }
+};
+
+template <template <class> class Builder, class Substitution, class IdentifierGenerator>
+add_capture_avoiding_replacement_with_an_identifier_generator<Builder, class Derived, Substitution, IdentifierGenerator>
+make_add_capture_avoiding_replacement_with_an_identifier_generator(Substitution& sigma, IdentifierGenerator& id_generator)
+{
+  return add_capture_avoiding_replacement_with_an_identifier_generator<Builder, Derived, Substitution, IdentifierGenerator>(sigma, id_generator);
+}
+
+
 /// \endcond
 
 } // namespace detail
@@ -428,6 +525,46 @@ T replace_variables_capture_avoiding(const T& x,
 }
 //--- end generated regular_formulas replace_capture_avoiding code ---//
 
+//--- start generated regular_formulas replace_capture_avoiding_with_identifier_generator code ---//
+/// \brief Applies sigma as a capture avoiding substitution to x using an identifier generator.
+/// \details This substitution function is much faster than replace_variables_capture_avoiding, but
+///          it requires an identifier generator that generates strings for fresh variables. These 
+///          strings must be unique in the sense that they have not been used for other variables.
+/// \param x The object to which the subsitution is applied.
+/// \param sigma A mutable substitution of which it can efficiently be checked whether a variable occurs in its 
+///              right hand side. The class maintain_variables_in_rhs is useful for this purpose. 
+/// \param id_generator A generator that generates unique strings, not yet used as variable names.
+
+template <typename T, typename Substitution, typename IdentifierGenerator>
+void replace_variables_capture_avoiding_with_an_identifier_generator(T& x,
+                       Substitution& sigma,
+                       IdentifierGenerator& id_generator,
+                       typename std::enable_if<!std::is_base_of<atermpp::aterm, T>::value>::type* = nullptr
+                      )
+{
+  data::detail::apply_replace_capture_avoiding_variables_builder_with_an_identifier_generator<regular_formulas::data_expression_builder, regular_formulas::detail::add_capture_avoiding_replacement_with_an_identifier_generator>(sigma, id_generator).update(x);
+}
+
+/// \brief Applies sigma as a capture avoiding substitution to x using an identifier generator..
+/// \details This substitution function is much faster than replace_variables_capture_avoiding, but
+///          it requires an identifier generator that generates strings for fresh variables. These 
+///          strings must be unique in the sense that they have not been used for other variables.
+/// \param x The object to which the substiution is applied.
+/// \param sigma A mutable substitution of which it can efficiently be checked whether a variable occurs in its 
+///              right hand side. The class maintain_variables_in_rhs is useful for this purpose. 
+/// \param id_generator A generator that generates unique strings, not yet used as variable names.
+/// \return The result is the term x to which sigma has been applied. 
+template <typename T, typename Substitution, typename IdentifierGenerator>
+T replace_variables_capture_avoiding_with_an_identifier_generator(const T& x,
+                    Substitution& sigma,
+                    IdentifierGenerator& id_generator,
+                    typename std::enable_if<std::is_base_of<atermpp::aterm, T>::value>::type* = nullptr
+                   )
+{
+  return data::detail::apply_replace_capture_avoiding_variables_builder_with_an_identifier_generator<regular_formulas::data_expression_builder, regular_formulas::detail::add_capture_avoiding_replacement_with_an_identifier_generator>(sigma, id_generator).apply(x);
+}
+//--- end generated regular_formulas replace_capture_avoiding_with_identifier_generator code ---//
+
 } // namespace regular_formulas
 
 namespace state_formulas
@@ -475,6 +612,49 @@ make_add_capture_avoiding_replacement(Substitution& sigma, std::multiset<data::v
 {
   return add_capture_avoiding_replacement<Builder, Derived, Substitution>(sigma, V);
 }
+
+// Below the code for add capture avoiding replacment with an identifier generator is provided. 
+
+template <template <class> class Builder, class Derived, class Substitution, class IdentifierGenerator>
+struct add_capture_avoiding_replacement_with_an_identifier_generator: public data::detail::add_capture_avoiding_replacement_with_an_identifier_generator<Builder, Derived, Substitution, IdentifierGenerator>
+{
+  typedef data::detail::add_capture_avoiding_replacement_with_an_identifier_generator<Builder, Derived, Substitution, IdentifierGenerator> super;
+  using super::enter;
+  using super::leave;
+  using super::update;
+  using super::apply;
+  using super::sigma;
+  using super::update_sigma;
+
+  state_formula operator()(const forall& x)
+  {
+    data::variable_list v = update_sigma.push(x.variables());
+    state_formula result = forall(v, (*this)(x.body()));
+    update_sigma.pop(v);
+    return result;
+  }
+
+  state_formula operator()(const exists& x)
+  {
+    data::variable_list v = update_sigma.push(x.variables());
+    state_formula result = exists(v, (*this)(x.body()));
+    update_sigma.pop(v);
+    return result;
+  }
+
+  add_capture_avoiding_replacement_with_an_identifier_generator(Substitution& sigma, IdentifierGenerator& id_generator)
+    : super(sigma, id_generator)
+  { }
+};
+
+template <template <class> class Builder, class Substitution, class IdentifierGenerator>
+add_capture_avoiding_replacement_with_an_identifier_generator<Builder, class Derived, Substitution, IdentifierGenerator>
+make_add_capture_avoiding_replacement_with_an_identifier_generator(Substitution& sigma, IdentifierGenerator& id_generator)
+{
+  return add_capture_avoiding_replacement_with_an_identifier_generator<Builder, Derived, Substitution, IdentifierGenerator>(sigma, id_generator);
+}
+
+
 /// \endcond
 
 } // namespace detail
@@ -644,6 +824,48 @@ T replace_variables_capture_avoiding(const T& x,
   return data::detail::apply_replace_capture_avoiding_variables_builder<state_formulas::data_expression_builder, state_formulas::detail::add_capture_avoiding_replacement>(sigma, V).apply(x);
 }
 //--- end generated state_formulas replace_capture_avoiding code ---//
+
+//--- start generated state_formulas replace_capture_avoiding_with_identifier_generator code ---//
+/// \brief Applies sigma as a capture avoiding substitution to x using an identifier generator.
+/// \details This substitution function is much faster than replace_variables_capture_avoiding, but
+///          it requires an identifier generator that generates strings for fresh variables. These 
+///          strings must be unique in the sense that they have not been used for other variables.
+/// \param x The object to which the subsitution is applied.
+/// \param sigma A mutable substitution of which it can efficiently be checked whether a variable occurs in its 
+///              right hand side. The class maintain_variables_in_rhs is useful for this purpose. 
+/// \param id_generator A generator that generates unique strings, not yet used as variable names.
+
+template <typename T, typename Substitution, typename IdentifierGenerator>
+void replace_variables_capture_avoiding_with_an_identifier_generator(T& x,
+                       Substitution& sigma,
+                       IdentifierGenerator& id_generator,
+                       typename std::enable_if<!std::is_base_of<atermpp::aterm, T>::value>::type* = nullptr
+                      )
+{
+  data::detail::apply_replace_capture_avoiding_variables_builder_with_an_identifier_generator<state_formulas::data_expression_builder, state_formulas::detail::add_capture_avoiding_replacement_with_an_identifier_generator>(sigma, id_generator).update(x);
+}
+
+/// \brief Applies sigma as a capture avoiding substitution to x using an identifier generator..
+/// \details This substitution function is much faster than replace_variables_capture_avoiding, but
+///          it requires an identifier generator that generates strings for fresh variables. These 
+///          strings must be unique in the sense that they have not been used for other variables.
+/// \param x The object to which the substiution is applied.
+/// \param sigma A mutable substitution of which it can efficiently be checked whether a variable occurs in its 
+///              right hand side. The class maintain_variables_in_rhs is useful for this purpose. 
+/// \param id_generator A generator that generates unique strings, not yet used as variable names.
+/// \return The result is the term x to which sigma has been applied. 
+template <typename T, typename Substitution, typename IdentifierGenerator>
+T replace_variables_capture_avoiding_with_an_identifier_generator(const T& x,
+                    Substitution& sigma,
+                    IdentifierGenerator& id_generator,
+                    typename std::enable_if<std::is_base_of<atermpp::aterm, T>::value>::type* = nullptr
+                   )
+{
+  return data::detail::apply_replace_capture_avoiding_variables_builder_with_an_identifier_generator<state_formulas::data_expression_builder, state_formulas::detail::add_capture_avoiding_replacement_with_an_identifier_generator>(sigma, id_generator).apply(x);
+}
+//--- end generated state_formulas replace_capture_avoiding_with_identifier_generator code ---//
+//
+//--- end generated lps replace_capture_avoiding_with_identifier_generator code ---//
 
 namespace detail
 {

--- a/libraries/pbes/include/mcrl2/pbes/builder.h
+++ b/libraries/pbes/include/mcrl2/pbes/builder.h
@@ -185,6 +185,10 @@ template <typename Derived>
 struct sort_expression_builder: public add_sort_expressions<data::sort_expression_builder, Derived>
 {
   typedef add_sort_expressions<data::sort_expression_builder, Derived> super;
+  using super::enter;
+  using super::leave;
+  using super::update;
+  using super::apply;
 };
 //--- end generated add_sort_expressions code ---//
 
@@ -325,6 +329,10 @@ template <typename Derived>
 struct data_expression_builder: public add_data_expressions<data::data_expression_builder, Derived>
 {
   typedef add_data_expressions<data::data_expression_builder, Derived> super;
+  using super::enter;
+  using super::leave;
+  using super::update;
+  using super::apply;
 };
 //--- end generated add_data_expressions code ---//
 
@@ -474,6 +482,10 @@ template <typename Derived>
 struct variable_builder: public add_variables<data::data_expression_builder, Derived>
 {
   typedef add_variables<data::data_expression_builder, Derived> super;
+  using super::enter;
+  using super::leave;
+  using super::update;
+  using super::apply;
 };
 //--- end generated add_variables code ---//
 
@@ -613,6 +625,10 @@ template <typename Derived>
 struct pbes_expression_builder: public add_pbes_expressions<pbes_system::pbes_expression_builder_base, Derived>
 {
   typedef add_pbes_expressions<pbes_system::pbes_expression_builder_base, Derived> super;
+  using super::enter;
+  using super::leave;
+  using super::update;
+  using super::apply;
 };
 //--- end generated add_pbes_expressions code ---//
 

--- a/libraries/pbes/include/mcrl2/pbes/replace.h
+++ b/libraries/pbes/include/mcrl2/pbes/replace.h
@@ -130,6 +130,57 @@ make_replace_propositional_variables_builder(const Substitution& sigma)
 {
   return replace_propositional_variables_builder<Builder, Substitution>(sigma);
 }
+
+// Below the code for the capture avoiding replacement with an identifier generator is provided.
+
+template <template <class> class Builder, class Derived, class Substitution, class IdentifierGenerator>
+struct add_capture_avoiding_replacement_with_an_identifier_generator: public data::detail::add_capture_avoiding_replacement_with_an_identifier_generator<Builder, Derived, Substitution, IdentifierGenerator>
+{
+  typedef data::detail::add_capture_avoiding_replacement_with_an_identifier_generator<Builder, Derived, Substitution, IdentifierGenerator> super;
+  using super::enter;
+  using super::leave;
+  using super::update;
+  using super::apply;
+  using super::update_sigma;
+
+  pbes_expression apply(const forall& x)
+  {
+    data::variable_list v = update_sigma.push(x.variables());
+    pbes_expression result = forall(v, apply(x.body()));
+    update_sigma.pop(v);
+    return result;
+  }
+
+  pbes_expression apply(const exists& x)
+  {
+    data::variable_list v = update_sigma.push(x.variables());
+    pbes_expression result = exists(v, apply(x.body()));
+    update_sigma.pop(v);
+    return result;
+  }
+
+  void update(pbes_equation& x)
+  {
+    data::variable_list v = update_sigma.push(x.variable().parameters());
+    x.variable() = propositional_variable(x.variable().name(), v);
+    x.formula() = apply(x.formula());
+    update_sigma.pop(v);
+  }
+
+  void update(pbes& x)
+  {
+    std::set<data::variable> v = update_sigma(x.global_variables());
+    x.global_variables() = v;
+    update(x.equations());
+    update_sigma.pop(v);
+  }
+
+  add_capture_avoiding_replacement_with_an_identifier_generator(Substitution& sigma, IdentifierGenerator& id_generator)
+    : super(sigma, id_generator)
+  { }
+};
+
+
 /// \endcond
 
 } // namespace detail
@@ -299,6 +350,46 @@ T replace_variables_capture_avoiding(const T& x,
   return data::detail::apply_replace_capture_avoiding_variables_builder<pbes_system::data_expression_builder, pbes_system::detail::add_capture_avoiding_replacement>(sigma, V).apply(x);
 }
 //--- end generated pbes_system replace_capture_avoiding code ---//
+
+//--- start generated pbes_system replace_capture_avoiding_with_identifier_generator code ---//
+/// \brief Applies sigma as a capture avoiding substitution to x using an identifier generator.
+/// \details This substitution function is much faster than replace_variables_capture_avoiding, but
+///          it requires an identifier generator that generates strings for fresh variables. These 
+///          strings must be unique in the sense that they have not been used for other variables.
+/// \param x The object to which the subsitution is applied.
+/// \param sigma A mutable substitution of which it can efficiently be checked whether a variable occurs in its 
+///              right hand side. The class maintain_variables_in_rhs is useful for this purpose. 
+/// \param id_generator A generator that generates unique strings, not yet used as variable names.
+
+template <typename T, typename Substitution, typename IdentifierGenerator>
+void replace_variables_capture_avoiding_with_an_identifier_generator(T& x,
+                       Substitution& sigma,
+                       IdentifierGenerator& id_generator,
+                       typename std::enable_if<!std::is_base_of<atermpp::aterm, T>::value>::type* = nullptr
+                      )
+{
+  data::detail::apply_replace_capture_avoiding_variables_builder_with_an_identifier_generator<pbes_system::data_expression_builder, pbes_system::detail::add_capture_avoiding_replacement_with_an_identifier_generator>(sigma, id_generator).update(x);
+}
+
+/// \brief Applies sigma as a capture avoiding substitution to x using an identifier generator..
+/// \details This substitution function is much faster than replace_variables_capture_avoiding, but
+///          it requires an identifier generator that generates strings for fresh variables. These 
+///          strings must be unique in the sense that they have not been used for other variables.
+/// \param x The object to which the substiution is applied.
+/// \param sigma A mutable substitution of which it can efficiently be checked whether a variable occurs in its 
+///              right hand side. The class maintain_variables_in_rhs is useful for this purpose. 
+/// \param id_generator A generator that generates unique strings, not yet used as variable names.
+/// \return The result is the term x to which sigma has been applied. 
+template <typename T, typename Substitution, typename IdentifierGenerator>
+T replace_variables_capture_avoiding_with_an_identifier_generator(const T& x,
+                    Substitution& sigma,
+                    IdentifierGenerator& id_generator,
+                    typename std::enable_if<std::is_base_of<atermpp::aterm, T>::value>::type* = nullptr
+                   )
+{
+  return data::detail::apply_replace_capture_avoiding_variables_builder_with_an_identifier_generator<pbes_system::data_expression_builder, pbes_system::detail::add_capture_avoiding_replacement_with_an_identifier_generator>(sigma, id_generator).apply(x);
+}
+//--- end generated pbes_system replace_capture_avoiding_with_identifier_generator code ---//
 
 /// \brief Applies a propositional variable substitution.
 template <typename T, typename Substitution>

--- a/libraries/process/include/mcrl2/process/builder.h
+++ b/libraries/process/include/mcrl2/process/builder.h
@@ -359,6 +359,10 @@ template <typename Derived>
 struct sort_expression_builder: public add_sort_expressions<data::sort_expression_builder, Derived>
 {
   typedef add_sort_expressions<data::sort_expression_builder, Derived> super;
+  using super::enter;
+  using super::leave;
+  using super::update;
+  using super::apply;
 };
 //--- end generated add_sort_expressions code ---//
 
@@ -680,6 +684,10 @@ template <typename Derived>
 struct data_expression_builder: public add_data_expressions<data::data_expression_builder, Derived>
 {
   typedef add_data_expressions<data::data_expression_builder, Derived> super;
+  using super::enter;
+  using super::leave;
+  using super::update;
+  using super::apply;
 };
 //--- end generated add_data_expressions code ---//
 
@@ -1009,6 +1017,10 @@ template <typename Derived>
 struct variable_builder: public add_variables<data::data_expression_builder, Derived>
 {
   typedef add_variables<data::data_expression_builder, Derived> super;
+  using super::enter;
+  using super::leave;
+  using super::update;
+  using super::apply;
 };
 //--- end generated add_variables code ---//
 
@@ -1322,6 +1334,10 @@ template <typename Derived>
 struct process_expression_builder: public add_process_expressions<core::builder, Derived>
 {
   typedef add_process_expressions<core::builder, Derived> super;
+  using super::enter;
+  using super::leave;
+  using super::update;
+  using super::apply;
 };
 //--- end generated add_process_expressions code ---//
 
@@ -1642,6 +1658,10 @@ template <typename Derived>
 struct process_identifier_builder: public add_process_identifiers<core::builder, Derived>
 {
   typedef add_process_identifiers<core::builder, Derived> super;
+  using super::enter;
+  using super::leave;
+  using super::update;
+  using super::apply;
 };
 //--- end generated add_process_identifiers code ---//
 

--- a/libraries/process/include/mcrl2/process/replace.h
+++ b/libraries/process/include/mcrl2/process/replace.h
@@ -109,6 +109,90 @@ apply_replace_capture_avoiding_variables_builder(Substitution& sigma, std::multi
 {
   return replace_capture_avoiding_variables_builder<Builder, Binder, Substitution>(sigma, V);
 }
+
+// Below the definitions are given for capture avoiding subsitution witn an identifier generator. 
+template <template <class> class Builder, class Derived, class Substitution, class IdentifierGenerator>
+struct add_capture_avoiding_replacement_with_an_identifier_generator: public data::detail::add_capture_avoiding_replacement_with_an_identifier_generator<Builder, Derived, Substitution, IdentifierGenerator>
+{
+  typedef data::detail::add_capture_avoiding_replacement_with_an_identifier_generator<Builder, Derived, Substitution, IdentifierGenerator> super;
+  using super::enter;
+  using super::leave;
+  using super::apply;
+  using super::update;
+  using super::update_sigma;
+
+  data::assignment_list::const_iterator find_variable(const data::assignment_list& a, const data::variable& v) const
+  {
+    for (data::assignment_list::const_iterator i = a.begin(); i != a.end(); ++i)
+    {
+      if (i->lhs() == v)
+      {
+        return i;
+      }
+    }
+    return a.end();
+  }
+
+  add_capture_avoiding_replacement_with_an_identifier_generator(Substitution& sigma, IdentifierGenerator& id_generator)
+    : super(sigma, id_generator)
+  { }
+
+  process::process_expression apply(const process::process_instance_assignment& x)
+  {
+    static_cast<Derived&>(*this).enter(x);
+    const data::assignment_list& a = x.assignments();
+    std::vector<data::assignment> v;
+
+    for (const data::variable& variable: x.identifier().variables())
+    {
+      const data::assignment_list::const_iterator k = find_variable(a, variable);
+      if (k == a.end())
+      {
+        data::data_expression e = apply(variable);
+        if (e != variable)
+        {
+          v.emplace_back(variable, e);
+        }
+      }
+      else
+      {
+        v.emplace_back(k->lhs(), apply(k->rhs()));
+      }
+    }
+    process::process_expression result = process::process_instance_assignment(x.identifier(), data::assignment_list(v.begin(), v.end()));
+    static_cast<Derived&>(*this).leave(x);
+    return result;
+  }
+
+  process_expression apply(const sum& x)
+  {
+    data::variable_list v = update_sigma.push(x.variables());
+    process_expression result = sum(v, apply(x.operand()));
+    update_sigma.pop(v);
+    return result;
+  }
+};
+
+template <template <class> class Builder, template <template <class> class, class, class, class> class Binder, class Substitution, class IdentifierGenerator>
+struct replace_capture_avoiding_variables__with_an_identifier_generator_builder: public Binder<Builder, replace_capture_avoiding_variables__with_an_identifier_generator_builder<Builder, Binder, Substitution, IdentifierGenerator>, Substitution, IdentifierGenerator>
+{
+  typedef Binder<Builder, replace_capture_avoiding_variables__with_an_identifier_generator_builder<Builder, Binder, Substitution, IdentifierGenerator>, Substitution, IdentifierGenerator> super;
+  using super::enter;
+  using super::leave;
+  using super::apply;
+  using super::update;
+
+  replace_capture_avoiding_variables__with_an_identifier_generator_builder(Substitution& sigma, IdentifierGenerator& id_generator)
+    : super(sigma, id_generator)
+  { }
+};
+
+template <template <class> class Builder, template <template <class> class, class, class, class> class Binder, class Substitution, class IdentifierGenerator>
+replace_capture_avoiding_variables__with_an_identifier_generator_builder<Builder, Binder, Substitution, IdentifierGenerator>
+apply_replace_capture_avoiding_variables__with_an_identifier_generator_builder(Substitution& sigma, IdentifierGenerator& id_generator)
+{
+  return replace_capture_avoiding_variables__with_an_identifier_generator_builder<Builder, Binder, Substitution, IdentifierGenerator>(sigma, id_generator);
+}
 /// \endcond
 
 } // namespace detail
@@ -278,6 +362,46 @@ T replace_variables_capture_avoiding(const T& x,
   return data::detail::apply_replace_capture_avoiding_variables_builder<process::data_expression_builder, process::detail::add_capture_avoiding_replacement>(sigma, V).apply(x);
 }
 //--- end generated process replace_capture_avoiding code ---//
+
+//--- start generated process replace_capture_avoiding_with_identifier_generator code ---//
+/// \brief Applies sigma as a capture avoiding substitution to x using an identifier generator.
+/// \details This substitution function is much faster than replace_variables_capture_avoiding, but
+///          it requires an identifier generator that generates strings for fresh variables. These 
+///          strings must be unique in the sense that they have not been used for other variables.
+/// \param x The object to which the subsitution is applied.
+/// \param sigma A mutable substitution of which it can efficiently be checked whether a variable occurs in its 
+///              right hand side. The class maintain_variables_in_rhs is useful for this purpose. 
+/// \param id_generator A generator that generates unique strings, not yet used as variable names.
+
+template <typename T, typename Substitution, typename IdentifierGenerator>
+void replace_variables_capture_avoiding_with_an_identifier_generator(T& x,
+                       Substitution& sigma,
+                       IdentifierGenerator& id_generator,
+                       typename std::enable_if<!std::is_base_of<atermpp::aterm, T>::value>::type* = nullptr
+                      )
+{
+  data::detail::apply_replace_capture_avoiding_variables_builder_with_an_identifier_generator<process::data_expression_builder, process::detail::add_capture_avoiding_replacement_with_an_identifier_generator>(sigma, id_generator).update(x);
+}
+
+/// \brief Applies sigma as a capture avoiding substitution to x using an identifier generator..
+/// \details This substitution function is much faster than replace_variables_capture_avoiding, but
+///          it requires an identifier generator that generates strings for fresh variables. These 
+///          strings must be unique in the sense that they have not been used for other variables.
+/// \param x The object to which the substiution is applied.
+/// \param sigma A mutable substitution of which it can efficiently be checked whether a variable occurs in its 
+///              right hand side. The class maintain_variables_in_rhs is useful for this purpose. 
+/// \param id_generator A generator that generates unique strings, not yet used as variable names.
+/// \return The result is the term x to which sigma has been applied. 
+template <typename T, typename Substitution, typename IdentifierGenerator>
+T replace_variables_capture_avoiding_with_an_identifier_generator(const T& x,
+                    Substitution& sigma,
+                    IdentifierGenerator& id_generator,
+                    typename std::enable_if<std::is_base_of<atermpp::aterm, T>::value>::type* = nullptr
+                   )
+{
+  return data::detail::apply_replace_capture_avoiding_variables_builder_with_an_identifier_generator<process::data_expression_builder, process::detail::add_capture_avoiding_replacement_with_an_identifier_generator>(sigma, id_generator).apply(x);
+}
+//--- end generated process replace_capture_avoiding_with_identifier_generator code ---//
 
 struct process_identifier_assignment
 {


### PR DESCRIPTION
…ing_with_an_identifier_generator

The functions replace_variables_capture_avoiding apply a substitution
while avoiding undesired capturing of variables by binders such as sum,
forall, exists, whr-clauses, lambda's. This function construct a set of
variables for every application of sigma, making this application slow.

In this commit a new additional substitution function is created with
the rather long name:

replace_variables_capture_avoiding_with_an_identifier_generator

This substitution requires an identifier generator, and it requires that
the substitution sigma can tell whether a variable occurs one of its
right hand sides. It does not need to construct an explicit set.

A substitution can be transformed to a substitution that maintains the
variables in its right hand side by a new class wrapper
maintain_variables_in_rh.

The new function
replace_variables_capture_avoiding_with_an_identifier_generator is made
available for all classes for which replace_variables_capture_avoiding
was also available.

The lineariser has been adapted to use the new substitution. For an
example such as merry_go_square actual linearisation is 10 times faster.
Furthermore, much of the code to calculate explicit right hand sides can
be removed also. This still needs to be done.

The latex file substitutions.tex is adapted to also contain the
definition of the new substitution.

Some points must still be addressed:
1) the name of the new function is too long. It should probably be shortened.
2) there are no tests. This is related to the problem that tests do not
   appear to work. See issue #1471.
3) Some of the code of replace_variables_capture_avoiding_with_an_identifier_generator
   is a direct copy of the code of replace_variables_capture_avoiding.
   It might be better to avoid this code copying, but as it stands, I do
   not see how.
4) The lineariser has unnecessary code to generate the variables in
   right hand sides. This must be cleaned up at some point.

This commit should be merged with the main branch after having been
reviewed by Wieger. It should be done after the August 2018 release as
the changes are substantial, especially to the lineariser.