### PR TITLE
[ltsgraph] updated Qt deprecated functions

### DIFF
--- a/tools/release/ltsgraph/springlayout.cpp
+++ b/tools/release/ltsgraph/springlayout.cpp
@@ -20,9 +20,9 @@ namespace Graph
 // Utility functions
 //
 
-inline float frand(float min, float max)
+// Todo: move to separate utility source file
+inline float fast_frand(float min, float max)
 {
-  //return ((float)qrand() / RAND_MAX) * (max - min) + min;
   // Fast pseudo rand, source: http://www.musicdsp.org/showone.php?id=273
   static int32_t seed = 1;
   seed *= 16807;
@@ -116,7 +116,7 @@ QVector3D repulsionForce(const QVector3D& a, const QVector3D& b, float repulsion
   QVector3D diff = a - b;
   float r = repulsion;
   r /= cube((std::max)(diff.length() / 2.0f, natlength / 10));
-  diff = diff * r + QVector3D(frand(-0.01f, 0.01f), frand(-0.01f, 0.01f), frand(-0.01f, 0.01f));
+  diff = diff * r + QVector3D(fast_frand(-0.01f, 0.01f), fast_frand(-0.01f, 0.01f), fast_frand(-0.01f, 0.01f));
   return diff;
 }
 
@@ -243,7 +243,7 @@ void SpringLayout::randomizeZ(float z)
   {
     if (!m_graph.node(n).anchored())
     {
-      m_graph.node(n).pos_mutable().setZ(m_graph.node(n).pos().z() + frand(-z, z));
+      m_graph.node(n).pos_mutable().setZ(m_graph.node(n).pos().z() + fast_frand(-z, z));
     }
   }
   m_graph.unlock(GRAPH_LOCK_TRACE);
@@ -257,7 +257,7 @@ class WorkerThread : public QThread
 {
   private:
     bool m_stopped;
-    QTime m_time;
+    QElapsedTimer m_time;
     SpringLayout& m_layout;
     int m_period;
   public:

--- a/tools/release/ltsgraph/springlayout.cpp
+++ b/tools/release/ltsgraph/springlayout.cpp
@@ -20,15 +20,6 @@ namespace Graph
 // Utility functions
 //
 
-// Todo: move to separate utility source file
-inline float fast_frand(float min, float max)
-{
-  // Fast pseudo rand, source: http://www.musicdsp.org/showone.php?id=273
-  static int32_t seed = 1;
-  seed *= 16807;
-  return ((((float)seed) * 4.6566129e-010f) + 1.0) * (max - min) / 2.0 + min;
-}
-
 inline float cube(float x)
 {
   return x * x * x;

--- a/tools/release/ltsgraph/utility.h
+++ b/tools/release/ltsgraph/utility.h
@@ -14,6 +14,7 @@
 
 #include <QOpenGLFunctions_3_3_Core>
 #include <QPainter>
+#include <QRandomGenerator>
 #include <QVector3D>
 #include <QStaticText>
 
@@ -67,7 +68,7 @@ constexpr float PI_2 = PI * 0.5f;
 inline
 float frand(float min, float max)
 {
-  return (static_cast<float>(qrand()) / RAND_MAX) * (max - min) + min;
+  return static_cast<float>(QRandomGenerator::global()->generateDouble() * (max - min) + min);
 }
 
 /// \brief Renders text, centered around the window coordinates at x and y (in pixels)

--- a/tools/release/ltsgraph/utility.h
+++ b/tools/release/ltsgraph/utility.h
@@ -14,11 +14,11 @@
 
 #include <QOpenGLFunctions_3_3_Core>
 #include <QPainter>
-#include <QRandomGenerator>
 #include <QVector3D>
 #include <QStaticText>
 
 #include <cmath>
+#include <random>
 
 /// \file This file contains various utility commands, instead of defining them inline in source files, such that they can be reused and/or
 /// moved to more logical locations.
@@ -68,7 +68,20 @@ constexpr float PI_2 = PI * 0.5f;
 inline
 float frand(float min, float max)
 {
-  return static_cast<float>(QRandomGenerator::global()->generateDouble() * (max - min) + min);
+  static thread_local std::random_device rd;
+  static thread_local std::mt19937 twister(rd());
+  std::uniform_real_distribution<> dist(min, max);
+  return dist(twister);
+}
+
+inline
+float fast_frand(float min, float max)
+{
+  // Fast pseudo rand, source: http://www.musicdsp.org/showone.php?id=273
+  static thread_local std::random_device rd;
+  static int32_t seed = rd();
+  seed *= 16807;
+  return (((static_cast<float> (seed)) * 4.6566129e-010f) + 1.0) * (max - min) / 2.0 + min;
 }
 
 /// \brief Renders text, centered around the window coordinates at x and y (in pixels)

--- a/tools/release/ltsgraph/utility.h
+++ b/tools/release/ltsgraph/utility.h
@@ -79,7 +79,7 @@ float fast_frand(float min, float max)
 {
   // Fast pseudo rand, source: http://www.musicdsp.org/showone.php?id=273
   static thread_local std::random_device rd;
-  static int32_t seed = rd();
+  static thread_local int32_t seed = rd();
   seed *= 16807;
   return (((static_cast<float> (seed)) * 4.6566129e-010f) + 1.0) * (max - min) / 2.0 + min;
 }


### PR DESCRIPTION
`qrand`, `QTime.start` and `QTime.elapsed` are deprecated since Qt5.15, updated to newer style