### PR TITLE
Add support for file piping in lts library

### DIFF
--- a/libraries/lps/include/mcrl2/lps/io.h
+++ b/libraries/lps/include/mcrl2/lps/io.h
@@ -63,7 +63,7 @@ void load_lps(Specification& spec, std::istream& stream, const std::string& sour
 template <typename Specification>
 void save_lps(const Specification& spec, const std::string& filename)
 {
-  if (filename.empty())
+  if (filename.empty() || filename == "-")
   {
     save_lps(spec, std::cout, "standard output");
     return;
@@ -84,7 +84,7 @@ void save_lps(const Specification& spec, const std::string& filename)
 template <typename Specification>
 void load_lps(Specification& spec, const std::string& filename)
 {
-  if (filename.empty())
+  if (filename.empty() || filename == "-")
   {
     load_lps(spec, std::cin, "standard input");
     return;

--- a/libraries/lts/include/mcrl2/lts/detail/counter_example.h
+++ b/libraries/lts/include/mcrl2/lts/detail/counter_example.h
@@ -69,11 +69,13 @@ class counter_example_constructor
 
     static const index_type m_root_index=-1;
     std::deque< action_index_pair > m_backward_tree;
-    const std::string m_filename;
+    const std::string m_name;
+    const bool m_structured_output;
   
   public:
-    counter_example_constructor(const std::string& filename)
-     : m_filename(filename)
+    counter_example_constructor(const std::string& name, bool structured_output)
+     : m_name(name)
+     , m_structured_output(structured_output)
     {}
 
     /// \brief Return the index of the root.
@@ -126,14 +128,27 @@ class counter_example_constructor
                                        mcrl2::data::sort_expression_list()),
                                 mcrl2::data::data_expression_list())));
       }
-      mCRL2log(log::verbose) << "Saved trace to file " + m_filename + "\n";
-      result.save(m_filename);
+      if (m_structured_output)
+        {
+          std::cout << m_name << ":";
+          result.save(std::cout, mcrl2::trace::tfLine);
+        }
+      else
+      {
+        std::string filename = m_name + ".trc";
+        mCRL2log(log::verbose) << "Saved trace to file " + filename + "\n";
+        result.save(filename);
+      }
     }
 
     /// \brief This function indicates that this is not a dummy counterexample class and that a serious counterexample is required.
     bool is_dummy() const
     {
       return false;
+    }
+    bool is_structured() const
+    {
+      return m_structured_output;
     }
 };
 
@@ -166,6 +181,10 @@ class dummy_counter_example_constructor
     bool is_dummy() const
     {
       return true;
+    }
+    bool is_structured() const
+    {
+      return false;
     }
 };
 

--- a/libraries/lts/include/mcrl2/lts/detail/counter_example.h
+++ b/libraries/lts/include/mcrl2/lts/detail/counter_example.h
@@ -129,10 +129,10 @@ class counter_example_constructor
                                 mcrl2::data::data_expression_list())));
       }
       if (m_structured_output)
-        {
-          std::cout << m_name << ":";
-          result.save(std::cout, mcrl2::trace::tfLine);
-        }
+      {
+        std::cout << m_name << ":";
+        result.save(std::cout, mcrl2::trace::tfLine);
+      }
       else
       {
         std::string filename = m_name + ".trc";
@@ -146,6 +146,9 @@ class counter_example_constructor
     {
       return false;
     }
+
+    /// \brief Returns whether this counter-example is printed in a machine-readable way to stdout
+    /// If false is returned, the counter-example is written to a file.
     bool is_structured() const
     {
       return m_structured_output;
@@ -182,6 +185,9 @@ class dummy_counter_example_constructor
     {
       return true;
     }
+
+    /// \brief Returns whether this counter-example is printed in a machine-readable way to stdout
+    /// If false is returned, the counter-example is written to a file.
     bool is_structured() const
     {
       return false;

--- a/libraries/lts/include/mcrl2/lts/detail/counter_example.h
+++ b/libraries/lts/include/mcrl2/lts/detail/counter_example.h
@@ -130,7 +130,7 @@ class counter_example_constructor
       }
       if (m_structured_output)
       {
-        std::cout << m_name << ":";
+        std::cout << m_name << ": ";
         result.save(std::cout, mcrl2::trace::tfLine);
       }
       else

--- a/libraries/lts/include/mcrl2/lts/detail/liblts_bisim.h
+++ b/libraries/lts/include/mcrl2/lts/detail/liblts_bisim.h
@@ -1208,12 +1208,13 @@ bool bisimulation_compare(
   const LTS_TYPE& l2,
   const bool branching /* =false*/,
   const bool preserve_divergences /*=false*/,
-  const bool generate_counter_examples /*= false*/)
+  const bool generate_counter_examples /*= false*/,
+  const bool structured_output /* = false */)
 {
   LTS_TYPE l1_copy(l1);
   LTS_TYPE l2_copy(l2);
   return destructive_bisimulation_compare(l1_copy,l2_copy,branching,preserve_divergences,
-                                          generate_counter_examples);
+                                          generate_counter_examples, structured_output);
 }
 
 template < class LTS_TYPE>
