### PR TITLE
Extend pbesconstelm with limited support for quantifiers

### DIFF
--- a/libraries/pbes/include/mcrl2/pbes/constelm.h
+++ b/libraries/pbes/include/mcrl2/pbes/constelm.h
@@ -676,6 +676,7 @@ class pbes_constelm_algorithm
               {
                 changed = true;
                 deleted_constraints.push_back(fi);
+                deleted_constraints.push_back(ei);
                 m_constraints.erase(k);
               }
             }

--- a/libraries/pbes/include/mcrl2/pbes/constelm.h
+++ b/libraries/pbes/include/mcrl2/pbes/constelm.h
@@ -520,19 +520,29 @@ struct constelm_quantifiers_inside_builder: public pbes_expression_builder<const
         }
       }
 
-      // Check if we need to add quantified variables that have a larger scope than elem
+      // Check if we need to add quantified variables that have a larger scope and
+      // and are at least one quantifier alternation away from elem
       bool add_rest = false;
+      bool is_forall = false;
+      bool quantifier_changed = false;
       for(auto qv = qvars.rbegin(); qv != qvars.rend(); ++qv)
       {
         const data::variable& var = qv->variable();
         if(var == elem)
         {
           add_rest = true;
+          is_forall = qv->is_forall();
         }
-        else if(add_rest && seen.count(var) == 0)
+        else if(add_rest)
         {
-          seen.insert(var);
-          todo.push(var);
+          // if the quantifier changes, we need to add all variables from now on
+          quantifier_changed |= qv->is_forall() != is_forall;
+          if(quantifier_changed && seen.count(var) == 0)
+          {
+            mCRL2log(log::verbose) << "adding variable " << var << ": " << var.sort() << std::endl;
+            seen.insert(var);
+            todo.push(var);
+          }
         }
       }
     }

--- a/libraries/pbes/include/mcrl2/pbes/constelm.h
+++ b/libraries/pbes/include/mcrl2/pbes/constelm.h
@@ -277,10 +277,12 @@ struct edge_condition_traverser: public pbes_expression_traverser<edge_condition
       cond_set.insert(data::optimized_forall(x.variables(), ec.Cpos, true));
 
       // Update FV
-      std::set<data::variable> bound_vars{x.variables().begin(), x.variables().end()};
       conj_FV = ec.FV;
-      ec.FV = utilities::detail::set_difference(ec.FV, bound_vars);
     }
+    ec.Cpos = data::optimized_forall(x.variables(), ec.Cpos, true);
+    ec.Cneg = data::optimized_exists(x.variables(), ec.Cneg, true);
+    std::set<data::variable> bound_vars{x.variables().begin(), x.variables().end()};
+    ec.FV = utilities::detail::set_difference(ec.FV, bound_vars);
     push(ec);
 
     // maintain quantifier scope
@@ -308,10 +310,12 @@ struct edge_condition_traverser: public pbes_expression_traverser<edge_condition
       cond_set.insert(data::optimized_forall(x.variables(), ec.Cneg, true));
 
       // Update FV
-      std::set<data::variable> bound_vars{x.variables().begin(), x.variables().end()};
       disj_FV = ec.FV;
-      ec.FV = utilities::detail::set_difference(ec.FV, bound_vars);
     }
+    ec.Cpos = data::optimized_exists(x.variables(), ec.Cpos, true);
+    ec.Cneg = data::optimized_forall(x.variables(), ec.Cneg, true);
+    std::set<data::variable> bound_vars{x.variables().begin(), x.variables().end()};
+    ec.FV = utilities::detail::set_difference(ec.FV, bound_vars);
     push(ec);
 
     // maintain quantifier scope

--- a/libraries/pbes/include/mcrl2/pbes/constelm.h
+++ b/libraries/pbes/include/mcrl2/pbes/constelm.h
@@ -549,6 +549,15 @@ class pbes_constelm_algorithm
                 changed = true;
               }
             }
+            if (changed)
+            {
+              std::set<data::variable> used_vars;
+              for(const auto& [var, expr]: m_constraints)
+              {
+                data::find_free_variables(m_constraints[*j], std::inserter(used_vars, used_vars.end()));
+              }
+              m_qvars = project(qvars, used_vars);
+            }
           }
           return changed;
         }
