### PR TITLE
mCRL2-GUI gui-tools detached

### DIFF
--- a/libraries/gui/source/arcball.cpp
+++ b/libraries/gui/source/arcball.cpp
@@ -17,6 +17,10 @@
   #include <GLKit/GLKMatrix4.h>
 #endif
 
+#ifndef M_PI
+  #define M_PI 3.14159265358979323846264338327950288
+#endif
+
 namespace mcrl2
 {
 namespace gui

--- a/tools/release/mcrl2-gui/CMakeLists.txt
+++ b/tools/release/mcrl2-gui/CMakeLists.txt
@@ -21,6 +21,7 @@ add_mcrl2_tool(mcrl2-gui
     copydialog.cpp
     copythread.cpp
     optionvalue.cpp
+    multiprocess.cpp
   DEPENDS
     mcrl2_utilities
     mcrl2_gui

--- a/tools/release/mcrl2-gui/multiprocess.cpp
+++ b/tools/release/mcrl2-gui/multiprocess.cpp
@@ -1,0 +1,60 @@
+// Author(s): Ferry Timmers
+// Copyright: see the accompanying file COPYING or copy at
+// https://github.com/mCRL2org/mCRL2/blob/master/COPYING
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include <QRegularExpression>
+
+#include "multiprocess.h"
+
+using Process = QMultiProcess::Process;
+using Processes = QMultiProcess::Processes;
+using size_type = Processes::size_type;
+using ReadMethod = QByteArray(Process::*)();
+
+QMultiProcess::Process* QMultiProcess::start(QIODevice::OpenMode mode)
+{
+  QPersistentProcess *process = new QPersistentProcess();
+  connect(process, SIGNAL(readyReadStandardError()), this, SIGNAL(readyReadStandardError()));
+  connect(process, SIGNAL(readyReadStandardOutput()), this, SIGNAL(readyReadStandardOutput()));
+  process->setWorkingDirectory(workingDirectory());
+  process->setProgram(program());
+  process->setArguments(arguments());
+  process->start(mode);
+  m_processes.emplace_back(process);
+  return process;
+}
+
+static inline QByteArray readAll(ReadMethod method, Processes &processes,
+  size_type &last)
+{
+  QByteArray output;
+  size_type current = 0;
+  for (size_type i = 0; i < processes.size(); ++i)
+  {
+    size_type index = (i + last) % processes.size();
+    QString str = ((*processes[index]).*method)();
+    if (str.isEmpty())
+      continue;
+
+    const QString label = QString("%1#  ").arg(index + 1);
+    output += label + str;
+    current = index;
+  }
+  last = current;
+  return output;
+}
+
+QByteArray QMultiProcess::readAllStandardError()
+{
+  return ::readAll(&Process::readAllStandardError, m_processes, m_last);
+}
+
+QByteArray QMultiProcess::readAllStandardOutput()
+{
+  return ::readAll(&Process::readAllStandardOutput, m_processes, m_last);
+}

--- a/tools/release/mcrl2-gui/multiprocess.h
+++ b/tools/release/mcrl2-gui/multiprocess.h
@@ -1,0 +1,49 @@
+// Author(s): Ferry Timmers
+// Copyright: see the accompanying file COPYING or copy at
+// https://github.com/mCRL2org/mCRL2/blob/master/COPYING
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#ifndef MULTIPROCESS_H
+#define MULTIPROCESS_H
+
+#include <memory>
+#include <vector>
+#include <QProcess>
+
+/// Process that does not terminate when destructed
+class QPersistentProcess : public QProcess
+{
+  public:
+    using QProcess::QProcess;
+
+    ~QPersistentProcess() { setProcessState(QProcess::NotRunning); }
+};
+
+/// Prototype process that spawns new process instances when started
+class QMultiProcess : public QProcess
+{
+  public:
+    using Process = QPersistentProcess;
+    using ProcessPtr = std::unique_ptr<Process>;
+    using Processes = std::vector<ProcessPtr>;
+
+    QMultiProcess() {}
+    ~QMultiProcess() {}
+
+    Process* start(QIODevice::OpenMode mode = ReadWrite);
+
+    QByteArray readAllStandardError();
+    QByteArray readAllStandardOutput();
+
+  private:
+
+    Processes m_processes;
+    Processes::size_type m_last = 0;
+
+};
+
+#endif /* MULTIPROCESS_H */

--- a/tools/release/mcrl2-gui/toolinstance.h
+++ b/tools/release/mcrl2-gui/toolinstance.h
@@ -29,7 +29,7 @@ class ToolInstance : public QWidget
 
     ToolInformation information() { return m_info; }
     QString executable();
-    QString arguments();
+    QStringList arguments();
 
   public slots:
     void onStateChange(QProcess::ProcessState state);

--- a/tools/release/mcrl2-gui/toolinstance.h
+++ b/tools/release/mcrl2-gui/toolinstance.h
@@ -18,6 +18,7 @@
 
 #include "toolinformation.h"
 #include "optionvalue.h"
+#include "multiprocess.h"
 
 class ToolInstance : public QWidget
 {
@@ -33,8 +34,8 @@ class ToolInstance : public QWidget
 
   public slots:
     void onStateChange(QProcess::ProcessState state);
-    void onStandardOutput();
-    void onStandardError();
+    void onOutputLog(const QByteArray &outText);
+    void onErrorLog(const QByteArray &outText);
     void onRun();
     void onAbort();
     void onSave();
@@ -47,7 +48,8 @@ class ToolInstance : public QWidget
     Ui::ToolInstance m_ui;
 
     QList<OptionValue*> m_optionValues;
-    QProcess m_process;
+    QProcess* m_process;
+    QMultiProcess* m_mprocess;
 
     FilePicker* m_pckFileOut;
     FilePicker* m_pckFileIn;


### PR DESCRIPTION
Change to mCRL2-GUI such that gui-based tools start detached from the main process.
This prevents gui-based tools from being killed when the tab they were spawned from is closed.