### PR TITLE
Improvements in aterm_io_binary

### DIFF
--- a/libraries/atermpp/include/mcrl2/atermpp/detail/indexed_set.h
+++ b/libraries/atermpp/include/mcrl2/atermpp/detail/indexed_set.h
@@ -1,11 +1,11 @@
 // Author(s): Jan Friso Groote
 // Copyright: see the accompanying file COPYING or copy at
 // https://github.com/mCRL2org/mCRL2/blob/master/COPYING
-// 
+//
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
-// 
+//
 /// \file atermpp/detail/indexed_set.cpp
 /// \brief This file contains some constants and functions shared
 ///        between indexed_sets and tables.
@@ -67,7 +67,7 @@ std::size_t indexed_set<ELEMENT>::put_in_hashtable(const ELEMENT& key, std::size
      and find whether key already exists */
 
   std::size_t deleted_position=detail::EMPTY; // This variable recalls a proper deleted position to insert n. EMPTY means not yet found.
-  std::size_t start = (std::hash<aterm>()(key)*detail::PRIME_NUMBER) & sizeMinus1;
+  std::size_t start = (std::hash<ELEMENT>()(key)*detail::PRIME_NUMBER) & sizeMinus1;
   std::size_t c = start;
 
   while (true)
@@ -77,16 +77,16 @@ std::size_t indexed_set<ELEMENT>::put_in_hashtable(const ELEMENT& key, std::size
     assert(v==detail::EMPTY || v == detail::DELETED || v<m_keys.size());
     if (v == detail::EMPTY)
     {
-      /* Found an empty spot, insert a new index belonging to key, 
+      /* Found an empty spot, insert a new index belonging to key,
          preferably at a deleted position, if that has been encountered. */
       if (deleted_position==detail::EMPTY)
-      { 
+      {
         --nr_of_insertions_until_next_rehash;
         assert(nr_of_insertions_until_next_rehash!=npos);
         hashtable[c] = n;
       }
       else
-      { 
+      {
         hashtable[deleted_position] = n;
       }
       return n;
@@ -96,7 +96,7 @@ std::size_t indexed_set<ELEMENT>::put_in_hashtable(const ELEMENT& key, std::size
     {
       /* Recall this position to be used, in case the element is not found. */
       if (deleted_position==detail::EMPTY)
-      { 
+      {
         deleted_position=c;
       }
     }
@@ -130,7 +130,7 @@ inline void indexed_set<ELEMENT>::resize_hashtable()
   std::size_t newsizeMinus1 = detail::calculateNewSize(sizeMinus1,largest_used_index, max_load);
 
   hashtable.clear();
-  hashtable.resize(newsizeMinus1+1,detail::EMPTY); 
+  hashtable.resize(newsizeMinus1+1,detail::EMPTY);
 
   sizeMinus1=newsizeMinus1;
   nr_of_insertions_until_next_rehash = ((sizeMinus1/100)*max_load);
@@ -140,7 +140,7 @@ inline void indexed_set<ELEMENT>::resize_hashtable()
 
   free_positions=std::stack < std::size_t >();
   /* rebuild the hashtable again, and put free indices in the free_position stack.
-     Count down, such that the lowest indices are highest in the stack, to be 
+     Count down, such that the lowest indices are highest in the stack, to be
      re-used first. */
   for (std::size_t i=m_keys.size(); i>0 ; )
   {
@@ -170,7 +170,7 @@ inline indexed_set<ELEMENT>::indexed_set(std::size_t initial_size /* = 100 */, u
 template <class ELEMENT>
 inline ssize_t indexed_set<ELEMENT>::index(const ELEMENT& elem) const
 {
-  std::size_t start = (std::hash<aterm>()(elem)*detail::PRIME_NUMBER) & sizeMinus1;
+  std::size_t start = (std::hash<ELEMENT>()(elem)*detail::PRIME_NUMBER) & sizeMinus1;
   std::size_t c = start;
   do
   {
@@ -196,7 +196,7 @@ inline ssize_t indexed_set<ELEMENT>::index(const ELEMENT& elem) const
 template <class ELEMENT>
 bool indexed_set<ELEMENT>::erase(const ELEMENT& key)
 {
-  std::size_t start = (std::hash<aterm>()(key)*detail::PRIME_NUMBER) & sizeMinus1;
+  std::size_t start = (std::hash<ELEMENT>()(key)*detail::PRIME_NUMBER) & sizeMinus1;
   std::size_t c = start;
   std::size_t v;
   while (true)
@@ -263,7 +263,7 @@ inline std::pair<std::size_t, bool> indexed_set<ELEMENT>::put(const ELEMENT& key
   {
     return std::make_pair(n,false);
   }
-  
+
   if (!free_positions.empty())
   {
     free_positions.pop();
@@ -276,13 +276,13 @@ inline std::pair<std::size_t, bool> indexed_set<ELEMENT>::put(const ELEMENT& key
   m_keys[n]=key;
   if (nr_of_insertions_until_next_rehash==0)
   {
-    resize_hashtable(); 
+    resize_hashtable();
   }
 
   return std::make_pair(n, true);
 }
 
 
-} // namespace atermpp 
+} // namespace atermpp
 
 #endif // MCRL2_ATERMPP_DETAIL_INDEXED_SET_H

--- a/libraries/atermpp/include/mcrl2/atermpp/function_symbol.h
+++ b/libraries/atermpp/include/mcrl2/atermpp/function_symbol.h
@@ -173,6 +173,12 @@ class function_symbol
       }
     }
 
+    bool defined() const
+    {
+      assert(is_valid());
+      return *this != AS_DEFAULT;
+    }
+
     /// \brief Return the name of the function_symbol.
     /// \return The name of the function symbol.
     const std::string& name() const

--- a/libraries/atermpp/source/aterm_io_binary.cpp
+++ b/libraries/atermpp/source/aterm_io_binary.cpp
@@ -304,9 +304,7 @@ static void write_symbol(const function_symbol& sym, ostream& os)
 static const function_symbol& get_function_symbol(const aterm& t)
 {
   assert(t.type_is_int() || t.type_is_list() || t.type_is_appl());
-  return t.type_is_int()  ? detail::function_adm.AS_INT :
-         t.type_is_list() ? (t==aterm_list() ? detail::function_adm.AS_EMPTY_LIST : detail::function_adm.AS_LIST) :
-         down_cast<aterm_appl>(t).function();
+  return detail::address(t)->function();
 }
 
 /**

--- a/libraries/atermpp/source/aterm_io_binary.cpp
+++ b/libraries/atermpp/source/aterm_io_binary.cpp
@@ -185,8 +185,16 @@ static char* text_buffer = nullptr;
 static std::size_t text_buffer_size = 0;
 
 static std::size_t  bits_in_buffer = 0; /* how many bits in bit_buffer are used */
+/**
+ * \brief Buffer that is filled starting from bit 127 when reading or writing
+ */
 static std::bitset<128> read_write_buffer(0);
 
+/**
+ * \brief Reverse the order of bits in val.
+ * \detail In BAF version 0x0304 the bits are written in reverse order. When bumping
+ * the version number, one should also consider to remove this reversal.
+ */
 static void reverse_bit_order(std::size_t& val)
 {
   val = ((val << 32) & 0xFFFFFFFF00000000) | ((val >> 32) & 0x00000000FFFFFFFF);
@@ -197,6 +205,9 @@ static void reverse_bit_order(std::size_t& val)
   val = ((val << 1)  & 0xAAAAAAAAAAAAAAAA) | ((val >> 1)  & 0x5555555555555555);
 }
 
+/**
+ * \brief Write the nr_bits least significant bits from val to os
+ */
 static void writeBits(std::size_t val, const std::size_t nr_bits, ostream& os)
 {
   if(nr_bits == 0)
@@ -220,7 +231,9 @@ static void writeBits(std::size_t val, const std::size_t nr_bits, ostream& os)
   }
 }
 
-
+/**
+ * \brief Flush the remaining bits in the buffer to os.
+ */
 static void flushBitsToWriter(ostream& os)
 {
   if (bits_in_buffer > 0)
@@ -256,6 +269,7 @@ bool readBits(std::size_t& val, const std::size_t nr_bits, istream& is)
   }
   while(bits_in_buffer < nr_bits)
   {
+    // Read bytes until the buffer is sufficiently full
     int byte = is.get();
     if(is.fail())
     {


### PR DESCRIPTION
I made some improvements to aterm_io_binary that should save time and memory. Some of the changes are just refactoring. Other changes are more involved, especially commits 9405270, 8b82418 and c65748f.