### PR TITLE
Several changes to the refinement algorithm in ltscompare

### DIFF
--- a/libraries/lts/include/mcrl2/lts/detail/liblts_failures_refinement.h
+++ b/libraries/lts/include/mcrl2/lts/detail/liblts_failures_refinement.h
@@ -379,8 +379,6 @@ bool destructive_refinement_checker(
                                                            // This line occurs at another place in the code than in 
                                                            // the original algorithm, where insertion in the anti-chain
                                                            // was too late, causing too many impl-spec pairs to be investigated.
-  std::size_t statistics_counter_max = l1.num_states() / 10;
-  std::size_t statistics_counter = statistics_counter_max;
   refinement_statistics<detail::state_states_counter_example_index_triple<COUNTER_EXAMPLE_CONSTRUCTOR>> stats(anti_chain, working);
 
   while (working.size()>0)                            // while working!=empty
@@ -392,13 +390,6 @@ bool destructive_refinement_checker(
     working.pop_front();     // At this point it could be checked whether impl_spec still exists in anti_chain.
                              // Small scale experiments show that this is a little bit more expensive than doing the explicit check below.
 
-    // Periodically report statistics.
-    if (--statistics_counter == 0)
-    {
-      report_statistics(stats);
-      statistics_counter = statistics_counter_max;
-    }
-    
     if (refinement==failures_divergence && weak_property_cache.diverges(impl_spec.state()))
                                                       // if impl diverges
     {
@@ -480,7 +471,7 @@ bool destructive_refinement_checker(
           ++stats.antichain_misses;
           if (strategy == exploration_strategy::es_breadth)
           {
-            working.push_back(impl_spec_counterex);   // push(impl,spec') into working;
+            working.push_back(impl_spec_counterex);   // add(impl,spec') at the bottom of the working;
           }
           else if (strategy == exploration_strategy::es_depth)
           {
@@ -489,7 +480,6 @@ bool destructive_refinement_checker(
         }
       }
     }
-    
   }
 
   report_statistics(stats);

--- a/libraries/lts/include/mcrl2/lts/detail/liblts_failures_refinement.h
+++ b/libraries/lts/include/mcrl2/lts/detail/liblts_failures_refinement.h
@@ -358,7 +358,7 @@ bool destructive_refinement_checker(
     bool initial_equal = false;
     std::tie(init_l2, initial_equal) = reduce(l1, refinement, weak_reduction, init_l2);
 
-    if (initial_equal)
+    if (initial_equal && weak_reduction)
     {
       mCRL2log(log::verbose) << "Both LTSs are (divergence-preserving) branching bisimular, so no need to check refinement relation.\n";
       return true;

--- a/libraries/lts/include/mcrl2/lts/detail/liblts_failures_refinement.h
+++ b/libraries/lts/include/mcrl2/lts/detail/liblts_failures_refinement.h
@@ -17,8 +17,8 @@
 // All algorithms come in a variant with and without internal steps. 
 // It is possible to generate a counter transition system in case the inclusion is answered by no.
 
-#ifndef _LIBLTS_FAILURES_REFINEMENT_H
-#define _LIBLTS_FAILURES_REFINEMENT_H
+#ifndef LIBLTS_FAILURES_REFINEMENT_H
+#define LIBLTS_FAILURES_REFINEMENT_H
 
 #include "unordered_set"
 #include "mcrl2/lts/detail/counter_example.h"
@@ -765,6 +765,4 @@ namespace detail
 } // namespace lts
 } // namespace mcrl2
 
-#endif //  _LIBLTS_FAILURES_REFINEMENT_H
-
-
+#endif //  LIBLTS_FAILURES_REFINEMENT_H

--- a/libraries/lts/include/mcrl2/lts/detail/liblts_failures_refinement.h
+++ b/libraries/lts/include/mcrl2/lts/detail/liblts_failures_refinement.h
@@ -300,6 +300,12 @@ bool destructive_refinement_checker(
     // Assign the reduced LTS, and set init_l2.
     init_l2=bisim_part.get_eq_class(init_l2);
     bisim_part.replace_transition_system(weak_reduction,preserve_divergence);
+
+    if (bisim_part.in_same_class(init_l2, l1.initial_state()))
+    {
+      mCRL2log(log::debug) << "Both LTSs are (divergence-preserving) branching bisimular, so no need to check refinement relation.\n";
+      return true;
+    }
   }
 
   const detail::lts_cache<LTS_TYPE> weak_property_cache(l1,weak_reduction);

--- a/libraries/lts/include/mcrl2/lts/detail/liblts_failures_refinement.h
+++ b/libraries/lts/include/mcrl2/lts/detail/liblts_failures_refinement.h
@@ -304,6 +304,8 @@ bool destructive_refinement_checker(
                         const exploration_strategy strategy,
                         COUNTER_EXAMPLE_CONSTRUCTOR generate_counter_example = detail::dummy_counter_example_constructor())
 {
+  assert(strategy == exploration_strategy::es_breadth || strategy == exploration_strategy::es_depth); // Need a valid strategy.
+
   if (!generate_counter_example.is_dummy())  // Counter example is requested, apply bisimulation to l2.
   {
     const bool preserve_divergence=weak_reduction && (refinement!=trace);

--- a/libraries/lts/include/mcrl2/lts/detail/liblts_failures_refinement.h
+++ b/libraries/lts/include/mcrl2/lts/detail/liblts_failures_refinement.h
@@ -273,6 +273,7 @@ struct refinement_statistics
   detail::anti_chain_type& antichain;
   std::deque<T>& working;
   std::size_t max_working = 0; // The largest size of working.
+  std::size_t max_antichain = 0; // The largest size of the antichain.
   std::size_t antichain_misses = 0; // Number of times a pair was inserted into the antichain.
   std::size_t antichain_inserts = 0; // Number of times antichain_insert was called.
 };
@@ -284,7 +285,8 @@ void report_statistics(refinement_statistics<T>& stats)
   mCRL2log(log::debug, "Performance") << "working (current: " << stats.working.size() << ", max: " << stats.max_working << ").\n";
   mCRL2log(log::debug, "Performance") << "antichain (hits: " << stats.antichain_inserts - stats.antichain_misses
       << ", misses: " << stats.antichain_misses
-      << ", size: " << stats.antichain.size() << ")\n";
+      << ", size: " << stats.antichain.size()
+      << ", max: " << stats.max_antichain << ")\n";
 }
 
 /// \brief This function checks using algorithms in the paper mentioned above that
@@ -373,14 +375,15 @@ bool destructive_refinement_checker(
   while (working.size()>0)                            // while working!=empty
   {
     detail::state_states_counter_example_index_triple < COUNTER_EXAMPLE_CONSTRUCTOR > impl_spec;   // pop (impl,spec) from working;
-    impl_spec.swap(working.front());  
-    stats.max_working = std::max(working.size(), stats.max_working);
+    impl_spec.swap(working.front());
+    stats.max_working   = std::max(working.size(), stats.max_working);
+    stats.max_antichain = std::max(anti_chain.size(), stats.max_antichain);
     working.pop_front();     // At this point it could be checked whether impl_spec still exists in anti_chain.
                              // Small scale experiments show that this is a little bit more expensive than doing the explicit check below.
-    --statistics_counter;
-    if (statistics_counter == 0)
+
+    // Periodically report statistics.
+    if (--statistics_counter == 0)
     {
-      // Periodically report statistics.
       report_statistics(stats);
       statistics_counter = statistics_counter_max;
     }

--- a/libraries/lts/include/mcrl2/lts/detail/liblts_failures_refinement.h
+++ b/libraries/lts/include/mcrl2/lts/detail/liblts_failures_refinement.h
@@ -756,8 +756,8 @@ namespace detail
         }
         mCRL2log(log::verbose) << "Finished printing acceptance sets.\n";
         // Ready printing acceptance sets.
-        return false;
       }
+      return false;
     }
 
     return true;   

--- a/libraries/lts/include/mcrl2/lts/detail/liblts_failures_refinement.h
+++ b/libraries/lts/include/mcrl2/lts/detail/liblts_failures_refinement.h
@@ -280,6 +280,21 @@ bool destructive_refinement_checker(
                         const exploration_strategy strategy,
                         COUNTER_EXAMPLE_CONSTRUCTOR generate_counter_example = detail::dummy_counter_example_constructor())
 {
+  if (!generate_counter_example.is_dummy())  // Counter example is requested, apply bisimulation to l2.
+  {
+    const bool preserve_divergence=weak_reduction && (refinement!=trace);
+    l2.clear_state_labels();
+    if (weak_reduction)
+    {
+      detail::scc_partitioner<LTS_TYPE> scc_part(l2);
+      scc_part.replace_transition_system(preserve_divergence);
+    }
+
+    detail::bisim_partitioner_gjkw<LTS_TYPE> bisim_part(l2,weak_reduction,preserve_divergence);
+    // Assign the reduced LTS, and set init_l2.
+    bisim_part.replace_transition_system(weak_reduction,preserve_divergence);
+  }
+
   std::size_t init_l2 = l2.initial_state() + l1.num_states();
   mcrl2::lts::detail::merge(l1,l2);
   l2.clear(); // No use for l2 anymore.

--- a/libraries/lts/include/mcrl2/lts/lts_algorithm.h
+++ b/libraries/lts/include/mcrl2/lts/lts_algorithm.h
@@ -760,15 +760,15 @@ bool compare(const LTS_TYPE& l1, const LTS_TYPE& l2, const lts_equivalence eq, c
 }
 
 template <class LTS_TYPE>
-bool compare(const LTS_TYPE& l1, const LTS_TYPE& l2, const lts_preorder pre, const bool generate_counter_example)
+bool compare(const LTS_TYPE& l1, const LTS_TYPE& l2, const lts_preorder pre, const bool generate_counter_example, const exploration_strategy strategy = es_breadth)
 {
   LTS_TYPE l1_copy(l1);
   LTS_TYPE l2_copy(l2);
-  return destructive_compare(l1_copy,l2_copy,pre,generate_counter_example);
+  return destructive_compare(l1_copy, l2_copy, pre, generate_counter_example, strategy);
 }
 
 template <class LTS_TYPE>
-bool destructive_compare(LTS_TYPE& l1, LTS_TYPE& l2, const lts_preorder pre, const bool generate_counter_example)
+bool destructive_compare(LTS_TYPE& l1, LTS_TYPE& l2, const lts_preorder pre, const bool generate_counter_example, const exploration_strategy strategy = es_breadth)
 {
   switch (pre)
   {
@@ -827,7 +827,7 @@ bool destructive_compare(LTS_TYPE& l1, LTS_TYPE& l2, const lts_preorder pre, con
       detail::bisimulation_reduce(l2,false);
 
       // Trace preorder now corresponds to simulation preorder
-      return destructive_compare(l1,l2,lts_pre_sim,generate_counter_example);
+      return destructive_compare(l1, l2, lts_pre_sim, generate_counter_example, strategy);
     }
     case lts_pre_weak_trace:
     {
@@ -840,52 +840,52 @@ bool destructive_compare(LTS_TYPE& l1, LTS_TYPE& l2, const lts_preorder pre, con
       detail::tau_star_reduce(l2);
 
       // Weak trace preorder now corresponds to strong trace preorder
-      return destructive_compare(l1,l2,lts_pre_trace,generate_counter_example);
+      return destructive_compare(l1, l2, lts_pre_trace, generate_counter_example, strategy);
     }
     case lts_pre_trace_anti_chain:
     {
       if (generate_counter_example)
       {
         detail::counter_example_constructor cec("counter_example_trace_preorder.trc");
-        return destructive_refinement_checker(l1, l2, trace, false, cec);
+        return destructive_refinement_checker(l1, l2, trace, false, strategy, cec);
       }
-      return destructive_refinement_checker(l1, l2, trace, false);
+      return destructive_refinement_checker(l1, l2, trace, false, strategy);
     }
     case lts_pre_weak_trace_anti_chain:
     {
       if (generate_counter_example)
       {
         detail::counter_example_constructor cec("counter_example_weak_trace_preorder.trc");
-        return destructive_refinement_checker(l1, l2, trace, true, cec);
+        return destructive_refinement_checker(l1, l2, trace, true, strategy, cec);
       }
-      return destructive_refinement_checker(l1, l2, trace, true);
+      return destructive_refinement_checker(l1, l2, trace, true, strategy);
     }
     case lts_pre_failures_refinement:
     {
       if (generate_counter_example)
       {
         detail::counter_example_constructor cec("counter_example_failures_refinement.trc");
-        return destructive_refinement_checker(l1, l2, failures, false, cec);
+        return destructive_refinement_checker(l1, l2, failures, false, strategy, cec);
       }
-      return destructive_refinement_checker(l1, l2, failures, false);
+      return destructive_refinement_checker(l1, l2, failures, false, strategy);
     }
     case lts_pre_weak_failures_refinement:
     {
       if (generate_counter_example)
       {
         detail::counter_example_constructor cec("counter_example_weak_failures_refinement.trc");
-        return destructive_refinement_checker(l1, l2, failures, true, cec);
+        return destructive_refinement_checker(l1, l2, failures, true, strategy, cec);
       }
-      return destructive_refinement_checker(l1, l2, failures, true);
+      return destructive_refinement_checker(l1, l2, failures, true, strategy);
     }
     case lts_pre_failures_divergence_refinement:
     {
       if (generate_counter_example)
       {
         detail::counter_example_constructor cec("counter_example_failures_divergence_refinement.trc");
-        return destructive_refinement_checker(l1, l2, failures_divergence, true,cec);
+        return destructive_refinement_checker(l1, l2, failures_divergence, true, strategy, cec);
       }
-      return destructive_refinement_checker(l1, l2, failures_divergence, true);
+      return destructive_refinement_checker(l1, l2, failures_divergence, true, strategy);
     }
     default:
       mCRL2log(log::error) << "Comparison for this preorder is not available\n";

--- a/libraries/lts/include/mcrl2/lts/lts_algorithm.h
+++ b/libraries/lts/include/mcrl2/lts/lts_algorithm.h
@@ -279,6 +279,8 @@ bool destructive_compare(LTS_TYPE& l1,
  * \param[in] pre The preorder with respect to which the LTSs will be compared.
  * \param[in] generate_counter_example Indicates whether a file containing a counter example is 
  *            generated when the comparison fails. 
+ * \param[in] strategy Choose breadth-first or depth-first for exploration strategy
+ *            of the antichain algorithms.
  * \retval true if this LTS is smaller than LTS \a l according to
  * preorder \a pre.
  * \retval false otherwise.
@@ -287,7 +289,8 @@ template <class  LTS_TYPE >
 bool compare(const LTS_TYPE&  l1,
              const  LTS_TYPE& l2,
              const lts_preorder pre,
-             const bool generate_counter_example);
+             const bool generate_counter_example,
+             const exploration_strategy strategy = es_breadth);
 
 /** \brief Determinises this LTS. */
 template <class LTS_TYPE>
@@ -760,7 +763,7 @@ bool compare(const LTS_TYPE& l1, const LTS_TYPE& l2, const lts_equivalence eq, c
 }
 
 template <class LTS_TYPE>
-bool compare(const LTS_TYPE& l1, const LTS_TYPE& l2, const lts_preorder pre, const bool generate_counter_example, const exploration_strategy strategy = es_breadth)
+bool compare(const LTS_TYPE& l1, const LTS_TYPE& l2, const lts_preorder pre, const bool generate_counter_example, const exploration_strategy strategy)
 {
   LTS_TYPE l1_copy(l1);
   LTS_TYPE l2_copy(l2);

--- a/tools/release/ltscompare/ltscompare.cpp
+++ b/tools/release/ltscompare/ltscompare.cpp
@@ -259,7 +259,7 @@ class ltscompare_tool : public ltscompare_base
       add_option("strategy", make_enum_argument<exploration_strategy>("NAME")
                  .add_value_short(es_breadth, "b", true)
                  .add_value_short(es_depth, "d")
-                 , "explore the state space using strategy NAME:"
+                 , "explore the state space using strategy NAME (only for antichain based algorithms; includes all failures refinements) :"
                  , 's').
       add_option("tau", make_mandatory_argument("ACTNAMES"),
                  "consider actions with a name in the comma separated list ACTNAMES to "
@@ -330,6 +330,15 @@ class ltscompare_tool : public ltscompare_base
         if (tool_options.strategy != es_breadth && tool_options.generate_counter_examples)
         {
           mCRL2log(mcrl2::log::warning) << "Generated counter example might not be the shortest with the " << print_exploration_strategy(tool_options.strategy) << " strategy.\n";
+        }
+
+        if (tool_options.preorder != lts_pre_trace_anti_chain
+            || tool_options.preorder != lts_pre_weak_trace_anti_chain
+            || tool_options.preorder != lts_pre_failures_refinement
+            || tool_options.preorder != lts_pre_weak_failures_refinement
+            || tool_options.preorder != lts_pre_failures_divergence_refinement)
+        {
+          throw parser.error("strategy can only be chosen for antichain based algorithms.");
         }
       }
 

--- a/tools/release/ltscompare/ltscompare.cpp
+++ b/tools/release/ltscompare/ltscompare.cpp
@@ -46,7 +46,7 @@ struct t_tool_options
     format_for_second(lts_none),
     equivalence(lts_eq_none),
     preorder(lts_pre_none),
-    strategy(es_none),
+    strategy(es_breadth),
     generate_counter_examples(false)
   {}
 
@@ -130,8 +130,9 @@ class ltscompare_tool : public ltscompare_base
 
       if (tool_options.preorder != lts_pre_none)
       {
-        mCRL2log(verbose) << "comparing LTSs using " <<
-                     description(tool_options.preorder) << "..." << std::endl;
+        mCRL2log(verbose) << "comparing LTSs for " <<
+                     description(tool_options.preorder) << "..."
+                     " using the " << print_exploration_strategy(tool_options.strategy) << " strategy.\n";
 
         result = destructive_compare(l1, l2, tool_options.preorder, tool_options.generate_counter_examples, tool_options.strategy);
 
@@ -149,7 +150,6 @@ class ltscompare_tool : public ltscompare_base
   public:
     bool run()
     {
-
       check_preconditions();
 
       if (tool_options.format_for_first==lts_none)
@@ -188,6 +188,7 @@ class ltscompare_tool : public ltscompare_base
           throw mcrl2::runtime_error("Reading the .dot format is not supported anymore.");
         }
       }
+
       return true;
     }
 
@@ -326,7 +327,10 @@ class ltscompare_tool : public ltscompare_base
       {
         tool_options.strategy = mcrl2::lts::parse_exploration_strategy(parser.option_argument("strategy"));
 
-        // Warn the user about strategy having no effect.
+        if (tool_options.strategy != es_breadth && tool_options.generate_counter_examples)
+        {
+          mCRL2log(mcrl2::log::warning) << "Generated counter example might not be the shortest with the " << print_exploration_strategy(tool_options.strategy) << " strategy.\n";
+        }
       }
 
       if (parser.options.count("in1"))


### PR DESCRIPTION
There are no tests for the refinement algorithm so it might be good idea if these changes are reviewed.

Summary of changes:
1. Apply (divergence-preserving) branching bisimulation to the specification when a counter example is requested. In principle it would also be possible to extract a counter example after preprocessing the merged lts, but that is more involved and the current solution does not affect the existing counter example generation.
1. Added the option (--strategy) to change the exploration strategy used by the refinement checking algorithm (either breadth or depth, could be optimized by using templates to prevent potential branch misses).
1. Changed the refusals_contained_in algorithm to follow the correct definition of refusals.
1. Gather some performance metrics about the working stack and antichain (the performance hit was minimal, but this could potentially be guarded by a constant in the code)
1. Removed an unnecessary copy when calling compare instead of destructive_compare, because the initial LTSs are no longer used anyway (this might also be applied to the bisimulation cases).
1. Added a check when both LTSs are branching bisimilar to directly conclude that a refinement relation exists.