### PR TITLE
Fixed generating documentation using newer Sphinx and argparse versions.

### DIFF
--- a/doc/sphinx/CMakeLists.txt
+++ b/doc/sphinx/CMakeLists.txt
@@ -20,7 +20,7 @@ else()
 endif()
 
 set(MCRL2_GENERATE_DOC_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/generate.py)
-set(MCRL2_GENERATE_DOC_COMMAND ${MCRL2_GENERATE_DOC_SCRIPT} --version=${MCRL2_VERSION} --path=${BIN_PATH}
+set(MCRL2_GENERATE_DOC_COMMAND ${MCRL2_GENERATE_DOC_SCRIPT} --version ${MCRL2_VERSION} --path=${BIN_PATH}
   --temp=${CMAKE_CURRENT_BINARY_DIR}/_temp --out=${CMAKE_CURRENT_BINARY_DIR}/html)
 
 if(MCRL2_PACKAGE_RELEASE)
@@ -32,7 +32,7 @@ add_custom_target(doc
   COMMENT "(Re)-generating mCRL2 documentation (regenerates all cached documentation)" VERBATIM
 )
 
-add_custom_target(fastdoc
+add_custom_target(fastdoc 
   COMMAND ${MCRL2_GENERATE_DOC_COMMAND} -dd
   COMMENT "Generating mCRL2 documentation (does not regenerate cached PDF, manual pages and Doxygen documentation)" VERBATIM
 )

--- a/doc/sphinx/source/__init__.py
+++ b/doc/sphinx/source/__init__.py
@@ -111,14 +111,14 @@ def generate_rst(binpath, temppath, outpath, version):
   print '<OPTIONS>', ' '.join(options)
 
   try:
-    sphinx.main( shared_opts +
+    sphinx.build_main( shared_opts +
                  ['-c', cfg_dev,
                  temp_dev, out_dev])
   except SystemExit as e:
     if e.code != 0:
       raise e
   try:
-    sphinx.main( shared_opts +
+    sphinx.build_main( shared_opts +
                  ['-c', cfg_usr,
                  temp_usr, out_usr])
   except SystemExit as e:

--- a/doc/sphinx/source/sphinxext/dparser_grammar.py
+++ b/doc/sphinx/source/sphinxext/dparser_grammar.py
@@ -1,5 +1,4 @@
 from sphinx.domains.std import ProductionList
-from sphinx.util.compat import make_admonition
 from docutils import nodes
 import os
 

--- a/doc/sphinx/source/sphinxext/tikz.py
+++ b/doc/sphinx/source/sphinxext/tikz.py
@@ -57,7 +57,7 @@ except ImportError:
     from sha import sha
 
 from docutils import nodes, utils
-from docutils.parsers.rst import directives
+from docutils.parsers.rst import directives, Directive
 
 from sphinx.errors import SphinxError
 try:
@@ -65,8 +65,6 @@ try:
 except:
     from sphinx.util import ensuredir, ENOENT, EPIPE
     
-from sphinx.util.compat import Directive
-
 class TikzExtError(SphinxError):
     category = 'Tikz extension error'
 


### PR DESCRIPTION
Currently it is not possible to build the documentation using Sphinx newer versions (at least 1.6 and up). The reason for this was the deprecation and moving around of several python libraries. The exact changes are described in the commit messages. For the argparse Python library that is also used the interface changed slightly as well.

Note that the changes in this pull request break compatibility with Sphinx 1.2.2 and below. This is the version that is available on Ubuntu 14.04 LTS, as such building documentation would no longer be supported there.