### PR TITLE
Check which variables cannot be enumerated in enumerate_quantifiers_rewriter

### DIFF
--- a/libraries/data/include/mcrl2/data/detail/split_finite_variables.h
+++ b/libraries/data/include/mcrl2/data/detail/split_finite_variables.h
@@ -46,6 +46,27 @@ void split_finite_variables(data::variable_list variables, const data::data_spec
   infinite_variables = data::variable_list(infinite.begin(), infinite.end());
 }
 
+template <typename Rewriter>
+inline
+void split_enumerable_variables(data::variable_list variables, const data::data_specification& data, const Rewriter& rewr, data::variable_list& enumerable_variables, data::variable_list& non_enumerable_variables)
+{
+  std::vector<data::variable> enumerable;
+  std::vector<data::variable> non_enumerable;
+  for (const data::variable& v: variables)
+  {
+    if (is_enumerable(data, rewr, v.sort()))
+    {
+      enumerable.push_back(v);
+    }
+    else
+    {
+      non_enumerable.push_back(v);
+    }
+  }
+  enumerable_variables = data::variable_list(enumerable.begin(), enumerable.end());
+  non_enumerable_variables = data::variable_list(non_enumerable.begin(), non_enumerable.end());
+}
+
 } // namespace detail
 
 } // namespace data

--- a/libraries/pbes/include/mcrl2/pbes/rewriters/enumerate_quantifiers_rewriter.h
+++ b/libraries/pbes/include/mcrl2/pbes/rewriters/enumerate_quantifiers_rewriter.h
@@ -144,7 +144,10 @@ struct enumerate_quantifiers_builder: public simplify_data_rewriter_builder<Deri
     pbes_expression result;
     if (m_enumerate_infinite_sorts)
     {
-      result = enumerate_forall(x.variables(), x.body());
+      data::variable_list enumerable;
+      data::variable_list non_enumerable;
+      data::detail::split_enumerable_variables(x.variables(), m_dataspec, super::super::R, enumerable, non_enumerable);
+      result = data::optimized_forall_no_empty_domain(non_enumerable, enumerate_forall(enumerable, x.body()));
     }
     else
     {
@@ -169,7 +172,10 @@ struct enumerate_quantifiers_builder: public simplify_data_rewriter_builder<Deri
     pbes_expression result;
     if (m_enumerate_infinite_sorts)
     {
-      result = enumerate_exists(x.variables(), x.body());
+      data::variable_list enumerable;
+      data::variable_list non_enumerable;
+      data::detail::split_enumerable_variables(x.variables(), m_dataspec, super::super::R, enumerable, non_enumerable);
+      result = data::optimized_exists_no_empty_domain(non_enumerable, enumerate_exists(enumerable, x.body()));
     }
     else
     {


### PR DESCRIPTION
When running the `enumerate_quantifiers_rewriter` with `enumerate_infinite_sorts = true`, it would try to enumerate all variables. However, variables of some sorts cannot be enumerated. This would result in an exception when rewriter an expression such as `(exists x:Real. x < 5) || (exists n:Nat. n != 2)`. However, rewriting this to `(exists x:Real. x < 5) || true` would still be a very useful result.

With this change the `enumerate_quantifiers_rewriter` only tries to enumerate variables that the enumerator can actually deal with.