### PR TITLE
Correct two typos in documentation

### DIFF
--- a/doc/sphinx/user_manual/language_reference/data.rst
+++ b/doc/sphinx/user_manual/language_reference/data.rst
@@ -252,12 +252,12 @@ rule will prevent us from getting into trouble.
    useful example is that of lists, for which the constructors ``[]`` and ``|>``
    are defined::
 
-    map remove: List(Nat) # Nat -> List(Nat);
-    var x, y: Nat;
-        l: List(Nat);
-    eqn remove([], x) = []; 
-        x == y -> remove(x |> l, y) = l;
-        x != y -> remove(x |> l, y) = x |> remove(l, y);
+     map remove: List(Nat) # Nat -> List(Nat);
+     var x, y: Nat;
+         l: List(Nat);
+     eqn remove([], x) = []; 
+         x == y -> remove(x |> l, y) = l;
+         x != y -> remove(x |> l, y) = x |> remove(l, y);
 
 .. _predefinedsorts:
 

--- a/doc/sphinx/user_manual/language_reference/data.rst
+++ b/doc/sphinx/user_manual/language_reference/data.rst
@@ -252,12 +252,12 @@ rule will prevent us from getting into trouble.
    useful example is that of lists, for which the constructors ``[]`` and ``|>``
    are defined::
 
-     map remove: List(Nat) # Nat -> Nat;
-     var x, y: Nat;
-         l: List(Nat);
-     eqn remove(x, []) = [];
-         x == y -> remove(x |> l, y) = l;
-         x != y -> remove(x |> l, y) = x |> remove(l, y);
+    map remove: List(Nat) # Nat -> List(Nat);
+    var x, y: Nat;
+        l: List(Nat);
+    eqn remove([], x) = []; 
+        x == y -> remove(x |> l, y) = l;
+        x != y -> remove(x |> l, y) = x |> remove(l, y);
 
 .. _predefinedsorts:
 


### PR DESCRIPTION
The code in doc/sphinx/user_manual/language_reference/data.rst does not compile as is. The two typos are: 1. the return type of remove should be List(Nat); and 2. the order of the arguments in the first equation is wrong.