@@ -1222,7 +1223,8 @@ bool destructive_bisimulation_compare(
   LTS_TYPE& l2,
   const bool branching /* =false*/,
   const bool preserve_divergences /*=false*/,
-  const bool generate_counter_examples /* = false */)
+  const bool generate_counter_examples /* = false */,
+  const bool structured_output /* = false */)
 {
   std::size_t init_l2 = l2.initial_state() + l1.num_states();
   mcrl2::lts::detail::merge(l1,l2);

--- a/libraries/lts/include/mcrl2/lts/detail/liblts_bisim_dnj.h
+++ b/libraries/lts/include/mcrl2/lts/detail/liblts_bisim_dnj.h
@@ -5512,7 +5512,7 @@ void bisimulation_reduce_dnj(LTS_TYPE& l, bool const branching = false,
 template <class LTS_TYPE>
 bool destructive_bisimulation_compare_dnj(LTS_TYPE& l1, LTS_TYPE& l2,
         bool const branching = false, bool const preserve_divergence = false,
-                                  bool const generate_counter_examples = false)
+        bool const generate_counter_examples = false, bool structured_output = false)
 {
     if (generate_counter_examples)
     {

--- a/libraries/lts/include/mcrl2/lts/detail/liblts_bisim_gjkw.h
+++ b/libraries/lts/include/mcrl2/lts/detail/liblts_bisim_gjkw.h
@@ -1915,7 +1915,8 @@ inline bool bisimulation_compare_gjkw(const LTS_TYPE& l1, const LTS_TYPE& l2,
 template <class LTS_TYPE>
 bool destructive_bisimulation_compare_gjkw(LTS_TYPE& l1, LTS_TYPE& l2,
           bool branching /* = false */, bool preserve_divergence /* = false */,
-                                  bool generate_counter_examples /* = false */)
+                                           bool generate_counter_examples /* = false */,
+                                           bool structured_output /* = false */)
 {
   if (generate_counter_examples)
   {

--- a/libraries/lts/include/mcrl2/lts/detail/liblts_failures_refinement.h
+++ b/libraries/lts/include/mcrl2/lts/detail/liblts_failures_refinement.h
@@ -658,38 +658,54 @@ namespace detail
         if (impl_action_labels.empty())
         {
           if (structured_output)
+          {
             std::cout << "left-acceptance:\n";
+          }
           else
+          {
             mCRL2log(log::verbose) << "The acceptance of the left process is empty.\n";
+          }
         }
         else
         {
           if (structured_output)
+          {
             std::cout << "left-acceptance:";
+          }
           else
+          {
             mCRL2log(log::verbose) << "A stable acceptance set of the left process is:\n";
+          }
           std::string sep = "";
           for(const label_type a : impl_action_labels)
+          {
+            if (structured_output)
             {
-              if (structured_output)
-              {
-                std::cout << sep << l.action_label(a);
-                sep = " ";
-              }
-              else
-                mCRL2log(log::verbose) << l.action_label(a) << "\n";
+              std::cout << sep << l.action_label(a);
+              sep = " ";
             }
+            else
+            {
+              mCRL2log(log::verbose) << l.action_label(a) << "\n";
+            }
+          }
           if (structured_output)
+          {
             std::cout << "\n";
+          }
         }
 
         // Print the acceptance sets of the specification.
         if (spec.empty())
         {
           if (structured_output)
+          {
             std::cout << "right-acceptance-sets:0\n";
+          }
           else
+          {
             mCRL2log(log::verbose) << "The process at the right has no acceptance sets.\n";
+          }
         }
         else
         {
@@ -698,16 +714,24 @@ namespace detail
           std::copy_if(spec.begin(), spec.end(), std::inserter(stable,stable.end()), [=](const state_type s){return weak_property_cache.stable(s);});
 
           if (structured_output)
+          {
             std::cout << "right-acceptance-sets:" << stable.size () << "\n";
+          }
           else
+          {
             mCRL2log(log::verbose) << "Below all corresponding stable acceptance sets of the right process are provided:\n";
+          }
           for(const state_type s : stable)
           {
             const action_label_set& spec_action_labels = weak_property_cache.action_labels(s);
             if (structured_output)
+            {
               std::cout << "right-acceptance:";
+            }
             else
+            {
               mCRL2log(log::verbose) << "An acceptance set of the right process is:\n";
+            }
             std::string sep = "";
             for(const label_type a : spec_action_labels)
             {
@@ -717,14 +741,20 @@ namespace detail
                 sep = " ";
               }
               else
+              {
                 mCRL2log(log::verbose) << l.action_label(a) << "\n";
+              }
             }
             if (structured_output)
+            {
               std::cout << "\n";
+            }
           }
         }
         if (!structured_output)
+        {
           mCRL2log(log::verbose) << "Finished printing acceptance sets.\n";
+        }
         // Ready printing acceptance sets.
       }
       return false;

--- a/libraries/lts/include/mcrl2/lts/detail/liblts_failures_refinement.h
+++ b/libraries/lts/include/mcrl2/lts/detail/liblts_failures_refinement.h
@@ -650,39 +650,93 @@ namespace detail
       }
     }
 
-    if (!success)
+    if (!success && provide_a_counter_example)
     {
-      if (provide_a_counter_example)
+      // Print the acceptance set of the implementation
+      if (impl_action_labels.empty())
       {
-        // Print the acceptance set of the implementation
-        if (impl_action_labels.empty())
+        if (structured_output)
         {
-          if (structured_output)
-          {
-            std::cout << "left-acceptance:\n";
-          }
-          else
-          {
-            mCRL2log(log::verbose) << "The acceptance of the left process is empty.\n";
-          }
+          std::cout << "left-acceptance:\n";
         }
         else
         {
+          mCRL2log(log::verbose) << "The acceptance of the left process is empty.\n";
+        }
+      }
+      else
+      {
+        if (structured_output)
+        {
+          std::cout << "left-acceptance: ";
+        }
+        else
+        {
+          mCRL2log(log::verbose) << "A stable acceptance set of the left process is:\n";
+        }
+        std::string sep = "";
+        for (const label_type a: impl_action_labels)
+        {
           if (structured_output)
           {
-            std::cout << "left-acceptance:";
+            std::cout << sep << l.action_label(a);
+            sep = ";";
           }
           else
           {
-            mCRL2log(log::verbose) << "A stable acceptance set of the left process is:\n";
+            mCRL2log(log::verbose) << l.action_label(a) << "\n";
+          }
+        }
+        if (structured_output)
+        {
+          std::cout << "\n";
+        }
+      }
+
+      // Print the acceptance sets of the specification.
+      if (spec.empty())
+      {
+        if (structured_output)
+        {
+          std::cout << "right-acceptance-sets: 0\n";
+        }
+        else
+        {
+          mCRL2log(log::verbose) << "The process at the right has no acceptance sets.\n";
+        }
+      }
+      else
+      {
+        set_of_states stable;
+        // Only the stable specification states contributed to this counter example.
+        std::copy_if(spec.begin(), spec.end(), std::inserter(stable,stable.end()), [=](const state_type s){return weak_property_cache.stable(s);});
+
+        if (structured_output)
+        {
+          std::cout << "right-acceptance-sets: " << stable.size () << "\n";
+        }
+        else
+        {
+          mCRL2log(log::verbose) << "Below all corresponding stable acceptance sets of the right process are provided:\n";
+        }
+        for (const state_type s: stable)
+        {
+          const action_label_set& spec_action_labels = weak_property_cache.action_labels(s);
+          if (structured_output)
+          {
+            std::cout << "right-acceptance: ";
+          }
+          else
+          {
+            mCRL2log(log::verbose) << "An acceptance set of the right process is:\n";
           }
           std::string sep = "";
-          for(const label_type a : impl_action_labels)
+          for (const label_type a: spec_action_labels)
           {
             if (structured_output)
             {
               std::cout << sep << l.action_label(a);
-              sep = " ";
+              sep = ";";
             }
             else
             {
@@ -694,73 +748,15 @@ namespace detail
             std::cout << "\n";
           }
         }
-
-        // Print the acceptance sets of the specification.
-        if (spec.empty())
-        {
-          if (structured_output)
-          {
-            std::cout << "right-acceptance-sets:0\n";
-          }
-          else
-          {
-            mCRL2log(log::verbose) << "The process at the right has no acceptance sets.\n";
-          }
-        }
-        else
-        {
-          set_of_states stable;
-          // Only the stable specification states contributed to this counter example.
-          std::copy_if(spec.begin(), spec.end(), std::inserter(stable,stable.end()), [=](const state_type s){return weak_property_cache.stable(s);});
-
-          if (structured_output)
-          {
-            std::cout << "right-acceptance-sets:" << stable.size () << "\n";
-          }
-          else
-          {
-            mCRL2log(log::verbose) << "Below all corresponding stable acceptance sets of the right process are provided:\n";
-          }
-          for(const state_type s : stable)
-          {
-            const action_label_set& spec_action_labels = weak_property_cache.action_labels(s);
-            if (structured_output)
-            {
-              std::cout << "right-acceptance:";
-            }
-            else
-            {
-              mCRL2log(log::verbose) << "An acceptance set of the right process is:\n";
-            }
-            std::string sep = "";
-            for(const label_type a : spec_action_labels)
-            {
-              if (structured_output)
-              {
-                std::cout << sep << l.action_label(a);
-                sep = " ";
-              }
-              else
-              {
-                mCRL2log(log::verbose) << l.action_label(a) << "\n";
-              }
-            }
-            if (structured_output)
-            {
-              std::cout << "\n";
-            }
-          }
-        }
-        if (!structured_output)
-        {
-          mCRL2log(log::verbose) << "Finished printing acceptance sets.\n";
-        }
-        // Ready printing acceptance sets.
       }
-      return false;
+      if (!structured_output)
+      {
+        mCRL2log(log::verbose) << "Finished printing acceptance sets.\n";
+      }
+      // Done printing acceptance sets.
     }
 
-    return true;
+    return success;
   }
 
 

--- a/libraries/lts/include/mcrl2/lts/lts_algorithm.h
+++ b/libraries/lts/include/mcrl2/lts/lts_algorithm.h
@@ -60,7 +60,8 @@ template <class LTS_TYPE>
 bool destructive_compare(LTS_TYPE& l1,
                          LTS_TYPE& l2,
                          const lts_equivalence eq,
-                         const bool generate_counter_examples = false)
+                         const bool generate_counter_examples = false,
+                         const bool structured_output = false)
 {
   // Merge this LTS and l and store the result in this LTS.
   // In the resulting LTS, the initial state i of l will have the
@@ -76,51 +77,51 @@ bool destructive_compare(LTS_TYPE& l1,
       if (generate_counter_examples)
       {
         mCRL2log(mcrl2::log::warning) << "The default bisimulation comparison algorithm cannot generate counter examples. Therefore the slower gv algorithm is used instead.\n";
-        return detail::destructive_bisimulation_compare(l1,l2, false,false,generate_counter_examples);
+        return detail::destructive_bisimulation_compare(l1,l2, false,false,generate_counter_examples,structured_output);
       }
-      return detail::destructive_bisimulation_compare_dnj(l1,l2, false,false,generate_counter_examples);
+      return detail::destructive_bisimulation_compare_dnj(l1,l2, false,false,generate_counter_examples,structured_output);
     }
     case lts_eq_bisim_gv:
     {
-      return detail::destructive_bisimulation_compare(l1,l2, false,false,generate_counter_examples);
+      return detail::destructive_bisimulation_compare(l1,l2, false,false,generate_counter_examples,structured_output);
     }
     case lts_eq_bisim_gjkw:
     {
-      return detail::destructive_bisimulation_compare_gjkw(l1,l2, false,false,generate_counter_examples);
+      return detail::destructive_bisimulation_compare_gjkw(l1,l2, false,false,generate_counter_examples,structured_output);
     }
     case lts_eq_branching_bisim:
     {
       if (generate_counter_examples)
       {
         mCRL2log(mcrl2::log::warning) << "The default branching bisimulation comparison algorithm cannot generate counter examples. Therefore the slower gv algorithm is used instead.\n";
-        return detail::destructive_bisimulation_compare(l1,l2, true,false,generate_counter_examples);
+        return detail::destructive_bisimulation_compare(l1,l2, true,false,generate_counter_examples,structured_output);
       }
-      return detail::destructive_bisimulation_compare_dnj(l1,l2, true,false,generate_counter_examples);
+      return detail::destructive_bisimulation_compare_dnj(l1,l2, true,false,generate_counter_examples,structured_output);
     }
     case lts_eq_branching_bisim_gv:
     {
-      return detail::destructive_bisimulation_compare(l1,l2, true,false,generate_counter_examples);
+      return detail::destructive_bisimulation_compare(l1,l2, true,false,generate_counter_examples,structured_output);
     }
     case lts_eq_branching_bisim_gjkw:
     {
-      return detail::destructive_bisimulation_compare_gjkw(l1,l2, true,false,generate_counter_examples);
+      return detail::destructive_bisimulation_compare_gjkw(l1,l2, true,false,generate_counter_examples,structured_output);
     }
     case lts_eq_divergence_preserving_branching_bisim:
     {
       if (generate_counter_examples)
       {
         mCRL2log(mcrl2::log::warning) << "The default divergence-preserving branching bisimulation comparison algorithm cannot generate counter examples. Therefore the slower gv algorithm is used instead.\n";
-        return detail::destructive_bisimulation_compare(l1,l2, true,true,generate_counter_examples);
+        return detail::destructive_bisimulation_compare(l1,l2, true,true,generate_counter_examples,structured_output);
       }
-      return detail::destructive_bisimulation_compare_dnj(l1,l2, true,true,generate_counter_examples);
+      return detail::destructive_bisimulation_compare_dnj(l1,l2, true,true,generate_counter_examples,structured_output);
     }
     case lts_eq_divergence_preserving_branching_bisim_gv:
     {
-      return detail::destructive_bisimulation_compare(l1,l2, true,true,generate_counter_examples);
+      return detail::destructive_bisimulation_compare(l1,l2, true,true,generate_counter_examples,structured_output);
     }
     case lts_eq_divergence_preserving_branching_bisim_gjkw:
     {
-      return detail::destructive_bisimulation_compare_gjkw(l1,l2, true,true,generate_counter_examples);
+      return detail::destructive_bisimulation_compare_gjkw(l1,l2, true,true,generate_counter_examples,structured_output);
     }
     case lts_eq_weak_bisim:
     {
@@ -179,7 +180,7 @@ bool destructive_compare(LTS_TYPE& l1,
       determinise(l2);
 
       // Trace equivalence now corresponds to bisimilarity
-      return detail::destructive_bisimulation_compare(l1,l2,false,false,generate_counter_examples);
+      return detail::destructive_bisimulation_compare(l1,l2,false,false,generate_counter_examples,structured_output);
     }
     case lts_eq_weak_trace:
     {
@@ -196,7 +197,7 @@ bool destructive_compare(LTS_TYPE& l1,
       determinise(l2);
 
       // Weak trace equivalence now corresponds to bisimilarity
-      return detail::destructive_bisimulation_compare(l1,l2,false,false,generate_counter_examples);
+      return detail::destructive_bisimulation_compare(l1,l2,false,false,generate_counter_examples,structured_output);
     }
     default:
     throw mcrl2::runtime_error("Comparison for this equivalence is not available");
@@ -220,7 +221,8 @@ template <class LTS_TYPE>
 bool compare(const LTS_TYPE& l1,
              const LTS_TYPE& l2,
              const lts_equivalence eq,
-             const bool generate_counter_examples = false);
+             const bool generate_counter_examples = false,
+             const bool structured_output = false);
 
 /** \brief Checks whether this LTS is smaller than another LTS according
  * to a preorder.
@@ -248,6 +250,7 @@ bool destructive_compare(LTS_TYPE& l1,
                          LTS_TYPE& l2,
                          const lts_preorder pre,
                          const bool generate_counter_example,
+                         const bool structured_output = false,
                          const lps::exploration_strategy strategy = lps::es_breadth,
                          const bool preprocess = true);
 
@@ -270,6 +273,7 @@ bool compare(const LTS_TYPE&  l1,
              const  LTS_TYPE& l2,
              const lts_preorder pre,
              const bool generate_counter_example,
+             const bool structured_output = false,
              const lps::exploration_strategy strategy = lps::es_breadth,
              const bool preprocess = true);
 
@@ -731,7 +735,7 @@ void reduce(LTS_TYPE& l,lts_equivalence eq)
 }
 
 template <class LTS_TYPE>
-bool compare(const LTS_TYPE& l1, const LTS_TYPE& l2, const lts_equivalence eq, const bool generate_counter_examples)
+bool compare(const LTS_TYPE& l1, const LTS_TYPE& l2, const lts_equivalence eq, const bool generate_counter_examples, const bool structured_output)
 {
   switch (eq)
   {
@@ -740,21 +744,21 @@ bool compare(const LTS_TYPE& l1, const LTS_TYPE& l2, const lts_equivalence eq, c
     default:
       LTS_TYPE l1_copy(l1);
       LTS_TYPE l2_copy(l2);
-      return destructive_compare(l1_copy,l2_copy,eq,generate_counter_examples);
+      return destructive_compare(l1_copy,l2_copy,eq,generate_counter_examples,structured_output);
   }
   return false;
 }
 
 template <class LTS_TYPE>
-bool compare(const LTS_TYPE& l1, const LTS_TYPE& l2, const lts_preorder pre, const bool generate_counter_example, const lps::exploration_strategy strategy, const bool preprocess)
+bool compare(const LTS_TYPE& l1, const LTS_TYPE& l2, const lts_preorder pre, const bool generate_counter_example, const bool structured_output, const lps::exploration_strategy strategy, const bool preprocess)
 {
   LTS_TYPE l1_copy(l1);
   LTS_TYPE l2_copy(l2);
-  return destructive_compare(l1_copy, l2_copy, pre, generate_counter_example, strategy, preprocess);
+  return destructive_compare(l1_copy, l2_copy, pre, generate_counter_example, structured_output, strategy, preprocess);
 }
 
 template <class LTS_TYPE>
-bool destructive_compare(LTS_TYPE& l1, LTS_TYPE& l2, const lts_preorder pre, const bool generate_counter_example, const lps::exploration_strategy strategy, const bool preprocess)
+bool destructive_compare(LTS_TYPE& l1, LTS_TYPE& l2, const lts_preorder pre, const bool generate_counter_example, const bool structured_output, const lps::exploration_strategy strategy, const bool preprocess)
 {
   switch (pre)
   {
@@ -813,7 +817,7 @@ bool destructive_compare(LTS_TYPE& l1, LTS_TYPE& l2, const lts_preorder pre, con
       detail::bisimulation_reduce(l2,false);
 
       // Trace preorder now corresponds to simulation preorder
-      return destructive_compare(l1, l2, lts_pre_sim, generate_counter_example, strategy);
+      return destructive_compare(l1, l2, lts_pre_sim, generate_counter_example, structured_output, strategy);
     }
     case lts_pre_weak_trace:
     {
@@ -826,13 +830,13 @@ bool destructive_compare(LTS_TYPE& l1, LTS_TYPE& l2, const lts_preorder pre, con
       detail::tau_star_reduce(l2);
 
       // Weak trace preorder now corresponds to strong trace preorder
-      return destructive_compare(l1, l2, lts_pre_trace, generate_counter_example, strategy);
+      return destructive_compare(l1, l2, lts_pre_trace, generate_counter_example, structured_output, strategy);
     }
     case lts_pre_trace_anti_chain:
     {
       if (generate_counter_example)
       {
-        detail::counter_example_constructor cec("counter_example_trace_preorder.trc");
+        detail::counter_example_constructor cec("counter_example_trace_preorder", structured_output);
         return destructive_refinement_checker(l1, l2, trace, false, strategy, preprocess, cec);
       }
       return destructive_refinement_checker(l1, l2, trace, false, strategy, preprocess);
@@ -841,7 +845,7 @@ bool destructive_compare(LTS_TYPE& l1, LTS_TYPE& l2, const lts_preorder pre, con
     {
       if (generate_counter_example)
       {
-        detail::counter_example_constructor cec("counter_example_weak_trace_preorder.trc");
+        detail::counter_example_constructor cec("counter_example_weak_trace_preorder", structured_output);
         return destructive_refinement_checker(l1, l2, trace, true, strategy, preprocess, cec);
       }
       return destructive_refinement_checker(l1, l2, trace, true, strategy, preprocess);
@@ -850,7 +854,7 @@ bool destructive_compare(LTS_TYPE& l1, LTS_TYPE& l2, const lts_preorder pre, con
     {
       if (generate_counter_example)
       {
-        detail::counter_example_constructor cec("counter_example_failures_refinement.trc");
+        detail::counter_example_constructor cec("counter_example_failures_refinement", structured_output);
         return destructive_refinement_checker(l1, l2, failures, false, strategy, preprocess, cec);
       }
       return destructive_refinement_checker(l1, l2, failures, false, strategy, preprocess);
@@ -859,7 +863,7 @@ bool destructive_compare(LTS_TYPE& l1, LTS_TYPE& l2, const lts_preorder pre, con
     {
       if (generate_counter_example)
       {
-        detail::counter_example_constructor cec("counter_example_weak_failures_refinement.trc");
+        detail::counter_example_constructor cec("counter_example_weak_failures_refinement", structured_output);
         return destructive_refinement_checker(l1, l2, failures, true, strategy, preprocess, cec);
       }
       return destructive_refinement_checker(l1, l2, failures, true, strategy, preprocess);
@@ -868,7 +872,7 @@ bool destructive_compare(LTS_TYPE& l1, LTS_TYPE& l2, const lts_preorder pre, con
     {
       if (generate_counter_example)
       {
-        detail::counter_example_constructor cec("counter_example_failures_divergence_refinement.trc");
+        detail::counter_example_constructor cec("counter_example_failures_divergence_refinement", structured_output);
         return destructive_refinement_checker(l1, l2, failures_divergence, true, strategy, preprocess, cec);
       }
       return destructive_refinement_checker(l1, l2, failures_divergence, true, strategy, preprocess);

--- a/libraries/lts/source/exploration.cpp
+++ b/libraries/lts/source/exploration.cpp
@@ -1066,7 +1066,7 @@ void lps2lts_algorithm::get_transitions(const lps::state& state,
                                         next_state_generator::enumerator_queue_t& enumeration_queue
                                        )
 {
-  bool structured_output = true;
+  bool structured_output = false;
   assert(transitions.empty());
   if (m_options.detect_divergence)
   {
@@ -1074,7 +1074,7 @@ void lps2lts_algorithm::get_transitions(const lps::state& state,
     { if (m_options.trace)
       {
         // Onderstaande string generatie kan duur uitpakken.
-        std::string filename_divergence_loop = m_options.trace_prefix + "_divergence_loop" + std::to_string(m_traces_saved) + ".trc";
+        std::string filename_divergence_loop = m_options.trace_prefix + "_divergence_loop" + std::to_string(m_traces_saved);
         check_divergence<detail::counter_example_constructor>(
                 detail::state_index_pair<detail::counter_example_constructor>(state,detail::counter_example_constructor::root_index()),
                 detail::counter_example_constructor(filename_divergence_loop, structured_output));

--- a/libraries/lts/source/exploration.cpp
+++ b/libraries/lts/source/exploration.cpp
@@ -1066,6 +1066,7 @@ void lps2lts_algorithm::get_transitions(const lps::state& state,
                                         next_state_generator::enumerator_queue_t& enumeration_queue
                                        )
 {
+  bool structured_output = true;
   assert(transitions.empty());
   if (m_options.detect_divergence)
   {
@@ -1076,7 +1077,7 @@ void lps2lts_algorithm::get_transitions(const lps::state& state,
         std::string filename_divergence_loop = m_options.trace_prefix + "_divergence_loop" + std::to_string(m_traces_saved) + ".trc";
         check_divergence<detail::counter_example_constructor>(
                 detail::state_index_pair<detail::counter_example_constructor>(state,detail::counter_example_constructor::root_index()),
-                detail::counter_example_constructor(filename_divergence_loop));
+                detail::counter_example_constructor(filename_divergence_loop, structured_output));
       }
       else
       {

--- a/libraries/lts/source/liblts_aut.cpp
+++ b/libraries/lts/source/liblts_aut.cpp
@@ -238,9 +238,8 @@ static bool read_initial_part_of_an_aut_transition(
   {
     return false;
   }
-  if (ch != '(')
+  if (ch == 0x04) // found EOT character that separates two files
   {
-    is.unget();
     return false;
   }
 

--- a/libraries/lts/source/liblts_aut.cpp
+++ b/libraries/lts/source/liblts_aut.cpp
@@ -383,7 +383,7 @@ static void read_from_aut(probabilistic_lts_aut_t& l, std::istream& is)
 
     if (!read_aut_transition(is,from,s,probabilistic_target_state,line_no))
     {
-      break; // eof encountered
+      break; // encountered EOF or something that is not a transition
     }
 
     check_state(from, nstate, line_no);

--- a/libraries/lts/source/liblts_aut.cpp
+++ b/libraries/lts/source/liblts_aut.cpp
@@ -240,7 +240,8 @@ static bool read_initial_part_of_an_aut_transition(
   }
   if (ch != '(')
   {
-    throw mcrl2::runtime_error("Expect opening bracket at line " + std::to_string(line_no) + ".");
+    is.unget();
+    return false;
   }
 
   is >> std::skipws >> from;
@@ -528,7 +529,7 @@ namespace lts
 
 void probabilistic_lts_aut_t::load(const std::string& filename)
 {
-  if (filename=="")
+  if (filename=="" || filename=="-")
   {
     read_from_aut(*this, std::cin);
   }
@@ -553,7 +554,7 @@ void probabilistic_lts_aut_t::load(std::istream& is)
 
 void probabilistic_lts_aut_t::save(std::string const& filename) const
 {
-  if (filename=="")
+  if (filename=="" || filename=="-")
   {
     write_to_aut(*this, std::cout);
   }
@@ -573,7 +574,7 @@ void probabilistic_lts_aut_t::save(std::string const& filename) const
 
 void lts_aut_t::load(const std::string& filename)
 {
-  if (filename=="")
+  if (filename=="" || filename=="-")
   {
     read_from_aut(*this, std::cin);
   }
@@ -598,7 +599,7 @@ void lts_aut_t::load(std::istream& is)
 
 void lts_aut_t::save(std::string const& filename) const
 {
-  if (filename=="")
+  if (filename=="" || filename=="-")
   {
     write_to_aut(*this, std::cout);
   }

--- a/libraries/trace/include/mcrl2/trace/trace.h
+++ b/libraries/trace/include/mcrl2/trace/trace.h
@@ -50,6 +50,7 @@ enum TraceFormat
 {
   tfMcrl2,  /**< Format is stored as an aterm */
   tfPlain,  /**< Format is stored in plain text. In this format there are only actions */
+  tfLine,   /**< Format is stored in a line of text. In this format there are only actions */
   tfUnknown /**< This value indicates that the format is unknown */
 };
 
@@ -498,6 +499,9 @@ class Trace
           case tfPlain:
             savePlain(os);
             break;
+          case tfLine:
+            saveLine(os);
+            break;
           default:
             break;
         }
