### PR TITLE
Sort property names in mcrl2-ide lexicographically

### DIFF
--- a/tools/release/mcrl2ide/filesystem.cpp
+++ b/tools/release/mcrl2ide/filesystem.cpp
@@ -641,6 +641,9 @@ std::cerr << "PAD |" << specFilePath.toStdString() << "|\n";
               properties.push_back(readPropertyFromFile(filePath));
             }
           }
+          properties.sort([] (const Property& lhs, const Property& rhs) {
+            return QString::compare(lhs.name, rhs.name) < 0;
+          });
           delete dirIterator;
 
           projectOpen = true;


### PR DESCRIPTION
Currently this is done by the OS, some of which default to sorting the
filenames (Windows) while others do not (Linux), which results in an
unsorted property list on some systems, which is annoying.