### PR TITLE
Fix crash in generatelts

### DIFF
--- a/libraries/lps/include/mcrl2/lps/explorer.h
+++ b/libraries/lps/include/mcrl2/lps/explorer.h
@@ -105,6 +105,8 @@ class todo_set
       : todo{init}
     {}
 
+    virtual ~todo_set() {}
+  
     virtual lps::state choose_element() = 0;
 
     virtual void insert(const lps::state& s) = 0;


### PR DESCRIPTION
The compiler pointed out this issue of a missing destructor. This fix resolves a crash in generatelts.

Full compiler warning:
```
In file included from /Users/jkeiren/Repositories/mCRL2/tools/developer/generatelts/generatelts.cpp:12:
In file included from /Library/Developer/CommandLineTools/usr/include/c++/v1/iostream:38:
In file included from /Library/Developer/CommandLineTools/usr/include/c++/v1/ios:216:
In file included from /Library/Developer/CommandLineTools/usr/include/c++/v1/__locale:15:
In file included from /Library/Developer/CommandLineTools/usr/include/c++/v1/string:500:
In file included from /Library/Developer/CommandLineTools/usr/include/c++/v1/string_view:176:
In file included from /Library/Developer/CommandLineTools/usr/include/c++/v1/__string:56:
In file included from /Library/Developer/CommandLineTools/usr/include/c++/v1/algorithm:644:
/Library/Developer/CommandLineTools/usr/include/c++/v1/memory:2335:5: warning: delete called on 'mcrl2::lps::todo_set' that is abstract but has non-virtual destructor [-Wdelete-non-virtual-dtor]
delete __ptr;
^
/Library/Developer/CommandLineTools/usr/include/c++/v1/memory:2648:7: note: in instantiation of member function 'std::__1::default_delete<mcrl2::lps::todo_set>::operator()' requested here
__ptr_.second()(__tmp);
^
/Library/Developer/CommandLineTools/usr/include/c++/v1/memory:2602:19: note: in instantiation of member function 'std::__1::unique_ptr<mcrl2::lps::todo_set, std::__1::default_delete<mcrl2::lps::todo_set> >::reset' requested here
~unique_ptr() { reset(); }
^
/Users/jkeiren/Repositories/mCRL2/libraries/lps/include/mcrl2/lps/explorer.h:602:38: note: in instantiation of member function 'std::__1::unique_ptr<mcrl2::lps::todo_set, std::__1::default_delete<mcrl2::lps::todo_set> >::~unique_ptr' requested here
case lps::es_breadth: return std::unique_ptr<todo_set>(new breadth_first_todo_set(init));
^
```

The example used was provided by @wiegerw based on a failure in codecity.