@@ -735,18 +739,32 @@ class Trace
       }
     }
 
-    void savePlain(std::ostream& os)
+    void save_text(std::ostream& os, std::string separator)
     {
+      std::string sep;
       for (std::size_t i=0; i<m_actions.size(); i++)
       {
-        os << pp(m_actions[i]);
-        os << std::endl;
+        os << sep << pp(m_actions[i]);
+        sep = separator;
         if (os.bad())
         {
           throw runtime_error("Could not write to stream.");
         }
       }
     }
+
+    void saveLine(std::ostream& os)
+    {
+      save_text(os, " ");
+      os << std::endl;
+    }
+
+    void savePlain(std::ostream& os)
+    {
+      save_text(os, "\n");
+      os << std::endl;
+    }
+
 };
 
 }

--- a/libraries/trace/include/mcrl2/trace/trace.h
+++ b/libraries/trace/include/mcrl2/trace/trace.h
@@ -755,7 +755,7 @@ class Trace
 
     void saveLine(std::ostream& os)
     {
-      save_text(os, " ");
+      save_text(os, ";");
       os << std::endl;
     }
 

--- a/tools/release/ltscompare/ltscompare.cpp
+++ b/tools/release/ltscompare/ltscompare.cpp
@@ -70,7 +70,9 @@ class ltscompare_tool : public ltscompare_base
       ltscompare_base(NAME,AUTHOR,
                       "compare two LTSs",
                       "Determine whether or not the labelled transition systems (LTSs) in INFILE1 and INFILE2 are related by some equivalence or preorder. "
-                      "If INFILE1 is not supplied, stdin is used.\n"
+                      "If INFILE1 is not supplied, stdin is used. "
+                      "If INFILE1 and/or INFILE2 is '-', stdin is used. "
+                      "Reading two LTSs via stdin is only supported for the 'aut' format, these LTSs must be separated by an EOT character (\\x04).\n"
                       "\n"
                       "The input formats are determined by the contents of INFILE1 and INFILE2. "
                       "Options --in1 and --in2 can be used to force the input format of INFILE1 and INFILE2, respectively. "

--- a/tools/release/ltscompare/ltscompare.cpp
+++ b/tools/release/ltscompare/ltscompare.cpp
@@ -114,27 +114,18 @@ class ltscompare_tool : public ltscompare_base
         result = destructive_compare(l1, l2, tool_options.preorder, tool_options.generate_counter_examples, tool_options.structured_output, tool_options.strategy, tool_options.enable_preprocessing);
 
         if (!tool_options.structured_output)
+        {
           mCRL2log(info) << "The LTS in " << tool_options.name_for_first
                          << " is " << ((result) ? "" : "not ")
                          << "included in"
                          << " the LTS in " << tool_options.name_for_second
                          << " (using " << description(tool_options.preorder)
                          << ")." << std::endl;
+        }
       }
 
