### PR TITLE
Fix capture avoiding substitutions for LPSs and use in lpsparunfold

### DIFF
--- a/libraries/lps/include/mcrl2/lps/replace_capture_avoiding.h
+++ b/libraries/lps/include/mcrl2/lps/replace_capture_avoiding.h
@@ -41,7 +41,7 @@ struct add_capture_avoiding_replacement: public process::detail::add_capture_avo
   {
     x.summation_variables() = v;
     x.condition() = apply(x.condition());
-    apply(x.multi_action());
+    x.multi_action() = apply(x.multi_action());
     x.assignments() = apply(x.assignments());
   }
 
@@ -64,11 +64,12 @@ struct add_capture_avoiding_replacement: public process::detail::add_capture_avo
 
   void update(deadlock_summand& x)
   {
-    data::variable_list v1 = sigma.add_fresh_variable_assignments(x.summation_variables());
+    data::variable_list sumvars = x.summation_variables();
+    data::variable_list v1 = sigma.add_fresh_variable_assignments(sumvars);
     x.summation_variables() = v1;
     x.condition() = apply(x.condition());
     update(x.deadlock());
-    sigma.remove_fresh_variable_assignments(x.summation_variables());
+    sigma.remove_fresh_variable_assignments(sumvars);
   }
 
   template <typename LinearProcess>

--- a/libraries/lps/include/mcrl2/lps/replace_capture_avoiding_with_an_identifier_generator.h
+++ b/libraries/lps/include/mcrl2/lps/replace_capture_avoiding_with_an_identifier_generator.h
@@ -45,7 +45,7 @@ struct add_capture_avoiding_replacement_with_an_identifier_generator
   {
     x.summation_variables() = v;
     x.condition() = apply(x.condition());
-    apply(x.multi_action());
+    x.multi_action() = apply(x.multi_action());
     x.assignments() = apply(x.assignments());
   }
 
@@ -64,7 +64,7 @@ struct add_capture_avoiding_replacement_with_an_identifier_generator
     update_sigma.pop(v);
   }
 