@@ -615,9 +624,9 @@ class pbes_constelm_algorithm
     std::string print_edge_update(const edge& e, const vertex& u, const vertex& v)
     {
       std::ostringstream out;
-      out << "\n<updating edge>" << e.to_string() << std::endl;
-      out << "  <source vertex       >" << u.to_string() << std::endl;
-      out << "  <target vertex before>" << v.to_string() << std::endl;
+      out << "\n<updating edge> " << e.to_string() << std::endl;
+      out << "  <source vertex       > " << u.to_string() << std::endl;
+      out << "  <target vertex before> " << v.to_string() << std::endl;
       return out.str();
     }
 
@@ -626,7 +635,7 @@ class pbes_constelm_algorithm
       std::ostringstream out;
       data::rewriter::substitution_type sigma;
       detail::make_constelm_substitution(u.constraints(), sigma);
-      out << "\nEvaluated condition " << e.condition() << sigma << " to " << value << std::endl;
+      out << "  <condition           > " << e.condition() << sigma << " to " << value << std::endl;
       return out.str();
     }
 

--- a/libraries/pbes/include/mcrl2/pbes/tools.h
+++ b/libraries/pbes/include/mcrl2/pbes/tools.h
@@ -38,7 +38,8 @@ void pbesconstelm(const std::string& input_filename,
                   data::rewrite_strategy rewrite_strategy,
                   pbes_rewriter_type rewriter_type,
                   bool compute_conditions,
-                  bool remove_redundant_equations
+                  bool remove_redundant_equations,
+                  bool check_quantifiers
                  );
 
 void pbesinfo(const std::string& input_filename,

--- a/libraries/pbes/include/mcrl2/pbes/tools/pbesconstelm.h
+++ b/libraries/pbes/include/mcrl2/pbes/tools/pbesconstelm.h
@@ -26,14 +26,15 @@ void pbesconstelm(const std::string& input_filename,
                   data::rewrite_strategy rewrite_strategy,
                   pbes_rewriter_type rewriter_type,
                   bool compute_conditions,
-                  bool remove_redundant_equations
+                  bool remove_redundant_equations,
+                  bool check_quantifiers
                  )
 {
   // load the pbes
   pbes p;
   load_pbes(p, input_filename, input_format);
 
-  constelm(p, rewrite_strategy, rewriter_type, compute_conditions, remove_redundant_equations);
+  constelm(p, rewrite_strategy, rewriter_type, compute_conditions, remove_redundant_equations, check_quantifiers);
 
   // save the result
   save_pbes(p, output_filename, output_format);

--- a/tools/release/pbesconstelm/pbesconstelm.cpp
+++ b/tools/release/pbesconstelm/pbesconstelm.cpp
@@ -36,12 +36,14 @@ class pbes_constelm_tool: public pbes_input_tool<pbes_output_tool<pbes_rewriter_
 
     bool m_compute_conditions = false;
     bool m_remove_redundant_equations = false;
+    bool m_check_quantifiers = false;
 
     void parse_options(const command_line_parser& parser) override
     {
       super::parse_options(parser);
       m_compute_conditions = parser.options.count("compute-conditions") > 0;
       m_remove_redundant_equations = parser.options.count("remove-equations") > 0;
+      m_check_quantifiers = parser.options.count("check-quantifiers") > 0;
     }
 
     void add_options(interface_description& desc) override
@@ -49,6 +51,7 @@ class pbes_constelm_tool: public pbes_input_tool<pbes_output_tool<pbes_rewriter_
       super::add_options(desc);
       desc.add_option("compute-conditions", "compute propagation conditions", 'c');
       desc.add_option("remove-equations", "remove redundant equations", 'e');
+      desc.add_option("check-quantifiers", "also analyse which quantified parameters are constant", 'a');
     }
 
   public:
@@ -77,7 +80,8 @@ class pbes_constelm_tool: public pbes_input_tool<pbes_output_tool<pbes_rewriter_
                    rewrite_strategy(),
                    rewriter_type(),
                    m_compute_conditions,
-                   m_remove_redundant_equations
+                   m_remove_redundant_equations,
+                   m_check_quantifiers
                   );
       return true;
     }


### PR DESCRIPTION
This pull request adds a new feature to `pbesconstelm`: with the command line option `-a`, some quantifiers can be eliminated. This may result in a reduction of the size of the underlying parity game. Furthermore, the computation of guards has been improved, so the resulting expressions are stronger (more likely to aid the algorithm) and more compact (for better performance).

There are still some open TODOs:

- [ ] Update corresponding documentation.
