### PR TITLE
Check dataspec only once when converting fsm->lts or aut->lts

### DIFF
--- a/libraries/lps/include/mcrl2/lps/parse.h
+++ b/libraries/lps/include/mcrl2/lps/parse.h
@@ -61,6 +61,15 @@ process::untyped_multi_action parse_multi_action_new(const std::string& text)
 }
 
 inline
+multi_action complete_multi_action(process::untyped_multi_action& x, multi_action_type_checker& typechecker, const data::data_specification& data_spec = data::detail::default_specification())
+{
+  multi_action result = lps::typecheck_multi_action(x, typechecker);
+  lps::translate_user_notation(result);
+  lps::normalize_sorts(result, data_spec);
+  return result;
+}
+
+inline
 multi_action complete_multi_action(process::untyped_multi_action& x, const process::action_label_list& action_decls, const data::data_specification& data_spec = data::detail::default_specification())
 {
   multi_action result = lps::typecheck_multi_action(x, data_spec, action_decls);
@@ -195,6 +204,20 @@ multi_action parse_multi_action(std::stringstream& in, const process::action_lab
   return detail::complete_multi_action(u, action_decls, data_spec);
 }
 
+/// \brief Parses a multi_action from an input stream
+/// \param in An input stream containing a multi_action
+/// \param[in] typechecker Typechecker used to check the action.
+/// \param[in] data_spec The data specification that is used for type checking.
+/// \return The parsed multi_action
+/// \exception mcrl2::runtime_error when the input does not match the syntax of a multi action.
+inline
+multi_action parse_multi_action(std::stringstream& in, multi_action_type_checker& typechecker, const data::data_specification& data_spec = data::detail::default_specification())
+{
+  std::string text = utilities::read_text(in);
+  process::untyped_multi_action u = detail::parse_multi_action_new(text);
+  return detail::complete_multi_action(u, typechecker, data_spec);
+}
+
 /// \brief Parses a multi_action from a string
 /// \param text A string containing a multi_action
 /// \param[in] action_decls A list of allowed action labels that is used for type checking.
@@ -206,6 +229,19 @@ multi_action parse_multi_action(const std::string& text, const process::action_l
 {
   std::stringstream ma_stream(text);
   return parse_multi_action(ma_stream, action_decls, data_spec);
+}
+
+/// \brief Parses a multi_action from a string
+/// \param text A string containing a multi_action
+/// \param[in] typechecker Typechecker used to check the action.
+/// \param[in] data_spec The data specification that is used for type checking.
+/// \return The parsed multi_action
+/// \exception mcrl2::runtime_error when the input does not match the syntax of a multi action.
+inline
+multi_action parse_multi_action(const std::string& text, multi_action_type_checker& typechecker, const data::data_specification& data_spec = data::detail::default_specification())
+{
+  std::stringstream ma_stream(text);
+  return parse_multi_action(ma_stream, typechecker, data_spec);
 }
 
 /// \brief Parses a process specification from an input stream

--- a/libraries/lps/include/mcrl2/lps/typecheck.h
+++ b/libraries/lps/include/mcrl2/lps/typecheck.h
@@ -135,6 +135,20 @@ multi_action typecheck_multi_action(process::untyped_multi_action& mult_act,
   return typechecker(mult_act);
 }
 
+/** \brief     Type check a multi action
+ *  Throws an exception if something went wrong.
+ *  \param[in] mult_act A multi action that has not been type checked.
+ *  \param[in] typechecker Checker that will be used to check multi_act
+ *  \post      mult_action is type checked and sorts have been added when necessary.
+ **/
+inline
+multi_action typecheck_multi_action(process::untyped_multi_action& mult_act,
+                                     multi_action_type_checker& typechecker
+                                    )
+{
+  return typechecker(mult_act);
+}
+
 /// \brief Type checks an action rename specification.
 /// \param arspec An action rename specifition.
 /// \param lpsspec A linear process specification, used for the datatypes and action declarations.

--- a/libraries/lts/include/mcrl2/lts/detail/lts_convert.h
+++ b/libraries/lts/include/mcrl2/lts/detail/lts_convert.h
@@ -239,9 +239,9 @@ inline void convert_core_lts(CONVERTOR& c,
 
 // =========================================================================   REWRITTEN CODE ==============
 
-inline action_label_lts translate_label_aux(const action_label_string& l1, 
-                                            const data::data_specification& data, 
-                                            const process::action_label_list& action_labels)
+inline action_label_lts translate_label_aux(const action_label_string& l1,
+                                            const data::data_specification& data,
+                                            lps::multi_action_type_checker& typechecker)
 {
   std::string l(l1);
   action_label_lts al;
@@ -255,7 +255,7 @@ inline action_label_lts translate_label_aux(const action_label_string& l1,
 
   try
   {
-    al=parse_lts_action(l,data,action_labels);
+    al=parse_lts_action(l,data,typechecker);
   }
   catch (mcrl2::runtime_error& e)
   {
@@ -469,9 +469,11 @@ class convertor<lts_fsm_base, lts_lts_base>
   public:
     const lts_fsm_base& m_lts_in;
     const lts_lts_base& m_lts_out;
+    lps::multi_action_type_checker m_typechecker;
 
     convertor(const lts_fsm_base& lts_base_in, lts_lts_base& lts_base_out):
-      m_lts_in(lts_base_in), m_lts_out(lts_base_out)
+      m_lts_in(lts_base_in), m_lts_out(lts_base_out),
+      m_typechecker(lts_base_out.data(), data::variable_list(), lts_base_out.action_label_declarations())
     {
     }
 };
@@ -502,7 +504,7 @@ inline void lts_convert_base_class(const lts_fsm_base& base_in,
 
 inline action_label_lts lts_convert_translate_label(const action_label_string& l1, convertor<lts_fsm_base, lts_lts_base>& c) 
 {
-  return translate_label_aux(l1, c.m_lts_out.data(), c.m_lts_out.action_label_declarations());
+  return translate_label_aux(l1, c.m_lts_out.data(), c.m_typechecker);
 }
 
 inline void lts_convert_translate_state(const state_label_fsm& state_label_in, 
@@ -677,11 +679,11 @@ class convertor<lts_aut_base, lts_lts_base>
 {
   public:
     const data::data_specification& m_data;
-    const process::action_label_list& m_action_labels;
+    lps::multi_action_type_checker m_typechecker;
 
     convertor(const lts_aut_base& /* lts_base_in*/, const lts_lts_base& lts_base_out)
       : m_data(lts_base_out.data()),
-        m_action_labels(lts_base_out.action_label_declarations())
+        m_typechecker(m_data, data::variable_list(), lts_base_out.action_label_declarations())
     {
     }
 };
@@ -712,7 +714,7 @@ inline void lts_convert_base_class(const lts_aut_base& base_in,
 
 inline action_label_lts lts_convert_translate_label(const action_label_string& l_in, convertor<lts_aut_base, lts_lts_base>& c)
 {
-  return translate_label_aux(l_in, c.m_data, c.m_action_labels);
+  return translate_label_aux(l_in, c.m_data, c.m_typechecker);
 }
 
 inline void lts_convert_translate_state(const state_label_empty& /* state_label_in */, state_label_lts& state_label_out, convertor<lts_aut_base, lts_lts_base>& /* c */)

--- a/libraries/lts/include/mcrl2/lts/lts_lts.h
+++ b/libraries/lts/include/mcrl2/lts/lts_lts.h
@@ -200,9 +200,9 @@ inline std::string pp(const action_label_lts& l)
 inline action_label_lts parse_lts_action(
   const std::string& multi_action_string,
   const data::data_specification& data_spec,
-  const process::action_label_list& act_decls)
+  lps::multi_action_type_checker& typechecker)
 {
-  return action_label_lts(lps::parse_multi_action(multi_action_string, act_decls, data_spec));
+  return action_label_lts(lps::parse_multi_action(multi_action_string, typechecker, data_spec));
 }
 
 namespace detail


### PR DESCRIPTION
When parsing a multi action, each time a new `multi_action_type_checker` was constructed. This also involved constructing a new `data_type_checker` each time and several checks on the data specification. This is inefficient when converting large transition systems from fsm or aut format to lts format.

I added several new functions that require a `multi_action_type_checker` as parameter. The lts library uses the new functions to convert transition systems more efficiently.