### PR TITLE
Changed ltscompare equivalence counterexamples to distinguishing formulas

### DIFF
--- a/libraries/lts/CMakeLists.txt
+++ b/libraries/lts/CMakeLists.txt
@@ -15,4 +15,5 @@ add_mcrl2_library(lts
   DEPENDS
     mcrl2_data
     mcrl2_lps
+    mcrl2_modal_formula
 )

--- a/libraries/lts/include/mcrl2/lts/detail/counter_example.h
+++ b/libraries/lts/include/mcrl2/lts/detail/counter_example.h
@@ -74,6 +74,12 @@ class counter_example_constructor
     const bool m_structured_output;
   
   public:
+    /// \brief Constructor
+    //  \param name The name of the model that the counter example is for
+    //  \param counter_example_file The name of the file to save the counter example to
+    //  \param structured_output Whether the counterexample should be printed to std:cout
+    //  \detail If structured_output=true, the counter example is not saved to file.
+    //          If counter_example_file="", the name of the counter example file name is derived from name (the parameter)
     counter_example_constructor(const std::string& name, const std::string& counter_example_file, bool structured_output)
      : m_name(name)
      , m_counter_example_file(counter_example_file)

--- a/libraries/lts/include/mcrl2/lts/detail/counter_example.h
+++ b/libraries/lts/include/mcrl2/lts/detail/counter_example.h
@@ -70,11 +70,13 @@ class counter_example_constructor
     static const index_type m_root_index=-1;
     std::deque< action_index_pair > m_backward_tree;
     const std::string m_name;
+    const std::string m_counter_example_file;
     const bool m_structured_output;
   
   public:
-    counter_example_constructor(const std::string& name, bool structured_output)
+    counter_example_constructor(const std::string& name, const std::string& counter_example_file, bool structured_output)
      : m_name(name)
+     , m_counter_example_file(counter_example_file)
      , m_structured_output(structured_output)
     {}
 
@@ -136,6 +138,10 @@ class counter_example_constructor
       else
       {
         std::string filename = m_name + ".trc";
+        if (!m_counter_example_file.empty())
+        {
+          filename = m_counter_example_file;
+        }
         mCRL2log(log::verbose) << "Saved trace to file " + filename + "\n";
         result.save(filename);
       }

--- a/libraries/lts/include/mcrl2/lts/detail/liblts_bisim.h
+++ b/libraries/lts/include/mcrl2/lts/detail/liblts_bisim.h
@@ -1132,36 +1132,42 @@ void bisimulation_reduce(
  *          algorithm by Groote and Vaandrager from 1990.
  * \param[in/out] l1 A first transition system.
  * \param[in/out] l2 A second transition system.
- * \param[branching] If true branching bisimulation is used, otherwise strong bisimulation is applied.
- * \param[preserve_divergences] If true and branching is true, preserve tau loops on states.
+ * \param[in] branching If true branching bisimulation is used, otherwise strong bisimulation is applied.
+ * \param[in] preserve_divergences If true and branching is true, preserve tau loops on states.
+ * \param[in] generate_counter_examples Whether to generate a counter example
+ * \param[in] structured_output
  * \retval True iff the initial states of the current transition system and l2 are (divergence preserving) (branching) bisimilar */
 template < class LTS_TYPE>
 bool destructive_bisimulation_compare(
   LTS_TYPE& l1,
   LTS_TYPE& l2,
-  const bool branching=false,
-  const bool preserve_divergences=false,
-  const bool generate_counter_examples = false);
+  const bool branching = false,
+  const bool preserve_divergences = false,
+  const bool generate_counter_examples = false,
+  const bool structured_output = false);
 
 
 /** \brief Checks whether the two initial states of two lts's are strong or branching bisimilar.
- *  \details The current transitions system and the lts l2 are first duplicated and subsequently
- *           reduced modulo bisimulation. If memory space is a concern, one could consider to
- *           use destructive_bisimulation_compare. This routine uses the Groote-Vaandrager
- *           branching bisimulation routine. It runs in O(mn) and uses O(n) memory where n is the
- *           number of states and m is the number of transitions.
+ * \details The current transitions system and the lts l2 are first duplicated and subsequently
+ *          reduced modulo bisimulation. If memory space is a concern, one could consider to
+ *          use destructive_bisimulation_compare. This routine uses the Groote-Vaandrager
+ *          branching bisimulation routine. It runs in O(mn) and uses O(n) memory where n is the
+ *          number of states and m is the number of transitions.
  * \param[in/out] l1 A first transition system.
  * \param[in/out] l2 A second transistion system.
- * \param[branching] If true branching bisimulation is used, otherwise strong bisimulation is applied.
- * \param[preserve_divergences] If true and branching is true, preserve tau loops on states.
+ * \param[in] branching If true branching bisimulation is used, otherwise strong bisimulation is applied.
+ * \param[in] preserve_divergences If true and branching is true, preserve tau loops on states.
+ * \param[in] generate_counter_examples Whether to generate a counter example
+ * \param[in] structured_output
  * \retval True iff the initial states of the current transition system and l2 are (divergence preserving) (branching) bisimilar */
 template < class LTS_TYPE>
 bool bisimulation_compare(
   const LTS_TYPE& l1,
   const LTS_TYPE& l2,
-  const bool branching=false,
-  const bool preserve_divergences=false,
-  const bool generate_counter_examples = false);
+  const bool branching = false,
+  const bool preserve_divergences = false,
+  const bool generate_counter_examples = false,
+  const bool structured_output = false);
 
 
 

