### PR TITLE
Fix problem with tau confluence reduction and recursive enumerator calls

### DIFF
--- a/libraries/lps/include/mcrl2/lps/explorer.h
+++ b/libraries/lps/include/mcrl2/lps/explorer.h
@@ -394,9 +394,12 @@ class explorer: public abortable
     template <typename SummandSequence>
     state find_representative(state& u0, const SummandSequence& summands)
     {
+      bool recursive_undo = m_recursive;
+      m_recursive = true;
       data::data_expression_list process_parameter_undo = process_parameter_values();
       state result = lps::find_representative(u0, [&](const state& u) { return generate_successors(u, summands); });
       set_process_parameter_values(process_parameter_undo);
+      m_recursive = recursive_undo;
       return result;
     }
 
@@ -604,7 +607,7 @@ class explorer: public abortable
       return transitions;
     }
 
-    // pre: d0 is in normal form
+    // pre: s0 is in normal form
     template <typename SummandSequence>
     std::vector<state> generate_successors(
       const state& s0,


### PR DESCRIPTION
When tau confluence reduction is used, the enumerator is called recursively when generating a state, as its callback function calls the method `find_representative`, which triggers more exploration. Therefore, the explorer should temporarily be set to recursive mode, to prevent issues with the enumerator.

Fixes #1649