-      if (tool_options.structured_output)
-      {
-        // Let the exit code depend on the result of the LTS comparison.
-        // This is expected behaviour for UNIX tools such as diff.
-        return result;
-      }
-      else
-      {
-        // When printing human readable output, the exit code is EXIT_SUCCESS
-        // for backwards compatibility.
-        std::cout << (result ? "true" : "false") << std::endl;
-        return true; // The tool terminates in a correct way.
-      }
+      std::cout << (tool_options.structured_output ? "result: " : "") << std::boolalpha << result << std::endl;
+      return true; // The tool terminates in a correct way.
     }
 
   public:
@@ -258,11 +249,6 @@ class ltscompare_tool : public ltscompare_base
       add_option("counter-example",
                  "generate counter example traces if the input lts's are not equivalent",'c').
       add_option("structured-output",
-                 // TODO: also write human readable stderr chatter like
-                 // "LTS in A is [not] included in B" in a structured way to stdout,
-                 // something like
-                 // 2_contains_1: no
-                 // 1_contains_2: yes
                  "generate counter examples on stdout",'x').
       add_hidden_option("no-preprocessing",
                         "disable preprocessing applied to the input LTSs for refinement checking",'\0');

--- a/tools/release/ltscompare/ltscompare.cpp
+++ b/tools/release/ltscompare/ltscompare.cpp
@@ -123,14 +123,18 @@ class ltscompare_tool : public ltscompare_base
       }
 
       if (tool_options.structured_output)
-        // behave as expected for UNIX tools, such as diff
-        exit(!result);
+      {
+        // Let the exit code depend on the result of the LTS comparison.
+        // This is expected behaviour for UNIX tools such as diff.
+        return result;
+      }
       else
-        {
-          // retain backward compatibility
-          std::cout << (result ? "true" : "false") << std::endl;
-          return true; // The tool terminates in a correct way.
-        }
+      {
+        // When printing human readable output, the exit code is EXIT_SUCCESS
+        // for backwards compatibility.
+        std::cout << (result ? "true" : "false") << std::endl;
+        return true; // The tool terminates in a correct way.
+      }
     }
 
   public:


### PR DESCRIPTION
These changes add support for file piping to several places, mainly in the lts library. This enables use of the tools without the need of storing intermediate files to disk.

Code contributed by Jan (Janneke) Nieuwenhuizen.