--- a/libraries/lts/include/mcrl2/lts/detail/liblts_bisim.h
+++ b/libraries/lts/include/mcrl2/lts/detail/liblts_bisim.h
@@ -10,6 +10,7 @@
 
 #ifndef _LIBLTS_BISIM_H
 #define _LIBLTS_BISIM_H
+#include <fstream>
 #include "mcrl2/modal_formula/state_formula.h"
 #include "mcrl2/lts/lts_utilities.h"
 #include "mcrl2/lts/detail/liblts_scc.h"

--- a/libraries/lts/include/mcrl2/lts/detail/liblts_bisim.h
+++ b/libraries/lts/include/mcrl2/lts/detail/liblts_bisim.h
@@ -282,7 +282,7 @@ class bisim_partitioner
     outgoing_transitions_per_state_action_t outgoing_transitions;
 
     // A counter for creating fresh variables
-    int freshVarCounter = 0;
+    int fresh_var_counter = 0;
 
 
     void create_initial_partition(const bool branching,
@@ -838,30 +838,30 @@ class bisim_partitioner
     }
 
     /**
-     * \brief createRegularFormula Creates a regular formula that represents action a
+     * \brief create_regular_formula Creates a regular formula that represents action a
      * \details In case the action comes from an LTS in the lts format.
      * \param[in] a The action for which to create a regular formula
      * \return The created regular formula
      */
-    regular_formulas::regular_formula createRegularFormula(const mcrl2::lps::multi_action& a) const
+    regular_formulas::regular_formula create_regular_formula(const mcrl2::lps::multi_action& a) const
     {
       return regular_formulas::regular_formula(action_formulas::multi_action(a.actions()));
     }
 
     /**
-     * \brief createRegularFormula Creates a regular formula that represents action a
+     * \brief create_regular_formula Creates a regular formula that represents action a
      * \details In case the action comes from an LTS in the aut or fsm format.
      * \param[in] a The action for which to create a regular formula
      * \return The created regular formula
      */
-    regular_formulas::regular_formula createRegularFormula(const mcrl2::lts::action_label_string& a) const
+    regular_formulas::regular_formula create_regular_formula(const mcrl2::lts::action_label_string& a) const
     {
       return mcrl2::regular_formulas::regular_formula(mcrl2::action_formulas::multi_action(
         process::action_list({ process::action(process::action_label(a, {}), {}) })));
     }
 
     /**
-     * \brief untilFormula Creates a state formula that corresponds to the until operator phi1<a>phi2 from HMLU
+     * \brief until_formula Creates a state formula that corresponds to the until operator phi1<a>phi2 from HMLU
      * \details This operator intuitively means: "phi1 holds while stuttering until we can do an a-step after which phi2 holds"
      *          In the operators of the mu-calculus that mCRL2 supports we can define this as:
      *              phi2 || (mu X.phi1 && (<tau>X || <a>phi2))  if a = tau
@@ -871,13 +871,13 @@ class bisim_partitioner
      * \param[in] phi2 The second state formula for the until operator
      * \return A state formula that corresponds to the until operator phi1<a>phi2 from HMLU
      */
-    mcrl2::state_formulas::state_formula untilFormula(const mcrl2::state_formulas::state_formula& phi1, const label_type& a,
-                                                      const mcrl2::state_formulas::state_formula& phi2)
+    mcrl2::state_formulas::state_formula until_formula(const mcrl2::state_formulas::state_formula& phi1, const label_type& a,
+                                                       const mcrl2::state_formulas::state_formula& phi2)
     {
-      std::string var = "X" + std::to_string(freshVarCounter++);
+      std::string var = "X" + std::to_string(fresh_var_counter++);
       mcrl2::state_formulas::state_formula tauStep =
           mcrl2::state_formulas::may(regular_formulas::regular_formula(action_formulas::multi_action()), mcrl2::state_formulas::variable(var, {}));
-      mcrl2::state_formulas::state_formula lastStep = mcrl2::state_formulas::may(createRegularFormula(aut.action_label(a)), phi2);
+      mcrl2::state_formulas::state_formula lastStep = mcrl2::state_formulas::may(create_regular_formula(aut.action_label(a)), phi2);
 
       mcrl2::state_formulas::state_formula until =
           mcrl2::state_formulas::mu(var, {}, mcrl2::state_formulas::and_(phi1, mcrl2::state_formulas::or_(tauStep, lastStep)));
@@ -948,11 +948,11 @@ class bisim_partitioner
           Phi2 = mcrl2::state_formulas::and_(Phi2, counter_formula_aux(Bp, R));
         }
 
-        Phi = untilFormula(Phi1, a, Phi2);
+        Phi = until_formula(Phi1, a, Phi2);
       }
       else
       {
-        Phi = mcrl2::state_formulas::may(createRegularFormula(aut.action_label(a)), Phi2);
+        Phi = mcrl2::state_formulas::may(create_regular_formula(aut.action_label(a)), Phi2);
       }
 
       if (blocks_containing_B1.count(R) == 0)