-  void apply(deadlock_summand& x)
+  void update(deadlock_summand& x)
   {
     data::variable_list v = update_sigma.push(x.summation_variables());
     x.summation_variables() = v;
@@ -98,7 +98,7 @@ struct add_capture_avoiding_replacement_with_an_identifier_generator
   {
     std::set<data::variable> v = update_sigma(x.global_variables());
     x.global_variables() = v;
-    apply(x.process());
+    update(x.process());
     x.action_labels() = apply(x.action_labels());
     x.initial_process() = apply(x.initial_process());
     update_sigma.pop(v);
@@ -114,7 +114,7 @@ struct add_capture_avoiding_replacement_with_an_identifier_generator
     do_specification(x);
   }
 
-  stochastic_distribution operator()(stochastic_distribution& x)
+  stochastic_distribution apply(stochastic_distribution& x)
   {
     data::variable_list v = update_sigma.push(x.variables());
     stochastic_distribution result(x.variables(), apply(x.distribution()));

--- a/libraries/lps/include/mcrl2/lps/replace_capture_avoiding_with_an_identifier_generator.h
+++ b/libraries/lps/include/mcrl2/lps/replace_capture_avoiding_with_an_identifier_generator.h
@@ -49,14 +49,14 @@ struct add_capture_avoiding_replacement_with_an_identifier_generator
     x.assignments() = apply(x.assignments());
   }
 
-  void apply(action_summand& x)
+  void update(action_summand& x)
   {
     data::variable_list v = update_sigma.push(x.summation_variables());
     do_action_summand(x, v);
     update_sigma.pop(v);
   }
 
-  void apply(stochastic_action_summand& x)
+  void update(stochastic_action_summand& x)
   {
     data::variable_list v = update_sigma.push(x.summation_variables());
     do_action_summand(x, v);
@@ -69,26 +69,26 @@ struct add_capture_avoiding_replacement_with_an_identifier_generator
     data::variable_list v = update_sigma.push(x.summation_variables());
     x.summation_variables() = v;
     x.condition() = apply(x.condition());
-    apply(x.deadlock());
+    update(x.deadlock());
     update_sigma.pop(v);
   }
 
   template<typename LinearProcess>
-  void do_linear_process(const LinearProcess& x)
+  void do_linear_process(LinearProcess& x)
   {
     data::variable_list v = update_sigma.push(x.process_parameters());
     x.process_parameters() = v;
-    apply(x.action_summands());
-    apply(x.deadlock_summands());
+    update(x.action_summands());
+    update(x.deadlock_summands());
     update_sigma.pop(v);
   }
 
-  void apply(linear_process& x)
+  void update(linear_process& x)
   {
     do_linear_process(x);
   }
 
-  void apply(stochastic_linear_process& x)
+  void update(stochastic_linear_process& x)
   {
     do_linear_process(x);
   }

--- a/libraries/lps/source/lpsparunfoldlib.cpp
+++ b/libraries/lps/source/lpsparunfoldlib.cpp
@@ -509,16 +509,14 @@ mcrl2::lps::stochastic_linear_process lpsparunfold::update_linear_process(const 
   // update the summands in new_lps
   unfold_summands(new_lps.action_summands(), determine_function, projection_functions);
 
-  new_lps.process_parameters() = mcrl2::data::variable_list(new_process_parameters.begin(), new_process_parameters.end());
+  // Replace occurrences of unfolded parameters by the corresponding case function
+  mutable_map_substitution< std::map< mcrl2::data::variable , mcrl2::data::data_expression > > s{parsub};
+  lps::replace_variables_capture_avoiding( new_lps, s );
 
-  for (auto i = parsub.begin()
-       ; i != parsub.end()
-       ; ++i)
-  {
-    mutable_map_substitution< std::map< mcrl2::data::variable , mcrl2::data::data_expression > > s;
-    s[ i->first ] = i->second;
-    mcrl2::lps::replace_variables( new_lps, s );
-  }
+  // NB: order is important. If we first replace the parameters, they are changed
+  // again when performing the capture avoiding substitution, most likely leading
+  // to an LPS that is not well-formed.
+  new_lps.process_parameters() = mcrl2::data::variable_list(new_process_parameters.begin(), new_process_parameters.end());
 
   mCRL2log(debug) << "\nNew LPS:\n" <<  lps::pp(new_lps) << std::endl;
 

--- a/libraries/lps/source/lpsparunfoldlib.cpp
+++ b/libraries/lps/source/lpsparunfoldlib.cpp
@@ -31,7 +31,7 @@ lpsparunfold::lpsparunfold(mcrl2::lps::stochastic_specification spec,
     std::map< mcrl2::data::sort_expression , lspparunfold::unfold_cache_element > *cache,
     bool add_distribution_laws
 )
-  : 
+  :
     m_cache(cache),
     m_data_specification(spec.data()),
     m_representative_generator(m_data_specification),
@@ -57,7 +57,7 @@ lpsparunfold::lpsparunfold(mcrl2::lps::stochastic_specification spec,
 
   {
     std::size_t size = mapping_and_constructor_names.size();
-    for (const function_symbol& f: m_data_specification.constructors()) 
+    for (const function_symbol& f: m_data_specification.constructors())
     {
       mapping_and_constructor_names.insert(f.name());
     };
@@ -221,7 +221,7 @@ std::map<function_symbol, data_expression_vector> lpsparunfold::create_arguments
     data_expression_vector arguments;
     if (is_function_sort(f.sort()))
     {
-      const function_sort& fs = atermpp::down_cast<function_sort>(f.sort()); 
+      const function_sort& fs = atermpp::down_cast<function_sort>(f.sort());
       for (const sort_expression& sort: fs.domain())
       {
         if (sort_vars[sort].size() == sort_index[sort])
@@ -287,7 +287,7 @@ void lpsparunfold::create_data_equations(
       /* Equations for projection functions */
       for(const data_expression& arg: function_arguments)
       {
-        data_expression lhs = application(projection_functions.at(projection_function_index), 
+        data_expression lhs = application(projection_functions.at(projection_function_index),
                                           application(f, function_arguments.begin(), function_arguments.end()));
         add_new_equation(lhs,arg);
 
@@ -306,9 +306,9 @@ void lpsparunfold::create_data_equations(
             }
             else
             {
-              lhs = application(projection_functions.at(projection_function_index), 
-                                application(alternative_f, 
-                                            arguments_of_alternative_f.begin(), 
+              lhs = application(projection_functions.at(projection_function_index),
+                                application(alternative_f,
+                                            arguments_of_alternative_f.begin(),
                                             arguments_of_alternative_f.end()));
             }
             try
@@ -318,7 +318,7 @@ void lpsparunfold::create_data_equations(
             }
             catch (mcrl2::runtime_error& e)
             {
-              mCRL2log(debug) << "Failed to generate equation " << lhs << "= ... as no default term of sort " << lhs.sort() << 
+              mCRL2log(debug) << "Failed to generate equation " << lhs << "= ... as no default term of sort " << lhs.sort() <<
                                  " could be generated.\n" << e.what() << "\n";
             }
           }
@@ -526,8 +526,8 @@ mcrl2::lps::stochastic_linear_process lpsparunfold::update_linear_process(const 
 }
 
 mcrl2::lps::stochastic_process_initializer lpsparunfold::update_linear_process_initialization(
-                   const data::function_symbol& determine_function, 
-                   std::size_t parameter_at_index, 
+                   const data::function_symbol& determine_function,
+                   std::size_t parameter_at_index,
                    const function_symbol_vector& projection_functions)
 {
   //
@@ -554,7 +554,7 @@ mcrl2::lps::stochastic_process_initializer lpsparunfold::update_linear_process_i
     index++;
   }
 
-  const mcrl2::lps::stochastic_process_initializer new_init(mcrl2::data::data_expression_list(new_ass_right.begin(), new_ass_right.end()), 
+  const mcrl2::lps::stochastic_process_initializer new_init(mcrl2::data::data_expression_list(new_ass_right.begin(), new_ass_right.end()),
                                                             m_init_process.distribution());
   mCRL2log(debug) << "Expressions for the new initial state: " << lps::pp(new_init) << std::endl;
 


### PR DESCRIPTION
The tool `lpsparunfold` should perform its substitutions in a capture-avoiding manner, as per the example in issue #1669. These changes achieve just that, and fix the capture-avoiding substitutions for LPSs along the way. They were broken because the wrong name was picked to some functions, meaning that they were never called by the builder framework.