--- a/libraries/lts/include/mcrl2/lts/detail/liblts_bisim.h
+++ b/libraries/lts/include/mcrl2/lts/detail/liblts_bisim.h
@@ -1135,6 +1135,7 @@ void bisimulation_reduce(
  * \param[in] branching If true branching bisimulation is used, otherwise strong bisimulation is applied.
  * \param[in] preserve_divergences If true and branching is true, preserve tau loops on states.
  * \param[in] generate_counter_examples Whether to generate a counter example
+ * \param[in] counter_example_file The file to store the counter example in
  * \param[in] structured_output
  * \retval True iff the initial states of the current transition system and l2 are (divergence preserving) (branching) bisimilar */
 template < class LTS_TYPE>
@@ -1144,6 +1145,7 @@ bool destructive_bisimulation_compare(
   const bool branching = false,
   const bool preserve_divergences = false,
   const bool generate_counter_examples = false,
+  const std::string& counter_example_file = "",
   const bool structured_output = false);
 
 
@@ -1158,6 +1160,7 @@ bool destructive_bisimulation_compare(
  * \param[in] branching If true branching bisimulation is used, otherwise strong bisimulation is applied.
  * \param[in] preserve_divergences If true and branching is true, preserve tau loops on states.
  * \param[in] generate_counter_examples Whether to generate a counter example
+ * \param[in] counter_example_file The file to store the counter example in
  * \param[in] structured_output
  * \retval True iff the initial states of the current transition system and l2 are (divergence preserving) (branching) bisimilar */
 template < class LTS_TYPE>
@@ -1167,6 +1170,7 @@ bool bisimulation_compare(
   const bool branching = false,
   const bool preserve_divergences = false,
   const bool generate_counter_examples = false,
+  const std::string& counter_example_file = "",
   const bool structured_output = false);
 
 
@@ -1212,6 +1216,7 @@ bool bisimulation_compare(
   const bool branching /* =false*/,
   const bool preserve_divergences /*=false*/,
   const bool generate_counter_examples /*= false*/,
+  const std::string& counter_example_file /*= ""*/,
   const bool structured_output /* = false */)
 {
   LTS_TYPE l1_copy(l1);
@@ -1227,6 +1232,7 @@ bool destructive_bisimulation_compare(
   const bool branching /* =false*/,
   const bool preserve_divergences /*=false*/,
   const bool generate_counter_examples /* = false */,
+  const std::string& counter_example_file /*= ""*/,
   const bool /*structured_output = false */)
 {
   std::size_t init_l2 = l2.initial_state() + l1.num_states();
@@ -1247,6 +1253,10 @@ bool destructive_bisimulation_compare(
     mcrl2::state_formulas::state_formula counter_example_formula = bisim_part.counter_formula(l1.initial_state(), init_l2);
 
     std::string filename = "Counterexample.mcf";
+    if (!counter_example_file.empty())
+    {
+      filename = counter_example_file;
+    }
     std::ofstream counter_file(filename);
     counter_file << mcrl2::state_formulas::pp(counter_example_formula);
     counter_file.close();

--- a/libraries/lts/include/mcrl2/lts/detail/liblts_bisim.h
+++ b/libraries/lts/include/mcrl2/lts/detail/liblts_bisim.h
@@ -909,64 +909,6 @@ class bisim_partitioner
       }
     }
 
-    void reachable_states_in_block_s_via_label_l(
-      const state_type s,
-      const block_index_type block_index_for_bottom_state,
-      const label_type l,
-      std::set < state_type > &result_set,
-      std::set < state_type > &visited,
-      const bool branching_bisimulation) const
-    {
-      // This function yields a set of states that are reachable via a sequence of tau steps
-      // in block block_index_for_bottom_state, followed by an l step.
-      // The technique used is to search through tau transitions from s, until a bottom state
-      // in the current class is found. From this state all reachable states are put in the result set.
-      if (visited.count(s)>0)
-      {
-        return;
-      }
-
-      visited.insert(s);
-      // Put all l reachable states in the result set.
-      for (outgoing_transitions_per_state_action_t::const_iterator i1=outgoing_transitions.lower_bound(std::pair<state_type,label_type>(s,l));
-           i1!=outgoing_transitions.upper_bound(std::pair<state_type, label_type>(s,l)); ++i1)
-      {
-        result_set.insert(to(i1));
-      }
-
-      // Search for tau reachable states that are still in the block with block_index_for_bottom_state.
-      if (branching_bisimulation)
-      {
-        for (label_type lab=0; lab<aut.num_action_labels(); ++lab)
-        {
-          if (aut.is_tau(aut.apply_hidden_label_map(lab)))
-          {
-            for (outgoing_transitions_per_state_action_t::const_iterator i=outgoing_transitions.lower_bound(std::pair<state_type,label_type>(s,lab));
-                 i!=outgoing_transitions.upper_bound(std::pair<state_type, label_type>(s,lab)); ++i)
-            {
-              // Now find out whether the block index of to(i) is part of the block with index block_index_for_bottom_state.
-              block_index_type b=block_index_of_a_state[to(i)];
-              while (b!=block_index_for_bottom_state && blocks[b].parent_block_index!=b)
-              {
-                assert(blocks[b].parent_block_index!=b);
-                b=blocks[b].parent_block_index;
-              }
-              if (b==block_index_for_bottom_state)
-              {
-                reachable_states_in_block_s_via_label_l(
-                  to(i),
-                  block_index_for_bottom_state,
-                  l,
-                  result_set,
-                  visited,
-                  branching_bisimulation);
-              }
-            }
-          }
-        }
-      }
-    }
-
 
 #ifndef NDEBUG
     // The method below is intended to check the consistency of the internal data

--- a/libraries/lts/include/mcrl2/lts/detail/liblts_bisim_dnj.h
+++ b/libraries/lts/include/mcrl2/lts/detail/liblts_bisim_dnj.h
@@ -5512,7 +5512,8 @@ void bisimulation_reduce_dnj(LTS_TYPE& l, bool const branching = false,
 template <class LTS_TYPE>
 bool destructive_bisimulation_compare_dnj(LTS_TYPE& l1, LTS_TYPE& l2,
         bool const branching = false, bool const preserve_divergence = false,
-        bool const generate_counter_examples = false, bool /*structured_output*/ = false)
+        bool const generate_counter_examples = false,
+        const std::string& /*counter_example_file*/ = "", bool /*structured_output*/ = false)
 {
     if (generate_counter_examples)
     {

--- a/libraries/lts/include/mcrl2/lts/detail/liblts_bisim_gjkw.h
+++ b/libraries/lts/include/mcrl2/lts/detail/liblts_bisim_gjkw.h
@@ -1916,6 +1916,7 @@ template <class LTS_TYPE>
 bool destructive_bisimulation_compare_gjkw(LTS_TYPE& l1, LTS_TYPE& l2,
           bool branching /* = false */, bool preserve_divergence /* = false */,
                                            bool generate_counter_examples /* = false */,
+                                           const std::string& /*counter_example_file = "" */,
                                            bool /*structured_output = false */)
 {
   if (generate_counter_examples)

--- a/libraries/lts/include/mcrl2/lts/lts_algorithm.h
+++ b/libraries/lts/include/mcrl2/lts/lts_algorithm.h
@@ -128,7 +128,7 @@ bool destructive_compare(LTS_TYPE& l1,
     {
       if (generate_counter_examples)
       {
-        mCRL2log(log::warning) << "Cannot generate counter example traces for weak bisimulation\n";
+        mCRL2log(log::warning) << "Cannot generate counter examples for weak bisimulation\n";
       }
       return detail::destructive_weak_bisimulation_compare(l1,l2,false);
     }
@@ -136,7 +136,7 @@ bool destructive_compare(LTS_TYPE& l1,
     {
       if (generate_counter_examples)
       {
-        mCRL2log(log::warning) << "Cannot generate counter example traces for for divergence-preserving weak bisimulation\n";
+        mCRL2log(log::warning) << "Cannot generate counter examples for divergence-preserving weak bisimulation\n";
       }
       return detail::destructive_weak_bisimulation_compare(l1,l2, true);
     }
@@ -144,7 +144,7 @@ bool destructive_compare(LTS_TYPE& l1,
     {
       if (generate_counter_examples)
       {
-        mCRL2log(log::warning) << "Cannot generate counter example traces for simulation equivalence\n";
+        mCRL2log(log::warning) << "Cannot generate counter examples for simulation equivalence\n";
       }
       // Run the partitioning algorithm on this merged LTS
       std::size_t init_l2 = l2.initial_state() + l1.num_states();
@@ -159,7 +159,7 @@ bool destructive_compare(LTS_TYPE& l1,
     {
       if (generate_counter_examples)
       {
-        mCRL2log(log::warning) << "Cannot generate counter example traces for ready-simulation equivalence\n";
+        mCRL2log(log::warning) << "Cannot generate counter examples for ready-simulation equivalence\n";
       }
       // Run the partitioning algorithm on this merged LTS
       std::size_t init_l2 = l2.initial_state() + l1.num_states();

--- a/libraries/lts/include/mcrl2/lts/lts_algorithm.h
+++ b/libraries/lts/include/mcrl2/lts/lts_algorithm.h
@@ -185,6 +185,11 @@ bool destructive_compare(LTS_TYPE& l1,
     }
     case lts_eq_weak_trace:
     {
+      if (generate_counter_examples)
+      {
+        mCRL2log(log::warning) << "Cannot generate counter examples for weak trace equivalence\n";
+      }
+
       // Eliminate silent steps and determinise first LTS
       detail::bisimulation_reduce(l1,true,false);
       detail::tau_star_reduce(l1);
@@ -198,7 +203,7 @@ bool destructive_compare(LTS_TYPE& l1,
       determinise(l2);
 
       // Weak trace equivalence now corresponds to bisimilarity
-      return detail::destructive_bisimulation_compare(l1,l2,false,false,generate_counter_examples,structured_output);
+      return detail::destructive_bisimulation_compare(l1,l2,false,false,false,structured_output);
     }
     case lts_eq_coupled_sim:
     {

--- a/libraries/lts/include/mcrl2/lts/lts_algorithm.h
+++ b/libraries/lts/include/mcrl2/lts/lts_algorithm.h
@@ -39,7 +39,7 @@ namespace lts
 /** \brief Applies a reduction algorithm to this LTS.
  * \param[in] l A labelled transition system that must be reduced.
  * \param[in] eq The equivalence with respect to which the LTS will be
- * reduced.
+ *            reduced.
  **/
 template <class LTS_TYPE>
 void reduce(LTS_TYPE& l, lts_equivalence eq);
@@ -48,8 +48,8 @@ void reduce(LTS_TYPE& l, lts_equivalence eq);
  * \param[in] l1 The first LTS that will be compared.
  * \param[in] l2 The second LTS that will be compared.
  * \param[in] eq The equivalence with respect to which the LTSs will be
- * compared.
- * \param[in] generate_counter_examples
+ *            compared.
+ * \param[in] generate_counter_examples Whether to generate a counter example
  * \retval true if the LTSs are found to be equivalent.
  * \retval false otherwise.
  * \warning This function alters the internal data structure of
@@ -222,8 +222,8 @@ bool destructive_compare(LTS_TYPE& l1,
  * \param[in] l1 The first LTS to compare.
  * \param[in] l2 The second LTS to compare.
  * \param[in] eq The equivalence with respect to which the LTSs will be
- * compared.
- * \param[in] generate_counter_examples If true counter examples are written to file.
+ *            compared.
+ * \param[in] generate_counter_examples Whether to generate a counter example
  * \retval true if the LTSs are found to be equivalent.
  * \retval false otherwise.
  */
@@ -239,9 +239,8 @@ bool compare(const LTS_TYPE& l1,
  * \param[in] l1 The first LTS to be compared.
  * \param[in] l2 The second LTS to be compared.
  * \param[in] pre The preorder with respect to which the LTSs will be
- * compared.
- * \param[in] generate_counter_example Indicates whether a file containing a counter example is
- *            generated when the comparison fails.
+ *            compared.
+ * \param[in] generate_counter_examples Whether to generate a counter example
  * \param[in] strategy Choose breadth-first or depth-first for exploration strategy
  *            of the antichain algorithms.
  * \param[in] preprocess Whether to allow preprocessing of the given LTSs.
@@ -269,8 +268,7 @@ bool destructive_compare(LTS_TYPE& l1,
  * \param[in] l1 The first LTS to be compared.
  * \param[in] l2 The second LTS to be compared.
  * \param[in] pre The preorder with respect to which the LTSs will be compared.
- * \param[in] generate_counter_example Indicates whether a file containing a counter example is
- *            generated when the comparison fails.
+ * \param[in] generate_counter_examples Whether to generate a counter example
  * \param[in] strategy Choose breadth-first or depth-first for exploration strategy
  *            of the antichain algorithms.
  * \param[in] preprocess Whether to allow preprocessing of the given LTSs.

--- a/libraries/lts/include/mcrl2/lts/lts_algorithm.h
+++ b/libraries/lts/include/mcrl2/lts/lts_algorithm.h
@@ -50,6 +50,7 @@ void reduce(LTS_TYPE& l, lts_equivalence eq);
  * \param[in] eq The equivalence with respect to which the LTSs will be
  *            compared.
  * \param[in] generate_counter_examples Whether to generate a counter example
+ * \param[in] counter_example_file The file to store the counter example in
  * \retval true if the LTSs are found to be equivalent.
  * \retval false otherwise.
  * \warning This function alters the internal data structure of
@@ -62,6 +63,7 @@ bool destructive_compare(LTS_TYPE& l1,
                          LTS_TYPE& l2,
                          const lts_equivalence eq,
                          const bool generate_counter_examples = false,
+                         const std::string& counter_example_file = std::string(),
                          const bool structured_output = false)
 {
   // Merge this LTS and l and store the result in this LTS.
@@ -78,51 +80,51 @@ bool destructive_compare(LTS_TYPE& l1,
       if (generate_counter_examples)
       {
         mCRL2log(mcrl2::log::warning) << "The default bisimulation comparison algorithm cannot generate counter examples. Therefore the slower gv algorithm is used instead.\n";
-        return detail::destructive_bisimulation_compare(l1,l2, false,false,generate_counter_examples,structured_output);
+        return detail::destructive_bisimulation_compare(l1,l2, false,false,generate_counter_examples,counter_example_file,structured_output);
       }
-      return detail::destructive_bisimulation_compare_dnj(l1,l2, false,false,generate_counter_examples,structured_output);
+      return detail::destructive_bisimulation_compare_dnj(l1,l2, false,false,generate_counter_examples,counter_example_file,structured_output);
     }
     case lts_eq_bisim_gv:
     {
-      return detail::destructive_bisimulation_compare(l1,l2, false,false,generate_counter_examples,structured_output);
+      return detail::destructive_bisimulation_compare(l1,l2, false,false,generate_counter_examples,counter_example_file,structured_output);
     }
     case lts_eq_bisim_gjkw:
     {
-      return detail::destructive_bisimulation_compare_gjkw(l1,l2, false,false,generate_counter_examples,structured_output);
+      return detail::destructive_bisimulation_compare_gjkw(l1,l2, false,false,generate_counter_examples,counter_example_file,structured_output);
     }
     case lts_eq_branching_bisim:
     {
       if (generate_counter_examples)
       {
         mCRL2log(mcrl2::log::warning) << "The default branching bisimulation comparison algorithm cannot generate counter examples. Therefore the slower gv algorithm is used instead.\n";
-        return detail::destructive_bisimulation_compare(l1,l2, true,false,generate_counter_examples,structured_output);
+        return detail::destructive_bisimulation_compare(l1,l2, true,false,generate_counter_examples,counter_example_file,structured_output);
       }
-      return detail::destructive_bisimulation_compare_dnj(l1,l2, true,false,generate_counter_examples,structured_output);
+      return detail::destructive_bisimulation_compare_dnj(l1,l2, true,false,generate_counter_examples,counter_example_file,structured_output);
     }
     case lts_eq_branching_bisim_gv:
     {
-      return detail::destructive_bisimulation_compare(l1,l2, true,false,generate_counter_examples,structured_output);
+      return detail::destructive_bisimulation_compare(l1,l2, true,false,generate_counter_examples,counter_example_file,structured_output);
     }
     case lts_eq_branching_bisim_gjkw:
     {
-      return detail::destructive_bisimulation_compare_gjkw(l1,l2, true,false,generate_counter_examples,structured_output);
+      return detail::destructive_bisimulation_compare_gjkw(l1,l2, true,false,generate_counter_examples,counter_example_file,structured_output);
     }
     case lts_eq_divergence_preserving_branching_bisim:
     {
       if (generate_counter_examples)
       {
         mCRL2log(mcrl2::log::warning) << "The default divergence-preserving branching bisimulation comparison algorithm cannot generate counter examples. Therefore the slower gv algorithm is used instead.\n";
-        return detail::destructive_bisimulation_compare(l1,l2, true,true,generate_counter_examples,structured_output);
+        return detail::destructive_bisimulation_compare(l1,l2, true,true,generate_counter_examples,counter_example_file,structured_output);
       }
-      return detail::destructive_bisimulation_compare_dnj(l1,l2, true,true,generate_counter_examples,structured_output);
+      return detail::destructive_bisimulation_compare_dnj(l1,l2, true,true,generate_counter_examples,counter_example_file,structured_output);
     }
     case lts_eq_divergence_preserving_branching_bisim_gv:
     {
-      return detail::destructive_bisimulation_compare(l1,l2, true,true,generate_counter_examples,structured_output);
+      return detail::destructive_bisimulation_compare(l1,l2, true,true,generate_counter_examples,counter_example_file,structured_output);
     }
     case lts_eq_divergence_preserving_branching_bisim_gjkw:
     {
-      return detail::destructive_bisimulation_compare_gjkw(l1,l2, true,true,generate_counter_examples,structured_output);
+      return detail::destructive_bisimulation_compare_gjkw(l1,l2, true,true,generate_counter_examples,counter_example_file,structured_output);
     }
     case lts_eq_weak_bisim:
     {
@@ -181,7 +183,7 @@ bool destructive_compare(LTS_TYPE& l1,
       determinise(l2);
 
       // Trace equivalence now corresponds to bisimilarity
-      return detail::destructive_bisimulation_compare(l1,l2,false,false,generate_counter_examples,structured_output);
+      return detail::destructive_bisimulation_compare(l1,l2,false,false,generate_counter_examples,counter_example_file,structured_output);
     }
     case lts_eq_weak_trace:
     {
@@ -203,7 +205,7 @@ bool destructive_compare(LTS_TYPE& l1,
       determinise(l2);
 
       // Weak trace equivalence now corresponds to bisimilarity
-      return detail::destructive_bisimulation_compare(l1,l2,false,false,false,structured_output);
+      return detail::destructive_bisimulation_compare(l1,l2,false,false,false,counter_example_file,structured_output);
     }
     case lts_eq_coupled_sim:
     {
@@ -224,6 +226,7 @@ bool destructive_compare(LTS_TYPE& l1,
  * \param[in] eq The equivalence with respect to which the LTSs will be
  *            compared.
  * \param[in] generate_counter_examples Whether to generate a counter example
+ * \param[in] counter_example_file The file to store the counter example in
  * \retval true if the LTSs are found to be equivalent.
  * \retval false otherwise.
  */
@@ -232,6 +235,7 @@ bool compare(const LTS_TYPE& l1,
              const LTS_TYPE& l2,
              const lts_equivalence eq,
              const bool generate_counter_examples = false,
+             const std::string& counter_example_file = "",
              const bool structured_output = false);
 
 /** \brief Checks whether this LTS is smaller than another LTS according
@@ -241,6 +245,7 @@ bool compare(const LTS_TYPE& l1,
  * \param[in] pre The preorder with respect to which the LTSs will be
  *            compared.
  * \param[in] generate_counter_examples Whether to generate a counter example
+ * \param[in] counter_example_file The file to store the counter example in
  * \param[in] strategy Choose breadth-first or depth-first for exploration strategy
  *            of the antichain algorithms.
  * \param[in] preprocess Whether to allow preprocessing of the given LTSs.
@@ -259,6 +264,7 @@ bool destructive_compare(LTS_TYPE& l1,
                          LTS_TYPE& l2,
                          const lts_preorder pre,
                          const bool generate_counter_example,
+                         const std::string& counter_example_file = "",
                          const bool structured_output = false,
                          const lps::exploration_strategy strategy = lps::es_breadth,
                          const bool preprocess = true);
@@ -269,6 +275,7 @@ bool destructive_compare(LTS_TYPE& l1,
  * \param[in] l2 The second LTS to be compared.
  * \param[in] pre The preorder with respect to which the LTSs will be compared.
  * \param[in] generate_counter_examples Whether to generate a counter example
+ * \param[in] counter_example_file The file to store the counter example in
  * \param[in] strategy Choose breadth-first or depth-first for exploration strategy
  *            of the antichain algorithms.
  * \param[in] preprocess Whether to allow preprocessing of the given LTSs.
@@ -281,6 +288,7 @@ bool compare(const LTS_TYPE&  l1,
              const  LTS_TYPE& l2,
              const lts_preorder pre,
              const bool generate_counter_example,
+             const std::string& counter_example_file = "",
              const bool structured_output = false,
              const lps::exploration_strategy strategy = lps::es_breadth,
              const bool preprocess = true);
@@ -743,7 +751,7 @@ void reduce(LTS_TYPE& l,lts_equivalence eq)
 }
 
 template <class LTS_TYPE>
-bool compare(const LTS_TYPE& l1, const LTS_TYPE& l2, const lts_equivalence eq, const bool generate_counter_examples, const bool structured_output)
+bool compare(const LTS_TYPE& l1, const LTS_TYPE& l2, const lts_equivalence eq, const bool generate_counter_examples, const std::string& counter_example_file, const bool structured_output)
 {
   switch (eq)
   {
@@ -752,21 +760,21 @@ bool compare(const LTS_TYPE& l1, const LTS_TYPE& l2, const lts_equivalence eq, c
     default:
       LTS_TYPE l1_copy(l1);
       LTS_TYPE l2_copy(l2);
-      return destructive_compare(l1_copy,l2_copy,eq,generate_counter_examples,structured_output);
+      return destructive_compare(l1_copy, l2_copy, eq ,generate_counter_examples, counter_example_file, structured_output);
   }
   return false;
 }
 
 template <class LTS_TYPE>
-bool compare(const LTS_TYPE& l1, const LTS_TYPE& l2, const lts_preorder pre, const bool generate_counter_example, const bool structured_output, const lps::exploration_strategy strategy, const bool preprocess)
+bool compare(const LTS_TYPE& l1, const LTS_TYPE& l2, const lts_preorder pre, const bool generate_counter_example, const std::string& counter_example_file, const bool structured_output, const lps::exploration_strategy strategy, const bool preprocess)
 {
   LTS_TYPE l1_copy(l1);
   LTS_TYPE l2_copy(l2);
-  return destructive_compare(l1_copy, l2_copy, pre, generate_counter_example, structured_output, strategy, preprocess);
+  return destructive_compare(l1_copy, l2_copy, pre, generate_counter_example, counter_example_file, structured_output, strategy, preprocess);
 }
 
 template <class LTS_TYPE>
-bool destructive_compare(LTS_TYPE& l1, LTS_TYPE& l2, const lts_preorder pre, const bool generate_counter_example, const bool structured_output, const lps::exploration_strategy strategy, const bool preprocess)
+bool destructive_compare(LTS_TYPE& l1, LTS_TYPE& l2, const lts_preorder pre, const bool generate_counter_example, const std::string& counter_example_file, const bool structured_output, const lps::exploration_strategy strategy, const bool preprocess)
 {
   switch (pre)
   {
@@ -825,7 +833,7 @@ bool destructive_compare(LTS_TYPE& l1, LTS_TYPE& l2, const lts_preorder pre, con
       detail::bisimulation_reduce(l2,false);
 
       // Trace preorder now corresponds to simulation preorder
-      return destructive_compare(l1, l2, lts_pre_sim, generate_counter_example, structured_output, strategy);
+      return destructive_compare(l1, l2, lts_pre_sim, generate_counter_example, counter_example_file, structured_output, strategy);
     }
     case lts_pre_weak_trace:
     {
@@ -838,13 +846,13 @@ bool destructive_compare(LTS_TYPE& l1, LTS_TYPE& l2, const lts_preorder pre, con
       detail::tau_star_reduce(l2);
 
       // Weak trace preorder now corresponds to strong trace preorder
-      return destructive_compare(l1, l2, lts_pre_trace, generate_counter_example, structured_output, strategy);
+      return destructive_compare(l1, l2, lts_pre_trace, generate_counter_example, counter_example_file, structured_output, strategy);
     }
     case lts_pre_trace_anti_chain:
     {
       if (generate_counter_example)
       {
-        detail::counter_example_constructor cec("counter_example_trace_preorder", structured_output);
+        detail::counter_example_constructor cec("counter_example_trace_preorder", counter_example_file, structured_output);
         return destructive_refinement_checker(l1, l2, refinement_type::trace, false, strategy, preprocess, cec);
       }
       return destructive_refinement_checker(l1, l2, refinement_type::trace, false, strategy, preprocess);
@@ -853,7 +861,7 @@ bool destructive_compare(LTS_TYPE& l1, LTS_TYPE& l2, const lts_preorder pre, con
     {
       if (generate_counter_example)
       {
-        detail::counter_example_constructor cec("counter_example_weak_trace_preorder", structured_output);
+        detail::counter_example_constructor cec("counter_example_weak_trace_preorder", counter_example_file, structured_output);
         return destructive_refinement_checker(l1, l2, refinement_type::trace, true, strategy, preprocess, cec);
       }
       return destructive_refinement_checker(l1, l2, refinement_type::trace, true, strategy, preprocess);
@@ -862,7 +870,7 @@ bool destructive_compare(LTS_TYPE& l1, LTS_TYPE& l2, const lts_preorder pre, con
     {
       if (generate_counter_example)
       {
-        detail::counter_example_constructor cec("counter_example_failures_refinement", structured_output);
+        detail::counter_example_constructor cec("counter_example_failures_refinement", counter_example_file, structured_output);
         return destructive_refinement_checker(l1, l2, refinement_type::failures, false, strategy, preprocess, cec);
       }
       return destructive_refinement_checker(l1, l2, refinement_type::failures, false, strategy, preprocess);
@@ -871,7 +879,7 @@ bool destructive_compare(LTS_TYPE& l1, LTS_TYPE& l2, const lts_preorder pre, con
     {
       if (generate_counter_example)
       {
-        detail::counter_example_constructor cec("counter_example_weak_failures_refinement", structured_output);
+        detail::counter_example_constructor cec("counter_example_weak_failures_refinement", counter_example_file, structured_output);
         return destructive_refinement_checker(l1, l2, refinement_type::failures, true, strategy, preprocess, cec);
       }
       return destructive_refinement_checker(l1, l2, refinement_type::failures, true, strategy, preprocess);
@@ -880,7 +888,7 @@ bool destructive_compare(LTS_TYPE& l1, LTS_TYPE& l2, const lts_preorder pre, con
     {
       if (generate_counter_example)
       {
-        detail::counter_example_constructor cec("counter_example_failures_divergence_refinement", structured_output);
+        detail::counter_example_constructor cec("counter_example_failures_divergence_refinement", counter_example_file, structured_output);
         return destructive_refinement_checker(l1, l2, refinement_type::failures_divergence, true, strategy, preprocess, cec);
       }
       return destructive_refinement_checker(l1, l2, refinement_type::failures_divergence, true, strategy, preprocess);

--- a/libraries/lts/source/exploration.cpp
+++ b/libraries/lts/source/exploration.cpp
@@ -1080,7 +1080,7 @@ void lps2lts_algorithm::get_transitions(const lps::state& state,
         std::string filename_divergence_loop = m_options.trace_prefix + "_divergence_loop" + std::to_string(m_traces_saved);
         check_divergence<detail::counter_example_constructor>(
                 detail::state_index_pair<detail::counter_example_constructor>(state,detail::counter_example_constructor::root_index()),
-                detail::counter_example_constructor(filename_divergence_loop, structured_output));
+                detail::counter_example_constructor(filename_divergence_loop, "", structured_output));
       }
       else
       {

--- a/tools/release/ltscompare/ltscompare.cpp
+++ b/tools/release/ltscompare/ltscompare.cpp
@@ -34,6 +34,7 @@ struct t_tool_options
   mcrl2::lps::exploration_strategy strategy = mcrl2::lps::es_breadth;
   std::vector<std::string> tau_actions;   // Actions with these labels must be considered equal to tau.
   bool generate_counter_examples = false;
+  std::string counter_example_file = "";
   bool structured_output = false;
   bool enable_preprocessing      = true;
 };
@@ -100,7 +101,7 @@ class ltscompare_tool : public ltscompare_base
         mCRL2log(verbose) << "comparing LTSs using " <<
                      tool_options.equivalence << "..." << std::endl;
 
-        result = destructive_compare(l1, l2, tool_options.equivalence, tool_options.generate_counter_examples, tool_options.structured_output);
+        result = destructive_compare(l1, l2, tool_options.equivalence, tool_options.generate_counter_examples, tool_options.counter_example_file, tool_options.structured_output);
 
         mCRL2log(info) << "LTSs are " << ((result) ? "" : "not ")
                        << "equal ("
@@ -113,7 +114,7 @@ class ltscompare_tool : public ltscompare_base
                      description(tool_options.preorder) << "..."
                      " using the " << print_exploration_strategy(tool_options.strategy) << " strategy.\n";
 
-        result = destructive_compare(l1, l2, tool_options.preorder, tool_options.generate_counter_examples, tool_options.structured_output, tool_options.strategy, tool_options.enable_preprocessing);
+        result = destructive_compare(l1, l2, tool_options.preorder, tool_options.generate_counter_examples, tool_options.counter_example_file, tool_options.structured_output, tool_options.strategy, tool_options.enable_preprocessing);
 
         if (!tool_options.structured_output)
         {
@@ -251,7 +252,9 @@ class ltscompare_tool : public ltscompare_base
                  "be internal (tau) actions in addition to those defined as such by "
                  "the input").
       add_option("counter-example",
-                 "generate counter example if the input lts's are not equivalent",'c');
+                 "generate counter example if the input lts's are not equivalent",'c').
+      add_option("counter-example-file", mcrl2::utilities::make_file_argument("NAME"),
+                 "the file to which the counterexample should be written");
       desc.add_hidden_option("structured-output",
                  "generate counter examples on stdout");
       desc.add_hidden_option("no-preprocessing",
@@ -296,6 +299,12 @@ class ltscompare_tool : public ltscompare_base
       }
 
       tool_options.generate_counter_examples = parser.has_option("counter-example");
+
+      if (parser.has_option("counter-example-file"))
+      {
+        tool_options.counter_example_file = parser.option_argument("counter-example-file");
+      }
+
       tool_options.structured_output = parser.has_option("structured-output");
 
       if (parser.arguments.size() == 1)

--- a/tools/release/ltscompare/ltscompare.cpp
+++ b/tools/release/ltscompare/ltscompare.cpp
@@ -251,7 +251,7 @@ class ltscompare_tool : public ltscompare_base
                  "be internal (tau) actions in addition to those defined as such by "
                  "the input").
       add_option("counter-example",
-                 "generate counter example traces if the input lts's are not equivalent",'c');
+                 "generate counter example if the input lts's are not equivalent",'c');
       desc.add_hidden_option("structured-output",
                  "generate counter examples on stdout");
       desc.add_hidden_option("no-preprocessing",


### PR DESCRIPTION
This pull request replaces the counter example option of ltscompare that returns traces on inequivalence with one that returns a distinguishing formula on inequivalence, based on the work of Rance Cleaveland and Henri Korver.
It also adds an option to ltscompare to specify the file in which the counter example should be saved.