### PR TITLE
Add PBESSMT tools

### DIFF
--- a/tools/experimental/CMakeLists.txt
+++ b/tools/experimental/CMakeLists.txt
@@ -5,6 +5,8 @@ set(MCRL2_TOOLS
   lpscombine
   lpsrealelm
   lpssymbolicbisim
+  pbes2cvc4
+  pbes2yices
   pbesabsinthe
   pbespareqelm
   pbespor

--- a/tools/experimental/pbes2cvc4/CMakeLists.txt
+++ b/tools/experimental/pbes2cvc4/CMakeLists.txt
@@ -1,0 +1,11 @@
+add_mcrl2_tool(pbes2cvc4
+        SOURCES
+        pbes2cvc4.cpp
+        data.cpp
+        unrolling.cpp
+        DEPENDS
+        mcrl2_data
+        mcrl2_bes
+        mcrl2_pbes
+        mcrl2_utilities
+        )

--- a/tools/experimental/pbes2cvc4/data.cpp
+++ b/tools/experimental/pbes2cvc4/data.cpp
@@ -1,0 +1,726 @@
+// Author(s): Ruud Koolen
+// Copyright: see the accompanying file COPYING or copy at
+// https://svn.win.tue.nl/trac/MCRL2/browser/trunk/COPYING
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#include <cstdio>
+
+#include "pbes2cvc4.h"
+
+#include "mcrl2/utilities/exception.h"
+
+#include "mcrl2/data/bool.h"
+#include "mcrl2/data/int.h"
+#include "mcrl2/data/nat.h"
+#include "mcrl2/data/pos.h"
+#include "mcrl2/data/real.h"
+#include "mcrl2/data/list.h"
+#include "mcrl2/data/replace.h"
+#include "mcrl2/data/representative_generator.h"
+
+using namespace mcrl2;
+using namespace mcrl2::data;
+
+// Topological sort.
+template<class T> std::vector<T> tsort(std::map<T, std::set<T> > dependencies)
+{
+	std::map<T, std::set<T> > reverse_dependencies;
+	for (typename std::map<T, std::set<T> >::const_iterator i = dependencies.begin(); i != dependencies.end(); i++) {
+		reverse_dependencies[i->first] = std::set<T>();
+	}
+	for (typename std::map<T, std::set<T> >::const_iterator i = dependencies.begin(); i != dependencies.end(); i++) {
+		for (typename std::set<T>::const_iterator j = i->second.begin(); j != i->second.end(); j++) {
+			reverse_dependencies[*j].insert(i->first);
+		}
+	}
+	
+	std::vector<T> output;
+	for (typename std::map<T, std::set<T> >::const_iterator i = dependencies.begin(); i != dependencies.end(); i++) {
+		if (i->second.empty()) {
+			output.push_back(i->first);
+		}
+	}
+	
+	size_t index = 0;
+	while (index < output.size()) {
+		T vertex = output[index];
+		index++;
+		
+		const std::set<T> &edges = reverse_dependencies.at(vertex);
+		for (typename std::set<T>::const_iterator i = edges.begin(); i != edges.end(); i++) {
+			if (dependencies[*i].erase(vertex) && dependencies[*i].empty()) {
+				output.push_back(*i);
+			}
+		}
+	}
+	
+	for (typename std::map<T, std::set<T> >::const_iterator i = dependencies.begin(); i != dependencies.end(); i++) {
+		for (typename std::set<T>::const_iterator j = i->second.begin(); j != i->second.end(); j++) {
+			std::cerr << i->first << " depends on " << *j << "\n";
+		}
+	}
+	for (typename std::map<T, std::set<T> >::const_iterator i = dependencies.begin(); i != dependencies.end(); i++) {
+		if (!i->second.empty()) {
+			throw mcrl2::runtime_error("Dependency loop");
+		}
+	}
+	
+	return output;
+}
+
+// Find all sorts that need to be defined in yices, ordered by dependency structure.
+static std::vector<mcrl2::data::sort_expression> order_sorts(const data_specification &data, const std::set<sort_expression> &used_sorts)
+{
+	std::map<sort_expression, std::set<sort_expression> > sort_dependencies;
+	for (std::set<sort_expression>::const_iterator i = used_sorts.begin(); i != used_sorts.end(); i++) {
+		if (*i == sort_bool::bool_() ||
+		    *i == sort_pos::pos() ||
+		    *i == sort_nat::nat() ||
+		    *i == sort_int::int_() ||
+		    *i == sort_real::real_())
+		{
+			sort_dependencies[*i] = std::set<sort_expression>();
+		} else if (is_container_sort(*i)) {
+			std::set<sort_expression> dependencies;
+			sort_expression base_sort = container_sort(*i).element_sort();
+			dependencies.insert(base_sort);
+			sort_dependencies[*i] = dependencies;
+		} else if (is_basic_sort(*i)) {
+			std::set<sort_expression> dependencies;
+			function_symbol_vector constructors = data.constructors(*i);
+			for (function_symbol_vector::iterator j = constructors.begin(); j != constructors.end(); j++) {
+				if (is_function_sort(j->sort())) {
+					sort_expression_list domain = function_sort(j->sort()).domain();
+					for (sort_expression_list::iterator k = domain.begin(); k != domain.end(); k++) {
+						if (sort_expression(*k) != *i) {
+							dependencies.insert(sort_expression(*k));
+						}
+					}
+				}
+			}
+			sort_dependencies[*i] = dependencies;
+		}
+	}
+	
+	try {
+		return tsort(sort_dependencies);
+	} catch(mcrl2::runtime_error e) {
+		throw mcrl2::runtime_error("Mutually recursive types detected, giving up.");
+	}
+}
+
+std::string translate_expression(data_expression expression, const std::map<variable, std::string> &bound_variables, const translated_data_specification &translation)
+{
+	if (sort_real::is_creal_application(expression)) {
+		application a(expression);
+		return "(/ " + translate_expression(*a.begin(), bound_variables, translation) + " " + translate_expression(*++a.begin(), bound_variables, translation) + ")";
+	} else if (sort_int::is_cint_application(expression)) {
+		application a(expression);
+		return translate_expression(*a.begin(), bound_variables, translation);
+	} else if (sort_int::is_cneg_application(expression)) {
+		application a(expression);
+		std::string result = translate_expression(*a.begin(), bound_variables, translation);
+		return "(- " + result + ")";
+	} else if (sort_nat::is_c0_function_symbol(expression)) {
+		return "0";
+	} else if (sort_nat::is_cnat_application(expression)) {
+		application a(expression);
+		return translate_expression(*a.begin(), bound_variables, translation);
+	} else if (sort_pos::is_c1_function_symbol(expression) || sort_pos::is_cdub_application(expression)) {
+		return data::pp(expression);
+	}
+	
+	
+	
+	if (is_function_symbol(expression)) {
+		function_symbol s(expression);
+		assert(translation.function_names.count(s));
+		return translation.function_names.at(s);
+	} else if (is_variable(expression)) {
+		assert(bound_variables.count(variable(expression)));
+		return bound_variables.at(variable(expression));
+	} else if (is_application(expression)) {
+		application a(expression);
+		assert(is_function_symbol(a.head()));
+		
+		assert(translation.function_names.count(function_symbol(a.head())));
+		if (translation.function_names.at(function_symbol(a.head())) == "") {
+			assert(a.size() == 1);
+			return translate_expression(*a.begin(), bound_variables, translation);
+		}
+		
+		std::string output = "(" + translation.function_names.at(function_symbol(a.head()));
+		for (application::const_iterator i = a.begin(); i != a.end(); ++i) {
+			output += " " + translate_expression(*i, bound_variables, translation);
+		}
+		output += ")";
+		return output;
+	} else {
+		throw mcrl2::runtime_error("Unable to translate expression " + data::pp(expression) + ", giving up.");
+	}
+}
+
+std::string define_variable(const translated_data_specification &translation, std::string name, mcrl2::data::sort_expression sort)
+{
+	if (sort == sort_pos::pos()) {
+		return "(declare-fun " + name + " () Int)\n"
+		       "(assert (>= " + name + " 1))\n";
+	} else if (sort == sort_nat::nat()) {
+		return "(declare-fun " + name + " () Int)\n"
+		       "(assert (>= " + name + " 0))\n";
+	} else {
+		assert(translation.sort_names.count(sort) > 0);
+		return "(declare-fun " + name + " () " + translation.sort_names.at(sort) + ")\n";
+	}
+}
+
+std::string sanitize_term(std::string term)
+{
+	if (term == "-") return "minus";
+	if (term == "[]") return "emptylist";
+	if (term == "|>") return "cons";
+	if (term == "<|") return "snoc";
+	if (term == "#") return "count";
+	if (term == "++") return "concat_";
+	if (term == ".") return "at";
+	for (size_t i = 0; i < term.size(); i++) {
+		if (term[i] == '\'') term[i] = '_';
+		if (term[i] == '@') term[i] = '_';
+		
+	}
+	return term;
+}
+
+static std::string mangle_sort_name(sort_expression sort)
+{
+	sort_expression base_sort = sort;
+	std::string name_prefix = "";
+	while (is_container_sort(base_sort)) {
+		container_sort container(base_sort);
+		name_prefix += container.container_name().function().name();
+		name_prefix += "-";
+		base_sort = container.element_sort();
+	}
+	assert(is_basic_sort(base_sort));
+	
+	std::string base_name = sanitize_term(basic_sort(base_sort).name());
+	return name_prefix + base_name;
+}
+
+static bool is_structured_sort(const mcrl2::data::data_specification &data, mcrl2::data::sort_expression sort)
+{
+	if (sort == sort_nat::natpair()) {
+		return true;
+	}
+	if (sort_list::is_list(sort)) {
+		return true;
+	}
+	for (size_t i = 0; i < data.mappings().size(); i++) {
+		function_symbol mapping = data.mappings()[i];
+		if (std::string(mapping.name()) == "@to_pos" && mapping.sort() == make_function_sort(sort, sort_pos::pos())) {
+			return true;
+		}
+	}
+	return false;
+}
+
+static void translate_sort_definition(const mcrl2::data::data_specification &data, mcrl2::data::sort_expression sort, set_identifier_generator &function_name_generator, translated_data_specification &translation)
+{
+	assert(is_basic_sort(sort) || is_container_sort(sort));
+	
+	if (sort == sort_bool::bool_()) {
+		translation.sort_names[sort] = "Bool";
+		translation.function_names[sort_bool::true_()] = "true";
+		translation.function_names[sort_bool::false_()] = "false";
+	} else if (sort == sort_pos::pos()) {
+		// HACK
+		translation.sort_names[sort] = "Int";
+	} else if (sort == sort_nat::nat()) {
+		// HACK
+		translation.sort_names[sort] = "Int";
+	} else if (sort == sort_int::int_()) {
+		translation.sort_names[sort] = "Int";
+	} else if (sort == sort_real::real_()) {
+		translation.sort_names[sort] = "Real";
+	} else {
+		std::string name = mangle_sort_name(sort);
+		function_symbol_vector constructors = data.constructors(sort);
+		
+		if (constructors.size() == 0) {
+			translation.sort_names[sort] = name;
+			translation.definition += "(declare-sort " + name + " 0)\n";
+		} else if (!is_structured_sort(data, sort)) {
+			throw mcrl2::runtime_error("Non-structured constructed sort " + data::pp(sort) + " found, giving up.");
+		} else {
+			translation.sort_names[sort] = name;
+			translation.definition += "(declare-datatypes () ( (" + name + "\n";
+			
+			int index = 0;
+			for (function_symbol_vector::iterator i = constructors.begin(); i != constructors.end(); i++) {
+				std::string constructor_name = sanitize_term(i->name());
+				if (function_name_generator.has_identifier(constructor_name)) {
+					constructor_name = name + "-" + constructor_name;
+				}
+				constructor_name = function_name_generator(constructor_name);
+				
+				translation.function_names[*i] = constructor_name;
+				translation.constructor_field_names[*i] = std::vector<std::string>();
+				
+				if (is_function_sort(i->sort())) {
+					translation.definition += "  ( " + constructor_name;
+					sort_expression_list domain = function_sort(i->sort()).domain();
+					for (sort_expression_list::iterator j = domain.begin(); j != domain.end(); j++) {
+						assert(translation.sort_names.count(*j) > 0);
+						std::string sort_name = translation.sort_names[*j];
+						std::string parameter_name = function_name_generator(name + itoa(index++));
+						
+						translation.definition += " (" + parameter_name + " " + sort_name + ")";
+						translation.constructor_field_names[*i].push_back(parameter_name);
+					}
+					translation.definition += ")\n";
+				} else {
+					translation.definition += "  ( " + constructor_name + ")\n";
+				}
+			}
+			
+			translation.definition += ")))\n";
+		}
+	}
+}
+
+class function_definition
+{
+	public:
+	enum function_definition_type { builtin_type, equations_type, identity_type, unavailable_type };
+	
+	protected:
+	function_definition_type m_type;
+	std::string m_name;
+	std::vector<data_equation> m_equations;
+	
+	public:
+	function_definition(): m_type(unavailable_type) {}
+	function_definition(const char *name): m_type(builtin_type), m_name(name) {}
+	function_definition(std::string name): m_type(builtin_type), m_name(name) {}
+	function_definition(const std::vector<data_equation> equations): m_type(equations_type), m_equations(equations) {}
+	function_definition(data_equation definition): m_type(equations_type)
+	{
+		m_equations.push_back(definition);
+	}
+	
+	protected:
+	function_definition(function_definition_type type, std::string name, const std::vector<data_equation> equations):
+		m_type(type),
+		m_name(name),
+		m_equations(equations)
+	{}
+	
+	public:
+	static function_definition unavailable() { return function_definition(unavailable_type, "", std::vector<data_equation>()); }
+	static function_definition identity() { return function_definition(identity_type, "", std::vector<data_equation>()); }
+	
+	bool is_builtin() const { return m_type == builtin_type; }
+	bool is_equations() const { return m_type == equations_type; }
+	bool is_identity() const { return m_type == identity_type; }
+	bool is_unavailable() const { return m_type == unavailable_type; }
+	const std::string &name() const { return m_name; }
+	const std::vector<data_equation> &equations() const { return m_equations; }
+};
+
+static void add_undefined_functions(std::map<mcrl2::data::function_symbol, function_definition> &function_definitions, const function_symbol_vector &functions)
+{
+	for (function_symbol_vector::const_iterator i = functions.begin(); i != functions.end(); i++) {
+		std::string name = i->name();
+		if (name[0] == '@' && function_definitions.count(*i) == 0) {
+			function_definitions[*i] = function_definition::unavailable();
+		}
+	}
+}
+
+// Constructs a list of all mcrl2 types and functions that map to yices builtins.
+static std::map<mcrl2::data::function_symbol, function_definition> builtin_function_map()
+{
+	std::map<function_symbol, function_definition> output;
+	
+	basic_sort bool_ = sort_bool::bool_();
+	basic_sort pos = sort_pos::pos();
+	basic_sort nat = sort_nat::nat();
+	basic_sort int_ = sort_int::int_();
+	basic_sort real = sort_real::real_();
+	
+	
+	variable b("b", bool_);
+	variable p("p", pos);
+	variable p2("p2", pos);
+	variable n("n", nat);
+	variable n2("n2", nat);
+	variable i("i", int_);
+	variable i2("i2", int_);
+	variable r("r", real);
+	variable r2("r2", real);
+	
+	
+	output[sort_bool::not_()] = "not";
+	output[sort_bool::and_()] = "and";
+	output[sort_bool::or_()] = "or";
+	output[sort_bool::implies()] = "=>";
+	
+	
+	function_symbol pos_one("one", pos);
+	output[pos_one] = "1";
+	
+	output[less(pos)] = "<";
+	output[less_equal(pos)] = "<=";
+	output[greater(pos)] = ">";
+	output[greater_equal(pos)] = ">=";
+	output[sort_pos::plus()] = "+";
+	output[sort_pos::times()] = "*";
+	output[sort_pos::succ()] = data_equation(variable_list({p}), sort_pos::succ(p), sort_pos::plus(p, pos_one));
+	output[sort_pos::add_with_carry()] = data_equation(variable_list({b, p, p2}), sort_pos::add_with_carry(b, p, p2), if_(b, sort_pos::succ(sort_pos::plus(p, p2)), sort_pos::plus(p, p2)));
+	
+	
+	function_symbol nat_zero("zero", nat);
+	output[nat_zero] = "0";
+	function_symbol nat_one("one", nat);
+	output[nat_one] = "1";
+	function_symbol nat_two("two", nat);
+	output[nat_two] = "2";
+	function_symbol nat_minus("-", function_sort(sort_expression_list({nat, nat}), nat));
+	output[nat_minus] = "-";
+	//function_symbol nat_do_exp("exp", function_sort(make_list(pos, nat), pos));
+	//output[nat_do_exp] = data_equation(atermpp::make_vector(p, n), nat_do_exp(p, n), if_(equal_to(n, nat_one), p, if_(equal_to(sort_nat::mod(n, nat_two), nat_one), sort_pos::times(p, nat_do_exp(sort_pos::times(p, p), sort_nat::div(n, nat_two))), nat_do_exp(sort_pos::times(p, p), sort_nat::div(n, nat_two)))));
+	
+	output[less(nat)] = "<";
+	output[less_equal(nat)] = "<=";
+	output[greater(nat)] = ">";
+	output[greater_equal(nat)] = ">=";
+	output[sort_nat::pos2nat()] = function_definition::identity();
+	output[sort_nat::nat2pos()] = function_definition::identity();
+	output[sort_nat::maximum(pos, nat)] = data_equation(variable_list({p, n}), sort_nat::maximum(p, n), sort_nat::nat2pos(sort_nat::maximum(sort_nat::pos2nat(p), n)));
+	output[sort_nat::maximum(nat, pos)] = data_equation(variable_list({n, p}), sort_nat::maximum(n, p), sort_nat::nat2pos(sort_nat::maximum(sort_nat::pos2nat(p), n)));
+	output[sort_nat::succ(nat)] = data_equation(variable_list({n}), sort_nat::succ(n), sort_nat::plus(n, nat_one));
+	output[sort_nat::pred()] = data_equation(variable_list({p}), sort_nat::pred(p), nat_minus(sort_nat::pos2nat(p), nat_one));
+	output[sort_nat::plus(pos, nat)] = "+";
+	output[sort_nat::plus(nat, pos)] = "+";
+	output[sort_nat::plus(nat, nat)] = "+";
+	output[sort_nat::times(nat, nat)] = "*";
+	output[sort_nat::div()] = "div";
+	output[sort_nat::mod()] = "mod";
+	output[sort_nat::exp(nat, nat)] = function_definition::unavailable();
+	output[sort_nat::exp(pos, nat)] = function_definition::unavailable();
+	//output[sort_nat::exp(nat, nat)] = data_equation(atermpp::make_vector(n, n2), sort_nat::exp(n, n2), if_(equal_to(n2, nat_zero), n, if_(less(n, nat_two), n, sort_nat::pos2nat(nat_do_exp(sort_nat::nat2pos(n), n2)))));
+	//output[sort_nat::exp(pos, nat)] = data_equation(atermpp::make_vector(p, n2), sort_nat::exp(p, n2), if_(equal_to(n2, nat_zero), p, if_(equal_to(p, pos_one), p, nat_do_exp(p, n2))));
+	
+	
+	function_symbol int_zero("zero", int_);
+	output[int_zero] = "0";
+	function_symbol int_one("one", int_);
+	output[int_one] = "1";
+	
+	output[less(int_)] = "<";
+	output[less_equal(int_)] = "<=";
+	output[greater(int_)] = ">";
+	output[greater_equal(int_)] = ">=";
+	output[sort_int::pos2int()] = function_definition::identity();
+	output[sort_int::int2pos()] = function_definition::identity();
+	output[sort_int::nat2int()] = function_definition::identity();
+	output[sort_int::int2nat()] = function_definition::identity();
+	output[sort_int::maximum(pos, int_)] = data_equation(variable_list({p, i}), sort_int::maximum(p, i), sort_int::int2pos(sort_int::maximum(sort_int::pos2int(p), i)));
+	output[sort_int::maximum(int_, pos)] = data_equation(variable_list({p, i}), sort_int::maximum(i, p), sort_int::int2pos(sort_int::maximum(i, sort_int::pos2int(p))));
+	output[sort_int::maximum(nat, int_)] = data_equation(variable_list({n, i}), sort_int::maximum(n, i), sort_int::int2nat(sort_int::maximum(sort_int::nat2int(n), i)));
+	output[sort_int::maximum(int_, nat)] = data_equation(variable_list({n, i}), sort_int::maximum(i, n), sort_int::int2nat(sort_int::maximum(i, sort_int::nat2int(n))));
+	output[sort_int::abs()] = "abs";
+	output[sort_int::negate(pos)] = "-";
+	output[sort_int::negate(nat)] = "-";
+	output[sort_int::negate(int_)] = "-";
+	output[sort_int::succ(int_)] = data_equation(variable_list({i}), sort_int::succ(i), sort_int::plus(i, int_one));
+	output[sort_int::pred(nat)] = data_equation(variable_list({n}), sort_int::pred(n), sort_int::minus(sort_int::nat2int(n), int_one));
+	output[sort_int::pred(int_)] = data_equation(variable_list({i}), sort_int::pred(i), sort_int::minus(i, int_one));
+	output[sort_int::plus(int_, int_)] = "+";
+	output[sort_int::minus(pos, pos)] = "-";
+	output[sort_int::minus(nat, nat)] = "-";
+	output[sort_int::minus(int_, int_)] = "-";
+	output[sort_int::times(int_, int_)] = "*";
+	output[sort_int::div(int_, pos)] = "div";
+	output[sort_int::mod(int_, pos)] = "mod";
+	output[sort_int::exp(int_, nat)] = function_definition::unavailable();
+	//output[sort_int::exp(int_, nat)] = data_equation(atermpp::make_vector(i, n), sort_int::exp(i, n), if_(equal_to(sort_nat::mod(n, nat_two), nat_zero), sort_int::nat2int(sort_nat::exp(sort_int::abs(i), n)), sort_int::minus(int_zero, sort_int::nat2int(sort_nat::exp(sort_int::abs(i), n)))));
+	
+	
+	function_symbol real_zero("zero", real);
+	output[real_zero] = "0";
+	function_symbol real_one("one", real);
+	output[real_one] = "1";
+	function_symbol real_half("half", real);
+	output[real_half] = "(/ 1 2)";
+	function_symbol real_div("div", function_sort(sort_expression_list({real, pos}), int_));
+	output[real_div] = "div";
+	//function_symbol real_do_exp("exp", function_sort(make_list(real, nat), real));
+	//output[real_do_exp] = data_equation(atermpp::make_vector(r, n), real_do_exp(r, n), if_(equal_to(n, nat_one), r, if_(equal_to(sort_nat::mod(n, nat_two), nat_one), sort_real::times(r, real_do_exp(sort_pos::times(r, r), sort_nat::div(n, nat_two))), real_do_exp(sort_real::times(r, r), sort_nat::div(n, nat_two)))));
+	
+	output[less(real)] = "<";
+	output[less_equal(real)] = "<=";
+	output[greater(real)] = ">";
+	output[greater_equal(real)] = ">=";
+	output[sort_real::pos2real()] = function_definition::identity();
+	output[sort_real::real2pos()] = function_definition::identity();
+	output[sort_real::nat2real()] = function_definition::identity();
+	output[sort_real::real2nat()] = function_definition::identity();
+	output[sort_real::int2real()] = function_definition::identity();
+	output[sort_real::real2int()] = function_definition::identity();
+	output[sort_real::creal()] = "/";
+	output[sort_real::abs(real)] = "abs";
+	output[sort_real::negate(real)] = "-";
+	output[sort_real::succ(real)] = data_equation(variable_list({r}), sort_real::succ(r), sort_real::plus(r, real_one));
+	output[sort_real::pred(real)] = data_equation(variable_list({r}), sort_real::pred(r), sort_real::minus(r, real_one));
+	output[sort_real::plus(real, real)] = "+";
+	output[sort_real::minus(real, real)] = "-";
+	output[sort_real::times(real, real)] = "*";
+	output[sort_real::divides(pos, pos)] = "/";
+	output[sort_real::divides(nat, nat)] = "/";
+	output[sort_real::divides(int_, int_)] = "/";
+	output[sort_real::divides(real, real)] = "/";
+	output[sort_real::exp(real, int_)] = function_definition::unavailable();
+	//output[sort_real::exp(real, int_)] = data_equation(atermpp::make_vector(r, i), sort_real::exp(r, i), if_(equal_to(i, int_zero), real_one, if_(less(i, int_zero), real_do_exp(sort_real::divides(real_one, r), sort_int::abs(i)), real_do_exp(r, sort_int::int2nat(i)))));
+	output[sort_real::floor()] = "to_int";
+	output[sort_real::ceil()] = data_equation(variable_list({r}), sort_real::ceil(r), sort_real::negate(sort_real::floor(sort_real::negate(r))));
+	output[sort_real::round()] = data_equation(variable_list({r}), sort_real::round(r), sort_real::floor(sort_real::plus(r, real_half)));
+	
+	
+	add_undefined_functions(output, sort_bool::bool_generate_functions_code());
+	add_undefined_functions(output, sort_pos::pos_generate_functions_code());
+	add_undefined_functions(output, sort_nat::nat_generate_functions_code());
+	add_undefined_functions(output, sort_int::int_generate_functions_code());
+	add_undefined_functions(output, sort_real::real_generate_functions_code());
+	
+	
+	return output;
+}
+
+
+
+void translate_data_specification(const mcrl2::pbes_system::pbes &pbes, translated_data_specification &translation)
+{
+	const data_specification &data = pbes.data();
+	
+	
+	std::map<mcrl2::data::function_symbol, function_definition> definitions = builtin_function_map();
+
+        const std::set<data_equation>& equations = pbes.data().equations();
+        data_equation_vector effective_equations(equations.begin(), equations.end());
+	for (size_t i = 0; i < effective_equations.size(); ) {
+		function_symbol symbol;
+		if (is_function_symbol(effective_equations[i].lhs())) {
+			symbol = function_symbol(effective_equations[i].lhs());
+		} else if (is_application(effective_equations[i].lhs())) {
+			application lhs(effective_equations[i].lhs());
+			if (is_function_symbol(lhs.head())) {
+				symbol = function_symbol(lhs.head());
+			} else {
+				i++;
+				continue;
+			}
+		} else {
+			i++;
+			continue;
+		}
+		
+		if (is_equal_to_function_symbol(symbol) ||
+		    is_not_equal_to_function_symbol(symbol) ||
+		    is_if_function_symbol(symbol) ||
+		    is_greater_function_symbol(symbol) ||
+		    is_greater_equal_function_symbol(symbol) ||
+		    definitions.count(symbol) > 0)
+		{
+			effective_equations[i] = effective_equations.back();
+			effective_equations.pop_back();
+		} else {
+			i++;
+		}
+	}
+	for (std::map<mcrl2::data::function_symbol, function_definition>::iterator i = definitions.begin(); i != definitions.end(); i++) {
+		if (i->second.is_equations()) {
+			effective_equations.insert(effective_equations.end(), i->second.equations().begin(), i->second.equations().end());
+		}
+	}
+	
+	
+	std::multimap<mcrl2::data::function_symbol, mcrl2::data::data_equation> function_equations;
+	std::multimap<mcrl2::data::data_equation, mcrl2::data::function_symbol> equation_functions;
+	for (data_equation_vector::const_iterator i = effective_equations.begin(); i != effective_equations.end(); i++) {
+		std::set<mcrl2::data::function_symbol> rhs_functions = find_function_symbols(i->rhs());
+		std::set<mcrl2::data::function_symbol> lhs_functions = find_function_symbols(i->lhs());
+		rhs_functions.insert(lhs_functions.begin(), lhs_functions.end());
+		std::set<mcrl2::data::function_symbol> condition_functions = find_function_symbols(i->condition());
+		rhs_functions.insert(condition_functions.begin(), condition_functions.end());
+		
+		for (std::set<mcrl2::data::function_symbol>::iterator j = lhs_functions.begin(); j != lhs_functions.end(); j++) {
+			function_equations.insert(std::pair<mcrl2::data::function_symbol, mcrl2::data::data_equation>(*j, *i));
+		}
+		for (std::set<mcrl2::data::function_symbol>::iterator j = rhs_functions.begin(); j != rhs_functions.end(); j++) {
+			equation_functions.insert(std::pair<mcrl2::data::data_equation, mcrl2::data::function_symbol>(*i, *j));
+		}
+	}
+	
+	
+	std::set<function_symbol> defined_functions;
+	std::set<data_equation> defined_equations;
+	std::set<function_symbol> function_queue = find_function_symbols(pbes);
+	std::set<function_symbol> constructors(data.constructors().begin(), data.constructors().end());
+	for (std::set<function_symbol>::const_iterator i = constructors.begin(); i != constructors.end(); i++) {
+		function_queue.erase(*i);
+	}
+	
+	while (!function_queue.empty()) {
+		function_symbol function = *function_queue.begin();
+		function_queue.erase(function);
+		
+		defined_functions.insert(function);
+		
+		std::multimap<mcrl2::data::function_symbol, mcrl2::data::data_equation>::const_iterator f_begin = function_equations.lower_bound(function);
+		std::multimap<mcrl2::data::function_symbol, mcrl2::data::data_equation>::const_iterator f_end = function_equations.upper_bound(function);
+		for (std::multimap<mcrl2::data::function_symbol, mcrl2::data::data_equation>::const_iterator i = f_begin; i != f_end; i++) {
+			data_equation equation = i->second;
+			defined_equations.insert(equation);
+			
+			std::multimap<mcrl2::data::data_equation, mcrl2::data::function_symbol>::const_iterator e_begin = equation_functions.lower_bound(equation);
+			std::multimap<mcrl2::data::data_equation, mcrl2::data::function_symbol>::const_iterator e_end = equation_functions.upper_bound(equation);
+			for (std::multimap<mcrl2::data::data_equation, mcrl2::data::function_symbol>::const_iterator j = e_begin; j != e_end; j++) {
+				if (constructors.count(j->second) > 0) {
+					continue;
+				}
+				
+				if (defined_functions.count(j->second) == 0) {
+					function_queue.insert(j->second);
+				}
+			}
+		}
+	}
+	
+	
+	set_identifier_generator function_name_generator;
+	
+	
+	
+	std::set<sort_expression> used_sorts = find_sort_expressions(defined_equations);
+	for (std::vector<pbes_system::pbes_equation>::const_iterator i = pbes.equations().begin(); i != pbes.equations().end(); i++) {
+		std::set<pbes_system::propositional_variable_instantiation> instantiations = pbes_system::find_propositional_variable_instantiations(i->formula());
+		for (std::set<pbes_system::propositional_variable_instantiation>::iterator j = instantiations.begin(); j != instantiations.end(); j++) {
+			std::set<sort_expression> sorts = find_sort_expressions(j->parameters());
+			used_sorts.insert(sorts.begin(), sorts.end());
+		}
+		//std::set<sort_expression> equation_sorts = pbes_system::find_sort_expressions(i->formula());
+		//used_sorts.insert(equation_sorts.begin(), equation_sorts.end());
+		//equation_sorts = pbes_system::find_sort_expressions(i->variable());
+		//used_sorts.insert(equation_sorts.begin(), equation_sorts.end());
+	}
+	
+	
+	
+	// Translate all sorts to yices sort definitions.
+	std::vector<sort_expression> sorts = order_sorts(data, used_sorts);
+	for (std::vector<sort_expression>::iterator i = sorts.begin(); i != sorts.end(); i++) {
+		translate_sort_definition(data, *i, function_name_generator, translation);
+		
+		// Equality and inequality must be defined for all sorts.
+		translation.function_names[equal_to(*i)] = "=";
+		translation.function_names[not_equal_to(*i)] = "distinct";
+		
+		variable v1("v1", *i);
+		variable v2("v2", *i);
+		definitions[equal_to(*i)] = "=";
+		definitions[not_equal_to(*i)] = "distinct";
+		definitions[if_(*i)] = "ite";
+		if (!definitions.count(greater(*i))) {
+			definitions[greater(*i)] = data_equation(variable_list({v1, v2}), greater(v1, v2), sort_bool::not_(less_equal(v1, v2)));
+		}
+		if (!definitions.count(greater_equal(*i))) {
+			definitions[greater_equal(*i)] = data_equation(variable_list({v1, v2}), greater_equal(v1, v2), sort_bool::not_(less(v1, v2)));
+		}
+	}
+	// The unrolling code may generate invocations of those functions.
+	translation.function_names[sort_bool::and_()] = "and";
+	translation.function_names[sort_bool::or_()] = "or";
+	translation.function_names[sort_bool::not_()] = "not";
+	
+	
+	
+	for (std::set<function_symbol>::const_iterator i = defined_functions.begin(); i != defined_functions.end(); i++) {
+		if (definitions.count(*i) > 0 && definitions[*i].is_builtin()) {
+			translation.function_names[*i] = definitions[*i].name();
+		} else if (definitions.count(*i) > 0 && definitions[*i].is_identity()) {
+			translation.function_names[*i] = "";
+		} else if (definitions.count(*i) > 0 && definitions[*i].is_unavailable()) {
+			throw mcrl2::runtime_error("Function " + data::pp(*i) + " not available in pbes2cvc4, giving up.");
+		} else {
+			std::string name = sanitize_term(i->name());
+			if (function_name_generator.has_identifier(name)) {
+				if (!function_sort(i->sort()).domain().empty()) {
+					name = mangle_sort_name(*function_sort(i->sort()).domain().begin()) + "-" + name;
+				}
+			}
+			name = function_name_generator(name);
+			
+			translation.definition += "(declare-fun " + name + " (";
+			if (is_function_sort(i->sort())) {
+				sort_expression_list domain = function_sort(i->sort()).domain();
+				for (sort_expression_list::iterator j = domain.begin(); j != domain.end(); j++) {
+					assert(translation.sort_names.count(*j) > 0);
+					translation.definition += translation.sort_names[*j] + " ";
+				}
+			}
+			assert(translation.sort_names.count(i->sort().target_sort()));
+			translation.definition += ") " + translation.sort_names[i->sort().target_sort()] + ")\n";
+			
+			translation.function_names[*i] = name;
+		}
+	}
+	
+	
+	for (std::set<data_equation>::const_iterator i = defined_equations.begin(); i != defined_equations.end(); i++) {
+		std::string quantification_domain;
+		std::map<variable, std::string> context;
+		for (variable_list::const_iterator j = i->variables().begin(); j != i->variables().end(); j++) {
+			if (find_free_variables(i->lhs()).count(*j) == 0 &&
+			    find_free_variables(i->rhs()).count(*j) == 0 &&
+			    find_free_variables(i->condition()).count(*j) == 0)
+			{
+				continue;
+			}
+			
+			std::string name = sanitize_term(j->name());
+			assert(translation.sort_names.count(j->sort()));
+			quantification_domain += "(" + name + " " + translation.sort_names[j->sort()] + ")";
+			context[*j] = name;
+		}
+		
+		std::string pattern = translate_expression(i->lhs(), context, translation);
+		std::string valuation = translate_expression(i->rhs(), context, translation);
+		std::string condition = translate_expression(i->condition(), context, translation);
+		
+		if (context.empty()) {
+			translation.definition += "(assert ";
+			if (i->condition() != sort_bool::true_()) {
+				translation.definition += "(=> " + condition + " ";
+			}
+			translation.definition += "(= " + pattern + " " + valuation + ")";
+			if (i->condition() != sort_bool::true_()) {
+				translation.definition += ")";
+			}
+			translation.definition += ")\n";
+		} else {
+			translation.definition += "(assert (forall (" + quantification_domain + ") (! ";
+			if (i->condition() != sort_bool::true_()) {
+				translation.definition += "(=> " + condition + " ";
+			}
+			translation.definition += "(= " + pattern + " " + valuation + ")";
+			if (i->condition() != sort_bool::true_()) {
+				translation.definition += ")";
+			}
+			translation.definition += " :rewrite-rule) ))\n";
+		}
+	}
+}

--- a/tools/experimental/pbes2cvc4/pbes2cvc4.cpp
+++ b/tools/experimental/pbes2cvc4/pbes2cvc4.cpp
@@ -1,0 +1,210 @@
+// Author(s): Ruud Koolen
+// Copyright: see the accompanying file COPYING or copy at
+// https://svn.win.tue.nl/trac/MCRL2/browser/trunk/COPYING
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+/// \file pbes2cvc4.cpp
+
+#define NAME "pbes2cvc4"
+#define AUTHOR "Ruud Koolen"
+
+#include "pbes2cvc4.h"
+
+#include "mcrl2/utilities/input_output_tool.h"
+#include "mcrl2/bes/pbes_input_tool.h"
+
+#include "mcrl2/pbes/io.h"
+#include "mcrl2/pbes/normalize.h"
+
+#include <fstream>
+
+
+using namespace mcrl2;
+using namespace mcrl2::log;
+using namespace mcrl2::pbes_system;
+using namespace mcrl2::utilities;
+using namespace mcrl2::utilities::tools;
+using namespace mcrl2::bes::tools;
+
+enum goal_t { disjunctiveWitness, disjunctiveAcyclicUnrolling, conjunctiveWitness, conjunctiveAcyclicUnrolling };
+
+inline std::istream& operator>>(std::istream& is, goal_t& goal)
+{
+  std::stringbuf buffer;
+  is >> &buffer;
+
+  if (buffer.str() == "disjunctiveWitness") goal = disjunctiveWitness;
+  else if (buffer.str() == "disjunctiveAcyclicUnrolling") goal = disjunctiveAcyclicUnrolling;
+  else if (buffer.str() == "conjunctiveWitness") goal = conjunctiveWitness;
+  else if (buffer.str() == "conjunctiveAcyclicUnrolling") goal = conjunctiveAcyclicUnrolling;
+  else is.setstate(std::ios_base::failbit);
+
+  return is;
+}
+
+inline std::ostream& operator<<(std::ostream& os, const goal_t goal)
+{
+  if (goal == disjunctiveWitness) os << "disjunctiveWitness";
+  else if (goal == disjunctiveAcyclicUnrolling) os << "disjunctiveAcyclicUnrolling";
+  else if (goal == conjunctiveWitness) os << "conjunctiveWitness";
+  else if (goal == conjunctiveAcyclicUnrolling) os << "conjunctiveAcyclicUnrolling";
+  return os;
+}
+
+
+inline std::string description(const goal_t goal)
+{
+  if (goal == disjunctiveWitness) return "a witness for a disjunctive PBES; if satisfiable, shows that the value of the PBES is true";
+  if (goal == disjunctiveAcyclicUnrolling) return "an acyclic unrolling for a disjunctive PBES; if unsatisfiable, shows that the value of the PBES is false";
+  if (goal == conjunctiveWitness) return "a witness for a conjunctive PBES; if satisfiable, shows that the value of the PBES is false";
+  if (goal == conjunctiveAcyclicUnrolling) return "an acyclic unrolling for a disjunctive PBES; if unsatisfiable, shows that the value of the PBES is true";
+  return "";
+}
+
+class pbes2cvc4_tool: public pbes_input_tool<input_output_tool>
+{
+  protected:
+    // Tool options.
+    unsigned int opt_levels; // Number of unrolling levels
+    bool opt_hasgoal;
+    goal_t opt_goal;
+
+    typedef pbes_input_tool<input_output_tool> super;
+
+  public:
+    pbes2cvc4_tool()
+      : super(
+        NAME,
+        AUTHOR,
+        "Generate a BES from a PBES and solve it. ",
+        "Solves (P)BES from INFILE. "
+        "If INFILE is not present, stdin is used. "),
+      opt_levels(10)
+    {}
+
+  protected:
+    void parse_options(const command_line_parser& parser)
+    {
+      super::parse_options(parser);
+
+      if (parser.options.count("levels"))
+      {
+        opt_levels = parser.option_argument_as< unsigned int > ("levels");
+      }
+
+      if (parser.options.count("goal") == 0)
+      {
+        opt_hasgoal = false;
+      }
+      else
+      {
+        opt_hasgoal = true;
+        opt_goal = parser.option_argument_as<goal_t>("goal");
+      }
+    }
+
+    void add_options(interface_description& desc)
+    {
+      super::add_options(desc);
+      desc.add_option("levels", make_mandatory_argument("NUM"), "unroll NUM levels", 'l');
+      desc.add_option("goal", make_enum_argument<goal_t>("GOAL").
+          add_value(disjunctiveWitness).
+          add_value(disjunctiveAcyclicUnrolling).
+          add_value(conjunctiveWitness).
+          add_value(conjunctiveAcyclicUnrolling),
+          "produce an SMT file for proving GOAL:", 'g');
+    }
+
+  public:
+    bool run()
+    {
+      // load the pbes
+      pbes p;
+      load_pbes(p, input_filename(), pbes_input_format());
+
+      normalize(p);
+
+      if (!opt_hasgoal)
+      {
+        parsed_pbes parsed;
+        if (parse_pbes(p, true, parsed))
+        {
+          std::cout << "disjunctive\n";
+          return true;
+        }
+        else if (parse_pbes(p, false, parsed))
+        {
+          std::cout << "conjunctive\n";
+          return true;
+        }
+        else
+        {
+          return false;
+        }
+      }
+
+      parsed_pbes parsed;
+      if (opt_goal == disjunctiveWitness || opt_goal == disjunctiveAcyclicUnrolling)
+      {
+        if (!parse_pbes(p, true, parsed))
+        {
+          mCRL2log(log::error) << "This is not a disjunctive PBES, giving up.\n";
+          return false;
+        }
+      }
+      else
+      {
+        if (!parse_pbes(p, false, parsed))
+        {
+          mCRL2log(log::error) << "This is not a conjunctive PBES, giving up.\n";
+          return false;
+        }
+      }
+
+      translated_data_specification specification;
+      translate_data_specification(p, specification);
+
+      std::string output;
+      if (opt_goal == disjunctiveWitness || opt_goal == conjunctiveWitness)
+      {
+        output = generate_witness_proposition(parsed, specification, opt_levels);
+      }
+      else
+      {
+        output = generate_acyclic_unrolling_proposition(parsed, specification, opt_levels);
+      }
+
+      if (output_filename().empty())
+      {
+        std::cout << output;
+        if (std::cout.fail())
+        {
+          std::cerr << "Could not write SMT problem to standard output\n";
+          return false;
+        }
+      }
+      else
+      {
+        std::ofstream outputfile;
+        outputfile.open(output_filename().c_str());
+        outputfile << output;
+        if (outputfile.fail())
+        {
+          std::cerr << "Could not write SMT problem to " << output_filename() << "\n";
+          return false;
+        }
+        outputfile.close();
+      }
+
+      return true;
+    }
+
+};
+
+int main(int argc, char* argv[])
+{
+  return pbes2cvc4_tool().execute(argc, argv);
+}

--- a/tools/experimental/pbes2cvc4/pbes2cvc4.h
+++ b/tools/experimental/pbes2cvc4/pbes2cvc4.h
@@ -1,0 +1,69 @@
+// Author(s): Ruud Koolen
+// Copyright: see the accompanying file COPYING or copy at
+// https://svn.win.tue.nl/trac/MCRL2/browser/trunk/COPYING
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef PBES2CVC4_H
+#define PBES2CVC4_H
+
+#include "mcrl2/data/data.h"
+#include "mcrl2/data/data_specification.h"
+#include "mcrl2/pbes/pbes.h"
+
+static inline std::string itoa(int number)
+{
+	char buffer[40];
+	snprintf(buffer, sizeof(buffer), "%d", number);
+	return std::string(buffer);
+}
+
+struct translated_data_specification
+{
+	std::string definition;
+	std::map<mcrl2::data::sort_expression, std::string> sort_names;
+	std::map<mcrl2::data::function_symbol, std::vector<std::string> > constructor_field_names;
+	std::map<mcrl2::data::function_symbol, std::string> function_names;
+};
+
+struct clause
+{
+	mcrl2::data::variable_vector quantification_domain;
+	mcrl2::data::data_expression predicate;
+	mcrl2::pbes_system::propositional_variable_instantiation instantiation;
+};
+
+struct equation
+{
+	mcrl2::pbes_system::fixpoint_symbol symbol;
+	mcrl2::pbes_system::propositional_variable variable;
+	std::vector<clause> clauses;
+};
+
+struct parsed_pbes
+{
+	std::set<mcrl2::data::variable> global_variables;
+	std::vector<equation> equations;
+	mcrl2::pbes_system::propositional_variable_instantiation initial_state;
+	bool disjunctive;
+};
+
+void translate_data_specification(const mcrl2::pbes_system::pbes &pbes, translated_data_specification &translation);
+
+std::string define_variable(const translated_data_specification &translation, std::string name, mcrl2::data::sort_expression sort);
+
+std::string translate_expression(mcrl2::data::data_expression expression, const std::map<mcrl2::data::variable, std::string> &bound_variables, const translated_data_specification &translation);
+
+std::string sanitize_term(std::string term);
+
+
+
+bool parse_pbes(const mcrl2::pbes_system::pbes &pbes, bool disjunctive, parsed_pbes &output);
+
+std::string generate_witness_proposition(const parsed_pbes &pbes, const translated_data_specification &translation, size_t levels);
+
+std::string generate_acyclic_unrolling_proposition(const parsed_pbes &pbes, const translated_data_specification &translation, size_t levels);
+
+#endif

--- a/tools/experimental/pbes2cvc4/pbescvc4solve.sh
+++ b/tools/experimental/pbes2cvc4/pbescvc4solve.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+PBES2CVC4=pbes2cvc4
+CVC4=cvc4
+
+die() {
+	echo "$1" >&2
+	exit 1
+}
+
+verbose=false
+if [[ $1 == -v ]]; then
+	verbose=true
+	shift
+fi
+
+pbes="$1"
+
+pbestype=$($PBES2CVC4 "$pbes") || die "Input PBES $pbes is not conjunctive or disjunctive, giving up."
+
+[[ $verbose == true ]] && [[ $pbestype == conjunctive ]] && echo "Found conjunctive PBES" >&2
+[[ $verbose == true ]] && [[ $pbestype == disjunctive ]] && echo "Found disjunctive PBES" >&2
+
+levels=1
+
+while true; do
+	[[ $verbose == true ]] && echo "Searching for witness of length $((levels * 2))..." >&2
+	cvc4file=$(mktemp pbescvc4solve.XXXXXXXXXXXX.smt2)
+	$PBES2CVC4 -g ${pbestype}Witness -l $((levels * 2)) $pbes $cvc4file || die "pbes2cvc4 failure"
+	result=$($CVC4 $cvc4file) || die "cvc4 failure"
+	rm -f $cvc4file
+	if [[ $result == sat ]]; then
+		[[ $verbose == true ]] && echo "Found!" >&2
+		if [[ $pbestype == disjunctive ]]; then
+			echo true
+		else
+			echo false
+		fi
+		exit 0
+	fi
+	
+	[[ $verbose == true ]] && echo "Searching for acyclic unrolling of length $levels..." >&2
+	cvc4file=$(mktemp pbescvc4solve.XXXXXXXXXXXX.smt2)
+	$PBES2CVC4 -g ${pbestype}AcyclicUnrolling -l $levels $pbes $cvc4file || die "pbes2cvc4 failure"
+	result=$($CVC4 $cvc4file) || die "cvc4 failure"
+	rm -f $cvc4file
+	if [[ $result == unsat ]]; then
+		[[ $verbose == true ]] && echo "Not found!" >&2
+		if [[ $pbestype == disjunctive ]]; then
+			echo false
+		else
+			echo true
+		fi
+		exit 0
+	fi
+	
+	levels=$((levels * 2))
+done

--- a/tools/experimental/pbes2cvc4/unrolling.cpp
+++ b/tools/experimental/pbes2cvc4/unrolling.cpp
@@ -1,0 +1,562 @@
+// Author(s): Ruud Koolen
+// Copyright: see the accompanying file COPYING or copy at
+// https://svn.win.tue.nl/trac/MCRL2/browser/trunk/COPYING
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#include "pbes2cvc4.h"
+
+using namespace mcrl2;
+using namespace mcrl2::data;
+using namespace mcrl2::pbes_system;
+
+static data_expression and_or(data_expression left, data_expression right, bool disjunction)
+{
+	if (disjunction) {
+		if (left == sort_bool::true_() || right == sort_bool::true_()) {
+			return sort_bool::true_();
+		} else if (left == sort_bool::false_()) {
+			return right;
+		} else if (right == sort_bool::false_()) {
+			return left;
+		} else {
+			return sort_bool::or_(left, right);
+		}
+	} else {
+		if (left == sort_bool::false_() || right == sort_bool::false_()) {
+			return sort_bool::false_();
+		} else if (left == sort_bool::true_()) {
+			return right;
+		} else if (right == sort_bool::true_()) {
+			return left;
+		} else {
+			return sort_bool::and_(left, right);
+		}
+	}
+}
+
+static bool parse_condition(pbes_expression expression, bool disjunctive, bool negate, data_expression &condition, variable_vector &quantification_domain)
+{
+	assert(find_propositional_variable_instantiations(expression).empty());
+	assert(quantification_domain.empty());
+	
+	while (is_pbes_not(expression)) {
+		negate = !negate;
+		expression = accessors::arg(expression);
+	}
+	if (is_pbes_imp(expression)) {
+		expression = or_(accessors::left(expression), not_(accessors::right(expression)));
+	}
+	
+	if (is_pbes_forall(expression) || is_pbes_exists(expression)) {
+		if (is_pbes_exists(expression) ^ disjunctive ^ negate) {
+			std::cerr << "Wat lastig, een verkeerde quantificatie\n";
+			return false;
+		}
+		
+		variable_list variables = accessors::var(expression);
+		bool result = parse_condition(accessors::arg(expression), disjunctive, negate, condition, quantification_domain);
+		quantification_domain.insert(quantification_domain.end(), variables.begin(), variables.end());
+		return result;
+	} else if (is_pbes_and(expression) || is_pbes_or(expression)) {
+		data_expression left_condition, right_condition;
+		variable_vector left_domain, right_domain;
+		
+		if (!parse_condition(accessors::left(expression), disjunctive, negate, left_condition, left_domain)) {
+			return false;
+		}
+		if (!parse_condition(accessors::right(expression), disjunctive, negate, right_condition, right_domain)) {
+			return false;
+		}
+		
+		quantification_domain.insert(quantification_domain.end(), left_domain.begin(), left_domain.end());
+		quantification_domain.insert(quantification_domain.end(), right_domain.begin(), right_domain.end());
+		condition = and_or(left_condition, right_condition, is_pbes_or(expression) ^ negate);
+		return true;
+	} else {
+		assert(is_data(expression));
+		condition = negate ? sort_bool::not_(data_expression(expression)) : data_expression(expression);
+		return true;
+	}
+}
+
+bool parse_clauses(pbes_expression expression, bool disjunctive, propositional_variable_instantiation constant_instantiation, variable_vector quantification_domain, data_expression condition, bool negate, std::vector<clause> &clauses)
+{
+	assert(clauses.empty());
+	
+	while (is_pbes_not(expression)) {
+		negate = !negate;
+		expression = accessors::arg(expression);
+	}
+	if (is_pbes_imp(expression)) {
+		expression = or_(accessors::left(expression), not_(accessors::right(expression)));
+	}
+	
+	if (is_data(expression)) {
+		data_expression new_condition = data_expression(expression);
+		if (negate) {
+			new_condition = sort_bool::not_(new_condition);
+		}
+		data_expression predicate = and_or(condition, new_condition, !disjunctive ^ negate);
+		
+		clause c;
+		c.quantification_domain = quantification_domain;
+		c.predicate = disjunctive ? predicate : sort_bool::not_(predicate);
+		c.instantiation = constant_instantiation;
+		clauses.push_back(c);
+		return true;
+	} else if (is_pbes_forall(expression) || is_pbes_exists(expression)) {
+		if (is_pbes_exists(expression) ^ disjunctive ^ negate) {
+			std::cerr << "Wat lastig, een verkeerde quantificatie\n";
+			return false;
+		}
+		
+		variable_list variables = accessors::var(expression);
+		quantification_domain.insert(quantification_domain.end(), variables.begin(), variables.end());
+		return parse_clauses(accessors::arg(expression), disjunctive, constant_instantiation, quantification_domain, condition, negate, clauses);
+	} else if (is_pbes_and(expression) || is_pbes_or(expression)) {
+		pbes_expression left = accessors::left(expression);
+		pbes_expression right = accessors::right(expression);
+		
+		if (is_pbes_and(expression) ^ disjunctive ^ negate) {
+			std::vector<clause> left_clauses, right_clauses;
+			if (!parse_clauses(left, disjunctive, constant_instantiation, quantification_domain, condition, negate, left_clauses)) {
+				return false;
+			}
+			if (!parse_clauses(right, disjunctive, constant_instantiation, quantification_domain, condition, negate, right_clauses)) {
+				return false;
+			}
+			clauses.insert(clauses.end(), left_clauses.begin(), left_clauses.end());
+			clauses.insert(clauses.end(), right_clauses.begin(), right_clauses.end());
+			return true;
+		}
+		
+		pbes_expression condition_part;
+		pbes_expression recurse_part;
+		
+		if (find_propositional_variable_instantiations(left).empty()) {
+			condition_part = left;
+			recurse_part = right;
+		} else if (find_propositional_variable_instantiations(right).empty()) {
+			condition_part = right;
+			recurse_part = left;
+		} else {
+			return false;
+		}
+		
+		data_expression new_condition;
+		variable_vector domain;
+		if (!parse_condition(condition_part, disjunctive, negate, new_condition, domain)) {
+			return false;
+		}
+		
+		quantification_domain.insert(quantification_domain.end(), domain.begin(), domain.end());
+		condition = and_or(condition, new_condition, !disjunctive ^ negate);
+		return parse_clauses(recurse_part, disjunctive, constant_instantiation, quantification_domain, condition, negate, clauses);
+	} else {
+		assert(is_propositional_variable_instantiation(expression));
+		propositional_variable_instantiation instantiation(expression);
+		
+		if (negate) {
+			mCRL2log(log::error) << "Found negatively occurring propositional variable instantiation " << pbes_system::pp(instantiation) << ", giving up.\n";
+			return false;
+		}
+		
+		clause c;
+		c.quantification_domain = quantification_domain;
+		c.predicate = disjunctive ? condition : sort_bool::not_(condition);
+		c.instantiation = instantiation;
+		clauses.push_back(c);
+		return true;
+	}
+}
+
+bool parse_pbes(const pbes &pbes, bool disjunctive, parsed_pbes &output)
+{
+	assert(output.equations.empty());
+	
+	// Create a TRUE variable or a FALSE variable.
+	core::identifier_string constant_variable_name(disjunctive ? "X_true" : "X_false");
+	
+	clause constant_clause;
+	constant_clause.predicate = sort_bool::true_();
+	constant_clause.instantiation = propositional_variable_instantiation(constant_variable_name, data_expression_list());
+	
+	equation constant_equation;
+	constant_equation.symbol = disjunctive ? fixpoint_symbol::nu() : fixpoint_symbol::mu();
+	constant_equation.variable = propositional_variable(constant_variable_name, variable_list());
+	constant_equation.clauses.push_back(constant_clause);
+	
+	for (std::vector<pbes_equation>::const_iterator i = pbes.equations().begin(); i != pbes.equations().end(); ++i) {
+		equation e;
+		e.symbol = i->symbol();
+		e.variable = i->variable();
+		if (!parse_clauses(i->formula(), disjunctive, constant_clause.instantiation, variable_vector(), disjunctive ? sort_bool::true_() : sort_bool::false_(), false, e.clauses)) {
+			output.equations.clear();
+			return false;
+		}
+		output.equations.push_back(e);
+	}
+	output.equations.push_back(constant_equation);
+	output.initial_state = pbes.initial_state();
+	output.disjunctive = disjunctive;
+	output.global_variables = pbes.global_variables();
+	
+/*	
+	std::cerr << "Parsed form:\n====================\n";
+	for (std::vector<equation>::iterator i = output.equations.begin(); i != output.equations.end(); ++i) {
+		std::cerr << pbes_system::pp(i->symbol) << " " << pbes_system::pp(i->variable) << " = \n";
+		for (std::vector<clause>::iterator j = i->clauses.begin(); j != i->clauses.end(); ++j) {
+			std::cerr << "    (";
+			if (!j->quantification_domain.empty()) {
+				std::cerr << "exists ";
+				for (variable_vector::iterator k = j->quantification_domain.begin(); k != j->quantification_domain.end(); ++k) {
+					std::cerr << data::pp(*k);
+					if (k != j->quantification_domain.end() - 1) {
+						std::cerr << ", ";
+					}
+				}
+				std::cerr << " . ";
+			}
+			std::cerr << data::pp(j->predicate);
+			std::cerr << (output.disjunctive ? " && " : " || ");
+			std::cerr << pbes_system::pp(j->instantiation);
+			std::cerr << ")";
+			if (j == i->clauses.end() - 1) {
+				std::cerr << ";";
+			} else {
+				std::cerr << (output.disjunctive ? " ||" : " &&");
+			}
+			std::cerr << "\n\n";
+		}
+	}
+*/	
+	return true;
+}
+
+struct unrolling_variables
+{
+	// Contains the name of PBES global variables.
+	std::map<data::variable, std::string> global_variables;
+	// Contains, for each propositional variable name, its index.
+	std::map<core::identifier_string, size_t> variable_indices;
+	// Contains, for each round i, the name of the variable T_i.
+	std::vector<std::string> equation_number_variables;
+	// Contains, for each round i, equation j, and data parameter k of equation j, the name of the variable d_i_j_k.
+	std::vector<std::vector<std::vector<std::string> > > parameter_variables;
+	// Contains, for each round i, equation j, clause k, and quantification variable E, the name of the variable E.
+	std::vector<std::vector<std::vector<std::vector<std::string> > > > quantification_variables;
+	
+	// The yices definition of the above variables.
+	std::string definition;
+};
+
+static void build_unrolling_variables(const parsed_pbes &pbes, const translated_data_specification &translation, size_t rounds, unrolling_variables &variables)
+{
+	assert(rounds > 0);
+	
+	std::string global_variable_base = "global";
+	std::string equation_number_base = "equation";
+	std::string parameter_base = "parameter";
+	std::string quantification_base = "quantification";
+	
+	for (std::set<data::variable>::const_iterator i = pbes.global_variables.begin(); i != pbes.global_variables.end(); ++i) {
+		std::string global_variable = global_variable_base + "-" + sanitize_term(i->name());
+		variables.global_variables[*i] = global_variable;
+		variables.definition += define_variable(translation, global_variable, i->sort());
+	}
+	
+	for (size_t i = 0; i < pbes.equations.size(); ++i) {
+		variables.variable_indices[pbes.equations[i].variable.name()] = i;
+	}
+	
+	for (size_t round = 0; round < rounds; ++round) {
+		std::string equation_number_variable = equation_number_base + "-" + itoa(round);
+		variables.equation_number_variables.push_back(equation_number_variable);
+		variables.definition += define_variable(translation, equation_number_variable, sort_nat::nat());
+		
+		std::vector<std::vector<std::string> > round_parameter_variables;
+		std::vector<std::vector<std::vector<std::string> > > round_quantification_variables;
+		for (std::vector<equation>::const_iterator i = pbes.equations.begin(); i != pbes.equations.end(); ++i) {
+			std::vector<std::string> equation_parameter_variables;
+			for (variable_list::const_iterator j = i->variable.parameters().begin(); j != i->variable.parameters().end(); ++j) {
+				std::string parameter_variable =
+					parameter_base + "-" +
+					sanitize_term(i->variable.name()) + "-" +
+					sanitize_term(j->name()) + "-" +
+					itoa(round);
+				equation_parameter_variables.push_back(parameter_variable);
+				variables.definition += define_variable(translation, parameter_variable, j->sort());
+			}
+			round_parameter_variables.push_back(equation_parameter_variables);
+			
+			std::vector<std::vector<std::string> > equation_quantification_variables;
+			for (std::vector<clause>::const_iterator j = i->clauses.begin(); j != i->clauses.end(); ++j) {
+				std::vector<std::string> clause_quantification_variables;
+				for (variable_vector::const_iterator k = j->quantification_domain.begin(); k != j->quantification_domain.end(); ++k) {
+					std::string quantification_variable =
+						quantification_base + "-" +
+						sanitize_term(i->variable.name()) + "-" +
+						itoa(equation_quantification_variables.size()) + "-" +
+						sanitize_term(k->name()) + "-" +
+						itoa(round);
+					clause_quantification_variables.push_back(quantification_variable);
+					variables.definition += define_variable(translation, quantification_variable, k->sort());
+				}
+				equation_quantification_variables.push_back(clause_quantification_variables);
+			}
+			round_quantification_variables.push_back(equation_quantification_variables);
+		}
+		variables.parameter_variables.push_back(round_parameter_variables);
+		variables.quantification_variables.push_back(round_quantification_variables);
+	}
+}
+
+static std::string assert_initial_state(const parsed_pbes &pbes, const translated_data_specification &translation, const unrolling_variables &variables)
+{
+	std::string output;
+	size_t variable_index = variables.variable_indices.at(pbes.initial_state.name());
+	output += "(assert (= " + variables.equation_number_variables[0] + " " + itoa(variable_index) + "))\n";
+	
+	const std::vector<std::string> &equation_variables = variables.parameter_variables[0][variable_index];
+	data_expression_list values = pbes.initial_state.parameters();
+	size_t index = 0;
+	for (data_expression_list::const_iterator i = values.begin(); i != values.end(); ++i) {
+		output += "(assert (= " + equation_variables[index++] + " " + translate_expression(*i, variables.global_variables, translation) + "))\n";
+	}
+	
+	return output;
+}
+
+static std::string join(const std::vector<std::string> &clauses, const std::string &op, bool simplify = true)
+{
+	assert(clauses.size() > 0);
+	if (clauses.size() == 1 && simplify) {
+		return clauses[0];
+	}
+	std::string output = "(" + op;
+	for (std::vector<std::string>::const_iterator i = clauses.begin(); i != clauses.end(); ++i) {
+		output += " " + *i;
+	}
+	output += ")";
+	return output;
+}
+
+static std::string assert_occurs(const parsed_pbes &pbes, const translated_data_specification &translation, const unrolling_variables &variables, size_t from_round, size_t to_round)
+{
+	std::vector<std::string> possibilities;
+	for (std::vector<equation>::const_iterator i = pbes.equations.begin(); i != pbes.equations.end(); ++i) {
+		size_t from_variable_index = variables.variable_indices.at(i->variable.name());
+		for (std::vector<clause>::const_iterator j = i->clauses.begin(); j != i->clauses.end(); ++j) {
+			size_t to_variable_index = variables.variable_indices.at(j->instantiation.name());
+			std::vector<std::string> clauses;
+			
+			clauses.push_back("(= " + variables.equation_number_variables.at(from_round) + " " + itoa(from_variable_index) + ")");
+			clauses.push_back("(= " + variables.equation_number_variables.at(to_round) + " " + itoa(to_variable_index) + ")");
+			
+			std::map<mcrl2::data::variable, std::string> bound_variables = variables.global_variables;
+			size_t index = 0;
+			for (variable_list::const_iterator k = i->variable.parameters().begin(); k != i->variable.parameters().end(); ++k) {
+				bound_variables[*k] = variables.parameter_variables[from_round][from_variable_index][index++];
+			}
+			for (variable_vector::const_iterator k = j->quantification_domain.begin(); k != j->quantification_domain.end(); ++k) {
+				bound_variables[*k] = variables.quantification_variables[from_round][from_variable_index][j - i->clauses.begin()][k - j->quantification_domain.begin()];
+			}
+			
+			if (j->predicate != sort_bool::true_()) {
+				clauses.push_back(translate_expression(j->predicate, bound_variables, translation));
+			}
+			
+			index = 0;
+			for (data_expression_list::const_iterator k = j->instantiation.parameters().begin(); k != j->instantiation.parameters().end(); ++k) {
+				std::string rhs = translate_expression(*k, bound_variables, translation);
+				std::string lhs = variables.parameter_variables[to_round][to_variable_index][index++];
+				clauses.push_back("(= " + lhs + " " + rhs + ")");
+			}
+			
+			possibilities.push_back("\n  " + join(clauses, "and"));
+		}
+	}
+	
+	return "(assert " + join(possibilities, "or") + ")\n";
+}
+
+static std::string define_assert_witness(const parsed_pbes &pbes, const translated_data_specification &translation, const unrolling_variables &variables, size_t levels)
+{
+	std::string output;
+	
+	std::string base = "witness";
+	std::string start_round_variable = base + "-start";
+	std::string end_round_variable = base + "-end";
+	std::string equation_variable = base + "-equation";
+	
+	output += define_variable(translation, start_round_variable, sort_nat::nat());
+	output += define_variable(translation, end_round_variable, sort_nat::nat());
+	output += define_variable(translation, equation_variable, sort_nat::nat());
+	
+	std::vector<std::vector<std::string> > parameter_variables;
+	for (std::vector<equation>::const_iterator i = pbes.equations.begin(); i != pbes.equations.end(); ++i) {
+		std::vector<std::string> equation_parameter_variables;
+		for (variable_list::const_iterator j = i->variable.parameters().begin(); j != i->variable.parameters().end(); ++j) {
+			std::string parameter_variable =
+				base + "-parameter-" +
+				sanitize_term(i->variable.name()) + "-" +
+				sanitize_term(j->name());
+			equation_parameter_variables.push_back(parameter_variable);
+			output += define_variable(translation, parameter_variable, j->sort());
+		}
+		parameter_variables.push_back(equation_parameter_variables);
+	}
+	
+	output += "(assert (< " + start_round_variable + " " + end_round_variable + "))\n";
+	
+	std::vector<std::string> valid_equation_options;
+	for (std::vector<equation>::const_iterator i = pbes.equations.begin(); i != pbes.equations.end(); ++i) {
+		if (pbes.disjunctive ? i->symbol.is_nu() : i->symbol.is_mu()) {
+			std::string option = "(= " + equation_variable + " " + itoa(variables.variable_indices.at(i->variable.name())) + ")";
+			valid_equation_options.push_back(option);
+		}
+	}
+	output += "(assert " + join(valid_equation_options, "or") + ")\n";
+	
+	std::vector<std::string> start_round_options;
+	std::vector<std::string> end_round_options;
+	for (size_t round = 0; round < levels; ++round) {
+		output += "(assert (=> (and (<= " + start_round_variable + " " + itoa(round) + ") (<= " + itoa(round) + " " + end_round_variable + ")) (<= " + equation_variable + " " + variables.equation_number_variables[round] + ")))\n";
+		
+		std::vector<std::string> requirements;
+		requirements.push_back("(= " + equation_variable + " " + variables.equation_number_variables[round] + ")");
+		for (size_t i = 0; i < pbes.equations.size(); ++i) {
+			for (size_t j = 0; j < pbes.equations[i].variable.parameters().size(); ++j) {
+				requirements.push_back("(= " + parameter_variables[i][j] + " " + variables.parameter_variables[round][i][j] + ")");
+			}
+		}
+		
+		requirements.push_back("(= " + start_round_variable + " " + itoa(round) + ")");
+		start_round_options.push_back("\n  " + join(requirements, "and"));
+		
+		requirements.pop_back();
+		requirements.push_back("(= " + end_round_variable + " " + itoa(round) + ")");
+		end_round_options.push_back("\n  " + join(requirements, "and"));
+	}
+	
+	output += "(assert " + join(start_round_options, "or") + ")\n";
+	output += "(assert " + join(end_round_options, "or") + ")\n";
+	
+	return output;
+}
+
+std::string generate_witness_proposition(const parsed_pbes &pbes, const translated_data_specification &translation, size_t levels)
+{
+	std::string output;
+	output += "(set-logic ALL_SUPPORTED)\n";
+	output += translation.definition;
+	
+	unrolling_variables unrolling;
+	build_unrolling_variables(pbes, translation, levels, unrolling);
+	output += unrolling.definition;
+	
+	output += assert_initial_state(pbes, translation, unrolling);
+	
+	for (size_t i = 0; i < levels - 1; ++i) {
+		output += assert_occurs(pbes, translation, unrolling, i, i + 1);
+	}
+	
+	output += define_assert_witness(pbes, translation, unrolling, levels);
+	
+	output += "(check-sat)\n";
+	return output;
+}
+
+static std::string assert_distinct(const parsed_pbes &pbes, const translated_data_specification &translation, const unrolling_variables &unrolling, size_t levels)
+{
+	std::string output;
+	
+	output += "(declare-datatypes () ( (pbes-state\n";
+	for (size_t i = 0; i < pbes.equations.size(); ++i) {
+		output += "  (pbes-state-" + itoa(i);
+		size_t index = 0;
+		for (data::variable_list::const_iterator j = pbes.equations[i].variable.parameters().begin(); j != pbes.equations[i].variable.parameters().end(); ++j) {
+			output += " (pbes-state-var-" + itoa(i) + "-" + itoa(index) + " " + translation.sort_names.at(j->sort()) + ")";
+			index++;
+		}
+		output += ")\n";
+	}
+	output += ")))\n";
+	
+	output += "(declare-fun make-pbes-state (Int";
+	for (size_t i = 0; i < pbes.equations.size(); ++i) {
+		for (data::variable_list::const_iterator j = pbes.equations[i].variable.parameters().begin(); j != pbes.equations[i].variable.parameters().end(); ++j) {
+			output += " " + translation.sort_names.at(j->sort());
+		}
+	}
+	output += ") pbes-state)\n";
+	for (size_t i = 0; i < pbes.equations.size(); ++i) {
+		output += "(assert (forall (";
+		for (size_t j = 0; j < pbes.equations.size(); ++j) {
+			size_t index = 0;
+			for (data::variable_list::const_iterator k = pbes.equations[j].variable.parameters().begin(); k != pbes.equations[j].variable.parameters().end(); ++k) {
+				output += "(pbes-state-var-" + itoa(j) + "-" + itoa(index++) + " " + translation.sort_names.at(k->sort()) + ")";
+			}
+		}
+		output += ") (! (= (make-pbes-state " + itoa(i);
+		for (size_t j = 0; j < pbes.equations.size(); ++j) {
+			size_t index = 0;
+			for (data::variable_list::const_iterator k = pbes.equations[j].variable.parameters().begin(); k != pbes.equations[j].variable.parameters().end(); ++k) {
+				output += " pbes-state-var-" + itoa(j) + "-" + itoa(index++);
+			}
+		}
+		output += ") ";
+		if (pbes.equations[i].variable.parameters().size() == 0) {
+			output += "pbes-state-" + itoa(i);
+		} else {
+			output += "(pbes-state-" + itoa(i);
+			size_t index = 0;
+			for (data::variable_list::const_iterator j = pbes.equations[i].variable.parameters().begin(); j != pbes.equations[i].variable.parameters().end(); ++j) {
+				output += " pbes-state-var-" + itoa(i) + "-" + itoa(index++);
+			}
+			output += ")";
+		}
+		output += ") :rewrite-rule)))\n";
+	}
+	
+	if (levels > 1) {
+		output += "(assert (distinct\n";
+		for (size_t i = 0; i < levels; ++i) {
+			output += "  (make-pbes-state " + unrolling.equation_number_variables[i];
+			for (size_t j = 0; j < unrolling.parameter_variables[i].size(); ++j) {
+				for (size_t k = 0; k < unrolling.parameter_variables[i][j].size(); ++k) {
+					output += " " + unrolling.parameter_variables[i][j][k];
+				}
+			}
+			output += ")\n";
+		}
+		output += "))\n";
+	}
+	
+	return output;
+}
+
+std::string generate_acyclic_unrolling_proposition(const parsed_pbes &pbes, const translated_data_specification &translation, size_t levels)
+{
+	std::string output;
+	output += "(set-logic ALL_SUPPORTED)\n";
+	output += translation.definition;
+	
+	unrolling_variables unrolling;
+	build_unrolling_variables(pbes, translation, levels, unrolling);
+	output += unrolling.definition;
+	
+	output += assert_initial_state(pbes, translation, unrolling);
+	
+	for (size_t i = 0; i < levels - 1; ++i) {
+		output += assert_occurs(pbes, translation, unrolling, i, i + 1);
+	}
+	
+	output += assert_distinct(pbes, translation, unrolling, levels);
+	
+	output += "(check-sat)\n";
+	return output;
+}

--- a/tools/experimental/pbes2yices/CMakeLists.txt
+++ b/tools/experimental/pbes2yices/CMakeLists.txt
@@ -1,0 +1,11 @@
+add_mcrl2_tool(pbes2yices
+        SOURCES
+        pbes2yices.cpp
+        data.cpp
+        unrolling.cpp
+        DEPENDS
+        mcrl2_data
+        mcrl2_bes
+        mcrl2_pbes
+        mcrl2_utilities
+        )

--- a/tools/experimental/pbes2yices/data.cpp
+++ b/tools/experimental/pbes2yices/data.cpp
@@ -1,0 +1,906 @@
+// Author(s): Ruud Koolen
+// Copyright: see the accompanying file COPYING or copy at
+// https://svn.win.tue.nl/trac/MCRL2/browser/trunk/COPYING
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#include <cstdio>
+
+#include "pbes2yices.h"
+
+#include "mcrl2/utilities/exception.h"
+
+#include "mcrl2/data/bool.h"
+#include "mcrl2/data/int.h"
+#include "mcrl2/data/nat.h"
+#include "mcrl2/data/pos.h"
+#include "mcrl2/data/real.h"
+#include "mcrl2/data/replace.h"
+#include "mcrl2/data/representative_generator.h"
+#include "mcrl2/data/substitutions/data_expression_assignment.h"
+
+using namespace mcrl2;
+using namespace mcrl2::data;
+
+static std::string sanitize_term(std::string term)
+{
+	if (term == "-") {
+		return "minus";
+	}
+	return term;
+}
+
+// Topological sort.
+template<class T> std::vector<T> tsort(std::map<T, std::set<T> > dependencies)
+{
+	std::map<T, std::set<T> > reverse_dependencies;
+	for (typename std::map<T, std::set<T> >::const_iterator i = dependencies.begin(); i != dependencies.end(); i++) {
+		reverse_dependencies[i->first] = std::set<T>();
+	}
+	for (typename std::map<T, std::set<T> >::const_iterator i = dependencies.begin(); i != dependencies.end(); i++) {
+		for (typename std::set<T>::const_iterator j = i->second.begin(); j != i->second.end(); j++) {
+			reverse_dependencies[*j].insert(i->first);
+		}
+	}
+	
+	std::vector<T> output;
+	for (typename std::map<T, std::set<T> >::const_iterator i = dependencies.begin(); i != dependencies.end(); i++) {
+		if (i->second.empty()) {
+			output.push_back(i->first);
+		}
+	}
+	
+	size_t index = 0;
+	while (index < output.size()) {
+		T vertex = output[index];
+		index++;
+		
+		const std::set<T> &edges = reverse_dependencies.at(vertex);
+		for (typename std::set<T>::const_iterator i = edges.begin(); i != edges.end(); i++) {
+			dependencies[*i].erase(vertex);
+			if (dependencies[*i].empty()) {
+				output.push_back(*i);
+			}
+		}
+	}
+	
+	for (typename std::map<T, std::set<T> >::const_iterator i = dependencies.begin(); i != dependencies.end(); i++) {
+		if (!i->second.empty()) {
+			throw mcrl2::runtime_error("Dependency loop");
+		}
+	}
+	
+	return output;
+}
+
+static std::set<data::function_symbol> get_builtin_constructors()
+{
+	std::set<data::function_symbol> output;
+	output.insert(sort_pos::c1());
+	output.insert(sort_pos::cdub());
+	output.insert(sort_nat::c0());
+	output.insert(sort_nat::cnat());
+	output.insert(sort_int::cint());
+	output.insert(sort_int::cneg());
+	output.insert(sort_real::creal());
+	return output;
+}
+
+std::string translate_expression(data_expression expression, const std::map<variable, std::string> &bound_variables, const translated_data_specification &translation)
+{
+	if (sort_real::is_creal_application(expression)) {
+		application a(expression);
+		return "(/ " + translate_expression(*a.begin(), bound_variables, translation) + " " + translate_expression(*++a.begin(), bound_variables, translation) + ")";
+	} else if (sort_int::is_cint_application(expression)) {
+		application a(expression);
+		return translate_expression(*a.begin(), bound_variables, translation);
+	} else if (sort_int::is_cneg_application(expression)) {
+		application a(expression);
+		std::string result = translate_expression(*a.begin(), bound_variables, translation);
+		if (result[0] == '(') {
+			return "(- 0 " + result + ")";
+		} else {
+			return "-" + result;
+		}
+	} else if (sort_nat::is_c0_function_symbol(expression)) {
+		return "0";
+	} else if (sort_nat::is_cnat_application(expression)) {
+		application a(expression);
+		return translate_expression(*a.begin(), bound_variables, translation);
+	} else if (sort_pos::is_c1_function_symbol(expression) || sort_pos::is_cdub_application(expression)) {
+		return data::pp(expression);
+	}
+	
+	
+	
+	if (is_function_symbol(expression)) {
+		function_symbol s(expression);
+		assert(translation.function_names.count(s));
+		return translation.function_names.at(s);
+	} else if (is_variable(expression)) {
+		assert(bound_variables.count(variable(expression)));
+		return bound_variables.at(variable(expression));
+	} else if (is_application(expression)) {
+		application a(expression);
+		assert(is_function_symbol(a.head()));
+		
+		assert(translation.function_names.count(function_symbol(a.head())));
+		if (translation.function_names.at(function_symbol(a.head())) == "") {
+			assert(a.size() == 1);
+			return translate_expression(*a.begin(), bound_variables, translation);
+		}
+		
+		std::string output = "(" + translation.function_names.at(function_symbol(a.head()));
+		for (application::const_iterator i = a.begin(); i != a.end(); ++i) {
+			output += " " + translate_expression(*i, bound_variables, translation);
+		}
+		output += ")";
+		return output;
+	} else {
+		throw mcrl2::runtime_error("Unable to translate expression " + data::pp(expression) + ", giving up.");
+	}
+}
+
+// Find all sorts that need to be defined in yices, ordered by dependency structure.
+static std::vector<mcrl2::data::sort_expression> required_sorts(const mcrl2::pbes_system::pbes &pbes)
+{
+	std::set<sort_expression> all_sorts(pbes.data().sorts().begin(), pbes.data().sorts().end());
+	
+	std::map<sort_expression, std::set<sort_expression> > sort_dependencies;
+	for (std::set<sort_expression>::const_iterator i = all_sorts.begin(); i != all_sorts.end(); i++) {
+		if (is_container_sort(*i)) {
+			std::set<sort_expression> dependencies;
+			sort_expression base_sort = container_sort(*i).element_sort();
+			dependencies.insert(base_sort);
+			sort_dependencies[*i] = dependencies;
+		} else if (is_basic_sort(*i)) {
+			std::set<sort_expression> dependencies;
+			function_symbol_vector constructors = pbes.data().constructors(*i);
+			for (function_symbol_vector::iterator j = constructors.begin(); j != constructors.end(); j++) {
+				if (is_function_sort(j->sort())) {
+					sort_expression_list domain = function_sort(j->sort()).domain();
+					for (sort_expression_list::iterator k = domain.begin(); k != domain.end(); k++) {
+						if (sort_expression(*k) != *i) {
+							dependencies.insert(sort_expression(*k));
+						}
+					}
+				}
+			}
+			sort_dependencies[*i] = dependencies;
+		}
+	}
+	
+	try {
+		return tsort(sort_dependencies);
+	} catch(mcrl2::runtime_error e) {
+		throw mcrl2::runtime_error("Mutually recursive types detected, giving up.");
+	}
+}
+
+// Flattens a sort name to a yices-compatible form.
+static std::string mangle_sort_name(sort_expression sort)
+{
+	sort_expression base_sort = sort;
+	std::string name_prefix = "";
+	while (is_container_sort(base_sort)) {
+		container_sort container(base_sort);
+		name_prefix += container.container_name().function().name();
+		name_prefix += "-";
+		base_sort = container.element_sort();
+	}
+	assert(is_basic_sort(base_sort));
+	
+	std::string base_name = sanitize_term(basic_sort(base_sort).name());
+	return name_prefix + base_name;
+}
+
+static void translate_sort_definition(const mcrl2::data::data_specification &data, mcrl2::data::sort_expression sort, set_identifier_generator &function_name_generator, translated_data_specification &translation)
+{
+	assert(is_basic_sort(sort) || is_container_sort(sort));
+	
+	if (sort == sort_bool::bool_()) {
+		translation.sort_names[sort] = "bool";
+		translation.function_names[sort_bool::true_()] = "true";
+		translation.function_names[sort_bool::false_()] = "false";
+	} else if (sort == sort_nat::nat()) {
+		translation.sort_names[sort] = "nat";
+	} else if (sort == sort_int::int_()) {
+		translation.sort_names[sort] = "int";
+	} else if (sort == sort_real::real_()) {
+		translation.sort_names[sort] = "real";
+	} else if (sort == sort_pos::pos()) {
+		translation.definition += "(define-type pos (subtype (n::nat) (> n 0 )))\n";
+		translation.sort_names[sort] = "pos";
+	} else {
+		std::string name = mangle_sort_name(sort);
+		function_symbol_vector constructors = data.constructors(sort);
+		
+		std::string definition;
+		if (constructors.size() == 0) {
+			definition = "(define-type " + name + ")";
+		} else {
+			definition += "(define-type " + name + " (datatype";
+			int index = 0;
+			for (function_symbol_vector::iterator i = constructors.begin(); i != constructors.end(); i++) {
+				std::string constructor_name = sanitize_term(i->name());
+				if (function_name_generator.has_identifier(constructor_name)) {
+					constructor_name = name + "-" + constructor_name;
+				}
+				translation.function_names[*i] = function_name_generator(constructor_name);
+				translation.constructor_field_names[*i] = std::vector<std::string>();
+				
+				definition += " ";
+				if (is_function_sort(i->sort())) {
+					definition += "(" + constructor_name;
+					
+					sort_expression_list domain = function_sort(i->sort()).domain();
+					for (sort_expression_list::iterator j = domain.begin(); j != domain.end(); j++) {
+						std::string sort_name;
+						if (*j == sort) {
+							sort_name = name;
+						} else {
+							assert(translation.sort_names.count(*j) > 0);
+							sort_name = translation.sort_names[*j];
+						}
+						
+						std::string field_name = "@@" + name + itoa(index++);
+						translation.constructor_field_names[*i].push_back(field_name);
+						definition += " " + field_name + "::" + sort_name;
+					}
+					
+					definition += ")";
+				} else {
+					definition += constructor_name;
+				}
+			}
+			definition += "))";
+		}
+		
+		translation.definition += definition + "\n";
+		translation.sort_names[sort] = name;
+	}
+}
+
+class function_definition
+{
+	public:
+	enum function_definition_type { builtin_type, equations_type, identity_type, unavailable_type };
+	
+	protected:
+	function_definition_type m_type;
+	std::string m_name;
+	std::vector<data_equation> m_equations;
+	
+	public:
+	function_definition(): m_type(unavailable_type) {}
+	function_definition(const char *name): m_type(builtin_type), m_name(name) {}
+	function_definition(std::string name): m_type(builtin_type), m_name(name) {}
+	function_definition(const std::vector<data_equation> equations): m_type(equations_type), m_equations(equations) {}
+	function_definition(data_equation definition): m_type(equations_type)
+	{
+		m_equations.push_back(definition);
+	}
+	
+	protected:
+	function_definition(function_definition_type type, std::string name, const std::vector<data_equation> equations):
+		m_type(type),
+		m_name(name),
+		m_equations(equations)
+	{}
+	
+	public:
+	static function_definition unavailable() { return function_definition(unavailable_type, "", std::vector<data_equation>()); }
+	static function_definition identity() { return function_definition(identity_type, "", std::vector<data_equation>()); }
+	
+	bool is_builtin() const { return m_type == builtin_type; }
+	bool is_equations() const { return m_type == equations_type; }
+	bool is_identity() const { return m_type == identity_type; }
+	bool is_unavailable() const { return m_type == unavailable_type; }
+	const std::string &name() const { return m_name; }
+	const std::vector<data_equation> &equations() const { return m_equations; }
+};
+
+static void add_undefined_functions(std::map<mcrl2::data::function_symbol, function_definition> &function_definitions, const function_symbol_vector &functions)
+{
+	for (function_symbol_vector::const_iterator i = functions.begin(); i != functions.end(); i++) {
+		std::string name = i->name();
+		if (name[0] == '@' && function_definitions.count(*i) == 0) {
+			function_definitions[*i] = function_definition::unavailable();
+		}
+	}
+}
+
+// Constructs a list of all mcrl2 types and functions that map to yices builtins.
+static std::map<mcrl2::data::function_symbol, function_definition> builtin_function_map(const std::vector<sort_expression> &sorts)
+{
+	std::map<function_symbol, function_definition> output;
+	
+	basic_sort bool_ = sort_bool::bool_();
+	basic_sort pos = sort_pos::pos();
+	basic_sort nat = sort_nat::nat();
+	basic_sort int_ = sort_int::int_();
+	basic_sort real = sort_real::real_();
+	
+	
+	variable b("b", bool_);
+	variable p("p", pos);
+	variable p2("p2", pos);
+	variable n("n", nat);
+	variable n2("n2", nat);
+	variable i("i", int_);
+	variable i2("i2", int_);
+	variable r("r", real);
+	variable r2("r2", real);
+	
+	
+	output[sort_bool::not_()] = "not";
+	output[sort_bool::and_()] = "and";
+	output[sort_bool::or_()] = "or";
+	output[sort_bool::implies()] = "=>";
+	
+	
+	function_symbol pos_one("one", pos);
+	output[pos_one] = "1";
+	
+	output[less(pos)] = "<";
+	output[less_equal(pos)] = "<=";
+	output[greater(pos)] = ">";
+	output[greater_equal(pos)] = ">=";
+	output[sort_pos::plus()] = "+";
+	output[sort_pos::times()] = "*";
+	output[sort_pos::succ()] = data_equation(variable_list({p}), sort_pos::succ(p), sort_pos::plus(p, pos_one));
+	output[sort_pos::add_with_carry()] = "(lambda (c::bool p1::pos p2::pos) (if c (+ 1 p1 p2) (+ p1 p2)))";
+	
+	
+	function_symbol nat_zero("zero", nat);
+	output[nat_zero] = "0";
+	function_symbol nat_one("one", nat);
+	output[nat_one] = "1";
+	function_symbol nat_two("two", nat);
+	output[nat_two] = "2";
+	function_symbol nat_minus("-", function_sort(sort_expression_list({nat, nat}), nat));
+	output[nat_minus] = "-";
+	function_symbol nat_do_exp("exp", function_sort(sort_expression_list({pos, nat}), pos));
+	output[nat_do_exp] = data_equation(variable_list({p, n}), nat_do_exp(p, n), if_(equal_to(n, nat_one), p, if_(equal_to(sort_nat::mod(n, nat_two), nat_one), sort_pos::times(p, nat_do_exp(sort_pos::times(p, p), sort_nat::div(n, nat_two))), nat_do_exp(sort_pos::times(p, p), sort_nat::div(n, nat_two)))));
+	
+	output[less(nat)] = "<";
+	output[less_equal(nat)] = "<=";
+	output[greater(nat)] = ">";
+	output[greater_equal(nat)] = ">=";
+	output[sort_nat::pos2nat()] = function_definition::identity();
+	output[sort_nat::nat2pos()] = function_definition::identity();
+	output[sort_nat::maximum(pos, nat)] = data_equation(variable_list({p, n}), sort_nat::maximum(p, n), sort_nat::nat2pos(sort_nat::maximum(sort_nat::pos2nat(p), n)));
+	output[sort_nat::maximum(nat, pos)] = data_equation(variable_list({n, p}), sort_nat::maximum(n, p), sort_nat::nat2pos(sort_nat::maximum(sort_nat::pos2nat(p), n)));
+	output[sort_nat::succ(nat)] = data_equation(variable_list({n}), sort_nat::succ(n), sort_nat::plus(n, nat_one));
+	output[sort_nat::pred()] = data_equation(variable_list({p}), sort_nat::pred(p), nat_minus(sort_nat::pos2nat(p), nat_one));
+	output[sort_nat::plus(pos, nat)] = "+";
+	output[sort_nat::plus(nat, pos)] = "+";
+	output[sort_nat::plus(nat, nat)] = "+";
+	output[sort_nat::times(nat, nat)] = "*";
+	output[sort_nat::div()] = "div";
+	output[sort_nat::mod()] = "mod";
+	output[sort_nat::exp(nat, nat)] = data_equation(variable_list({n, n2}), sort_nat::exp(n, n2), if_(equal_to(n2, nat_zero), n, if_(less(n, nat_two), n, sort_nat::pos2nat(nat_do_exp(sort_nat::nat2pos(n), n2)))));
+	output[sort_nat::exp(pos, nat)] = data_equation(variable_list({p, n2}), sort_nat::exp(p, n2), if_(equal_to(n2, nat_zero), p, if_(equal_to(p, pos_one), p, nat_do_exp(p, n2))));
+	
+	
+	function_symbol int_zero("zero", int_);
+	output[int_zero] = "0";
+	function_symbol int_one("one", int_);
+	output[int_one] = "1";
+	
+	output[less(int_)] = "<";
+	output[less_equal(int_)] = "<=";
+	output[greater(int_)] = ">";
+	output[greater_equal(int_)] = ">=";
+	output[sort_int::pos2int()] = function_definition::identity();
+	output[sort_int::int2pos()] = function_definition::identity();
+	output[sort_int::nat2int()] = function_definition::identity();
+	output[sort_int::int2nat()] = function_definition::identity();
+	output[sort_int::maximum(pos, int_)] = data_equation(variable_list({p, i}), sort_int::maximum(p, i), sort_int::int2pos(sort_int::maximum(sort_int::pos2int(p), i)));
+	output[sort_int::maximum(int_, pos)] = data_equation(variable_list({i, p}), sort_int::maximum(i, p), sort_int::int2pos(sort_int::maximum(i, sort_int::pos2int(p))));
+	output[sort_int::maximum(nat, int_)] = data_equation(variable_list({n, i}), sort_int::maximum(n, i), sort_int::int2nat(sort_int::maximum(sort_int::nat2int(n), i)));
+	output[sort_int::maximum(int_, nat)] = data_equation(variable_list({i, n}), sort_int::maximum(i, n), sort_int::int2nat(sort_int::maximum(i, sort_int::nat2int(n))));
+	output[sort_int::abs()] = data_equation(variable_list({i}), sort_int::abs(i), if_(less(i, int_zero), sort_int::minus(int_zero, i), i));
+	output[sort_int::negate(pos)] = data_equation(variable_list({p}), sort_int::negate(p), sort_int::minus(int_zero, sort_int::pos2int(p)));
+	output[sort_int::negate(nat)] = data_equation(variable_list({n}), sort_int::negate(n), sort_int::minus(int_zero, sort_int::nat2int(n)));
+	output[sort_int::negate(int_)] = data_equation(variable_list({i}), sort_int::negate(i), sort_int::minus(int_zero, i));
+	output[sort_int::succ(int_)] = data_equation(variable_list({i}), sort_int::succ(i), sort_int::plus(i, int_one));
+	output[sort_int::pred(nat)] = data_equation(variable_list({n}), sort_int::pred(n), sort_int::minus(sort_int::nat2int(n), int_one));
+	output[sort_int::pred(int_)] = data_equation(variable_list({i}), sort_int::pred(i), sort_int::minus(i, int_one));
+	output[sort_int::plus(int_, int_)] = "+";
+	output[sort_int::minus(pos, pos)] = "-";
+	output[sort_int::minus(nat, nat)] = "-";
+	output[sort_int::minus(int_, int_)] = "-";
+	output[sort_int::times(int_, int_)] = "*";
+	output[sort_int::div(int_, pos)] = "div";
+	output[sort_int::mod(int_, pos)] = "mod";
+	output[sort_int::exp(int_, nat)] = data_equation(variable_list({i, n}), sort_int::exp(i, n), if_(equal_to(sort_nat::mod(n, nat_two), nat_zero), sort_int::nat2int(sort_nat::exp(sort_int::abs(i), n)), sort_int::minus(int_zero, sort_int::nat2int(sort_nat::exp(sort_int::abs(i), n)))));
+	
+	
+	function_symbol real_zero("zero", real);
+	output[real_zero] = "0";
+	function_symbol real_one("one", real);
+	output[real_one] = "1";
+	function_symbol real_half("half", real);
+	output[real_half] = "(/ 1 2)";
+	function_symbol real_div("div", function_sort(sort_expression_list({real, pos}), int_));
+	output[real_div] = "div";
+	function_symbol real_do_exp("exp", function_sort(sort_expression_list({real, nat}), real));
+	output[real_do_exp] = data_equation(variable_list({r, n}), real_do_exp(r, n), if_(equal_to(n, nat_one), r, if_(equal_to(sort_nat::mod(n, nat_two), nat_one), sort_real::times(r, real_do_exp(sort_pos::times(r, r), sort_nat::div(n, nat_two))), real_do_exp(sort_real::times(r, r), sort_nat::div(n, nat_two)))));
+	
+	output[less(real)] = "<";
+	output[less_equal(real)] = "<=";
+	output[greater(real)] = ">";
+	output[greater_equal(real)] = ">=";
+	output[sort_real::pos2real()] = function_definition::identity();
+	output[sort_real::real2pos()] = function_definition::identity();
+	output[sort_real::nat2real()] = function_definition::identity();
+	output[sort_real::real2nat()] = function_definition::identity();
+	output[sort_real::int2real()] = function_definition::identity();
+	output[sort_real::real2int()] = function_definition::identity();
+	output[sort_real::creal()] = "/";
+	output[sort_real::abs(real)] = data_equation(variable_list({r}), sort_real::abs(r), if_(less(r, real_zero), sort_real::minus(real_zero, r), r));
+	output[sort_real::negate(real)] = data_equation(variable_list({r}), sort_real::negate(r), sort_real::minus(real_zero, r));
+	output[sort_real::succ(real)] = data_equation(variable_list({r}), sort_real::succ(r), sort_real::plus(r, real_one));
+	output[sort_real::pred(real)] = data_equation(variable_list({r}), sort_real::pred(r), sort_real::minus(r, real_one));
+	output[sort_real::plus(real, real)] = "+";
+	output[sort_real::minus(real, real)] = "-";
+	output[sort_real::times(real, real)] = "*";
+	output[sort_real::divides(pos, pos)] = "/";
+	output[sort_real::divides(nat, nat)] = "/";
+	output[sort_real::divides(int_, int_)] = "/";
+	output[sort_real::divides(real, real)] = "/";
+	output[sort_real::exp(real, int_)] = data_equation(variable_list({r, i}), sort_real::exp(r, i), if_(equal_to(i, int_zero), real_one, if_(less(i, int_zero), real_do_exp(sort_real::divides(real_one, r), sort_int::abs(i)), real_do_exp(r, sort_int::int2nat(i)))));
+	output[sort_real::floor()] = data_equation(variable_list({r}), sort_real::floor(r), real_div(r, pos_one));
+	output[sort_real::ceil()] = data_equation(variable_list({r}), sort_real::ceil(r), sort_real::negate(real_div(sort_real::negate(r), pos_one)));
+	output[sort_real::round()] = data_equation(variable_list({r}), sort_real::round(r), sort_real::floor(sort_real::plus(r, real_half)));
+	
+	
+	add_undefined_functions(output, sort_bool::bool_generate_functions_code());
+	add_undefined_functions(output, sort_pos::pos_generate_functions_code());
+	add_undefined_functions(output, sort_nat::nat_generate_functions_code());
+	add_undefined_functions(output, sort_int::int_generate_functions_code());
+	add_undefined_functions(output, sort_real::real_generate_functions_code());
+	
+	
+	for (std::vector<sort_expression>::const_iterator i = sorts.begin(); i != sorts.end(); ++i) {
+		variable v1("v1", *i);
+		variable v2("v2", *i);
+		
+		output[if_(*i)] = "if";
+		if (!output.count(greater(*i))) {
+			output[greater(*i)] = data_equation(variable_list({v1, v2}), greater(v1, v2), sort_bool::not_(less_equal(v1, v2)));
+		}
+		if (!output.count(greater_equal(*i))) {
+			output[greater_equal(*i)] = data_equation(variable_list({v1, v2}), greater_equal(v1, v2), sort_bool::not_(less(v1, v2)));
+		}
+	}
+	
+	
+	return output;
+}
+
+// A rule is a data equation in a given matching context.
+// Besides an rhs and condition, it has data expressions corresponding to matching terms,
+// and instantiations for variables that no longer exist in the matching contest.
+// For example, the rewrite rule "foo(x, y, []) = z" in the matching context "foo(v2 |> v3, v0, v1)"
+//   with arguments = [a, b, head(L), tail(L)]
+// has parameters { 0 -> y, 1 -> [] }:
+//   matching term v0 corresponds to expression y,
+//   matching term v1 corresponds to expression [],
+//   matching terms v2 and v3 don't correspond to anything in the rewrite rule
+// and bound_variables { x -> "L" }.
+struct rule
+{
+	data_expression rhs;
+	data_expression condition;
+	std::map<size_t, data_expression> parameters;
+	std::map<variable, std::string> bound_variables;
+};
+
+static std::string match_pattern(
+	const data_specification &specification,
+	const translated_data_specification &translation,
+	sort_expression sort,
+	data_expression pattern,
+	set_identifier_generator &argument_variable_generator,
+	std::vector<variable> argument_variables,
+	std::vector<std::string> arguments,
+	data_expression condition,
+	std::vector<rule> rules)
+{
+	if (rules.empty()) {
+		representative_generator generator(specification);
+		data_expression expression = generator(sort);
+		mCRL2log(log::warning) << "Completing function definition with rule " << data::pp(data_equation(variable_list(), condition, pattern, expression)) << "\n";
+		return translate_expression(expression, std::map<variable, std::string>(), translation);
+	}
+	
+	rule first_rule = rules[0];
+	for (size_t i = 0; i < arguments.size(); ++i) {
+		if (first_rule.parameters.count(i) && !is_variable(first_rule.parameters[i])) {
+			assert(is_function_symbol(first_rule.parameters[i]) || is_application(first_rule.parameters[i]));
+			
+			function_symbol_vector constructors = specification.constructors(first_rule.parameters[i].sort().target_sort());
+			
+			std::map<function_symbol, size_t> constructor_indices;
+			for (size_t j = 0; j < constructors.size(); ++j) {
+				constructor_indices[constructors[j]] = j;
+			}
+			
+			std::vector<std::vector<rule> > split_rules;
+			split_rules.resize(constructors.size());
+			for (std::vector<rule>::iterator j = rules.begin(); j != rules.end(); ++j) {
+				rule new_rule;
+				new_rule.rhs = j->rhs;
+				new_rule.condition = j->condition;
+				new_rule.bound_variables = j->bound_variables;
+				for (size_t k = 0; k < i; ++k) {
+					if (j->parameters.count(k)) {
+						new_rule.parameters[k] = j->parameters[k];
+					}
+				}
+				for (size_t k = i + 1; k < arguments.size(); ++k) {
+					if (j->parameters.count(k)) {
+						new_rule.parameters[k - 1] = j->parameters[k];
+					}
+				}
+				
+				if (!j->parameters.count(i) || is_variable(j->parameters[i])) {
+					if (j->parameters.count(i)) {
+						new_rule.bound_variables[variable(j->parameters[i])] = arguments[i];
+					}
+					
+					for (std::vector<std::vector<rule> >::iterator k = split_rules.begin(); k != split_rules.end(); ++k) {
+						k->push_back(new_rule);
+					}
+				} else {
+					function_symbol constructor;
+					if (is_function_symbol(j->parameters[i])) {
+						constructor = function_symbol(j->parameters[i]);
+					} else {
+						assert(is_application(j->parameters[i]));
+						application a(j->parameters[i]);
+						constructor = function_symbol(a.head());
+						
+						size_t index = arguments.size() - 1;
+						for (application::const_iterator k = a.begin(); k != a.end(); ++k) {
+							new_rule.parameters[index++] = *k;
+						}
+					}
+					assert(constructor_indices.count(constructor));
+					split_rules[constructor_indices[constructor]].push_back(new_rule);
+				}
+			}
+			
+			std::vector<std::string> base_arguments;
+			base_arguments.insert(base_arguments.end(), arguments.begin(), arguments.begin() + i);
+			base_arguments.insert(base_arguments.end(), arguments.begin() + i + 1, arguments.end());
+			
+			std::vector<variable> base_argument_variables;
+			base_argument_variables.insert(base_argument_variables.end(), argument_variables.begin(), argument_variables.begin() + i);
+			base_argument_variables.insert(base_argument_variables.end(), argument_variables.begin() + i + 1, argument_variables.end());
+			
+			std::string output;
+			for (size_t j = 0; j < constructors.size(); ++j) {
+				assert(translation.constructor_field_names.count(constructors[j]));
+				std::vector<std::string> constructor_field_names = translation.constructor_field_names.at(constructors[j]);
+				assert(constructor_field_names.size() == (is_function_sort(constructors[j].sort()) ? function_sort(constructors[j].sort()).domain().size() : 0));
+				
+				std::vector<std::string> case_arguments = base_arguments;
+				std::vector<variable> term_variables;
+				for (size_t k = 0; k < constructor_field_names.size(); ++k) {
+					case_arguments.push_back("(" + constructor_field_names[k] + " " + arguments[i] + ")");
+					term_variables.push_back(variable(argument_variable_generator("v"), sort_bool::bool_()));
+				}
+				
+				std::vector<variable> case_argument_variables = base_argument_variables;
+				case_argument_variables.insert(case_argument_variables.end(), term_variables.begin(), term_variables.end());
+				data_expression term;
+				if (constructor_field_names.size() > 0) {
+					term = application(constructors[j], term_variables.begin(), term_variables.end());
+				} else {
+					term = constructors[j];
+				}
+				data_expression_assignment assignment(argument_variables[i], term);
+				data_expression new_pattern = replace_free_variables(pattern, assignment);
+				
+				std::string result = match_pattern(specification, translation, sort, new_pattern, argument_variable_generator, case_argument_variables, case_arguments, condition, split_rules[j]);
+				if (j == 0) {
+					output = result;
+				} else {
+					assert(translation.function_names.count(constructors[j]));
+					output = "(if (" + translation.function_names.at(constructors[j]) + "? " + arguments[i] + ") " + result + " " + output + ")";
+				}
+			}
+			
+			return output;
+		}
+	}
+	
+	std::map<variable, std::string> bound_variables = first_rule.bound_variables;
+	for (size_t i = 0; i < arguments.size(); ++i) {
+		if (first_rule.parameters.count(i)) {
+			assert(is_variable(first_rule.parameters[i]));
+			bound_variables[variable(first_rule.parameters[i])] = arguments[i];
+		}
+	}
+	
+	if (first_rule.condition != sort_bool::true_()) {
+		data_expression case_condition = first_rule.condition;
+		std::string condition_result = translate_expression(case_condition, bound_variables, translation);
+		std::string true_result = translate_expression(first_rule.rhs, bound_variables, translation);
+		rules.erase(rules.begin());
+		std::string false_result = match_pattern(specification, translation, sort, pattern, argument_variable_generator, argument_variables, arguments, sort_bool::and_(condition, sort_bool::not_(case_condition)), rules);
+		
+		return "(if " + condition_result + " " + true_result + " " + false_result + ")";
+	}
+	
+	return translate_expression(first_rule.rhs, bound_variables, translation);
+}
+
+
+struct remove_duplicate_variables_builder: public data_expression_builder<remove_duplicate_variables_builder>
+{
+  typedef data_expression_builder<remove_duplicate_variables_builder> super;
+  using super::enter;
+  using super::leave;
+  using super::apply;
+
+  set_identifier_generator generator;
+  std::set<variable> seen;
+  std::map<variable, variable> replacements;
+
+  remove_duplicate_variables_builder(set_identifier_generator &generator_): generator(generator_) {}
+
+  variable apply(const variable &v)
+  {
+    if (seen.count(v))
+    {
+      core::identifier_string name = generator(v.name());
+      variable new_variable(name, v.sort());
+      replacements[new_variable] = v;
+      return new_variable;
+    }
+    else
+    {
+      seen.insert(v);
+      return v;
+    }
+  }
+
+#if BOOST_MSVC
+#include "mcrl2/core/detail/builder_msvc.inc.h"
+#endif
+};
+
+
+
+// Converts a set of equations together defining a function into a function definition in yices format.
+static std::string construct_function_definition(data::function_symbol function, const std::vector<data_equation> &equations, const data_specification &specification, const translated_data_specification &translation)
+{
+	if (!is_function_sort(function.sort())) {
+		assert(equations.size() == 1);
+		assert(equations[0].condition() == sort_bool::true_());
+		std::string output;
+		output += "(define ";
+		output += translation.function_names.at(function);
+		output += "::";
+		output += translation.sort_names.at(function.sort());
+		output += " ";
+		output += translate_expression(equations[0].rhs(), std::map<variable, std::string>(), translation);
+		output += ")";
+		return output;
+	}
+	
+	set_identifier_generator argument_variable_generator;
+	std::vector<variable> argument_variables;
+	std::vector<std::string> arguments;
+	
+	function_sort sort(function.sort());
+	sort_expression_list domain = sort.domain();
+	for (sort_expression_list::iterator i = domain.begin(); i != domain.end(); ++i) {
+		core::identifier_string name = argument_variable_generator("v");
+		arguments.push_back(name);
+		argument_variables.push_back(variable(name, *i));
+	}
+	data_expression pattern = application(function, argument_variables.begin(), argument_variables.end());
+	
+	std::set<function_symbol> all_constructors(specification.constructors().begin(), specification.constructors().end());
+	
+	std::vector<rule> rules;
+	for (std::vector<data_equation>::const_iterator i = equations.begin(); i != equations.end(); ++i) {
+		// The lhs may contain duplicate variables.
+		// Replace them with fresh ones, and add equality conditions.
+		set_identifier_generator generator;
+		for (variable_list::iterator j = i->variables().begin(); j != i->variables().end(); ++j) {
+			generator.add_identifier(j->name());
+		}
+		remove_duplicate_variables_builder remover(generator);
+		data_expression lhs = remover.apply(i->lhs());
+		std::vector<data_expression> conditions;
+		if (i->condition() != sort_bool::true_()) {
+			conditions.push_back(i->condition());
+		}
+		for (std::map<variable, variable>::iterator j = remover.replacements.begin(); j != remover.replacements.end(); ++j) {
+			conditions.push_back(equal_to(j->first, j->second));
+		}
+		
+		
+		
+		rule new_rule;
+		new_rule.rhs = i->rhs();
+		new_rule.condition = lazy::join_and(conditions.begin(), conditions.end());
+		
+		assert(is_application(lhs));
+		application a(lhs);
+		assert(a.head() == function);
+		
+		int index = 0;
+		bool invalid = false;
+		for (application::const_iterator j = a.begin(); j != a.end(); ++j) {
+			new_rule.parameters[index++] = *j;
+			
+			std::set<function_symbol> functions_used = find_function_symbols(*j);
+			for (std::set<function_symbol>::iterator k = functions_used.begin(); k != functions_used.end(); ++k) {
+				if (!all_constructors.count(*k)) {
+					invalid = true;
+					break;
+				}
+			}
+		}
+		
+		if (!invalid) {
+			rules.push_back(new_rule);
+		}
+	}
+	
+	std::string rhs = match_pattern(specification, translation, sort.codomain(), pattern, argument_variable_generator, argument_variables, arguments, sort_bool::true_(), rules);
+	
+	assert(translation.function_names.count(function));
+	assert(translation.sort_names.count(sort.codomain()));
+	
+	std::string output;
+	output += "(define ";
+	output += translation.function_names.at(function);
+	output += "::(-> ";
+	for (sort_expression_list::iterator i = domain.begin(); i != domain.end(); ++i) {
+		assert(translation.sort_names.count(*i));
+		output += translation.sort_names.at(*i);
+		output += " ";
+	}
+	output += translation.sort_names.at(sort.codomain());
+	output += ") (lambda (";
+	size_t index = 0;
+	for (sort_expression_list::iterator i = domain.begin(); i != domain.end(); ++i) {
+		if (index != 0) {
+			output += " ";
+		}
+		output += arguments[index++];
+		output += "::";
+		output += translation.sort_names.at(*i);
+	}
+	output += ") ";
+	output += rhs;
+	output += "))";
+	
+	return output;
+}
+
+void translate_data_specification(const mcrl2::pbes_system::pbes &pbes, translated_data_specification &translation)
+{
+	const data_specification &data = pbes.data();
+	
+	set_identifier_generator function_name_generator;
+	
+	// Translate all sorts to yices sort definitions.
+	std::vector<sort_expression> sorts = required_sorts(pbes);
+	for (std::vector<sort_expression>::iterator i = sorts.begin(); i != sorts.end(); i++) {
+		translate_sort_definition(data, *i, function_name_generator, translation);
+		
+		// Equality and inequality must be defined for all sorts.
+		translation.function_names[equal_to(*i)] = "=";
+		translation.function_names[not_equal_to(*i)] = "/=";
+	}
+	// The unrolling code may generate invocations of those functions.
+	translation.function_names[sort_bool::and_()] = "and";
+	translation.function_names[sort_bool::or_()] = "or";
+	translation.function_names[sort_bool::not_()] = "not";
+	
+	std::set<data::function_symbol> builtin_constructors = get_builtin_constructors();
+	std::map<mcrl2::data::function_symbol, function_definition> definitions = builtin_function_map(sorts);
+	std::map<mcrl2::data::function_symbol, std::vector<data_equation> > equations;
+	for (std::set<data_equation>::const_iterator i = pbes.data().equations().begin(); i != pbes.data().equations().end(); i++) {
+		if (is_application(i->lhs())) {
+			application lhs(i->lhs());
+			if (is_function_symbol(lhs.head())) {
+				function_symbol function(lhs.head());
+				equations[function].push_back(*i);
+			}
+		} else if (is_function_symbol(i->lhs())) {
+			function_symbol lhs(i->lhs());
+			equations[lhs].push_back(*i);
+		}
+	}
+	for (std::map<mcrl2::data::function_symbol, std::vector<data_equation> >::iterator i = equations.begin(); i != equations.end(); ++i) {
+		if (definitions.count(i->first) == 0) {
+			definitions[i->first] = i->second;
+		}
+	}
+	
+	std::map<mcrl2::data::function_symbol, std::set<mcrl2::data::function_symbol> > definition_dependencies;
+	std::set<data::function_symbol> queue = find_function_symbols(pbes);
+	while (!queue.empty()) {
+		data::function_symbol function = *queue.begin();
+		queue.erase(function);
+		
+		std::set<mcrl2::data::function_symbol> dependencies;
+		if (translation.function_names.count(function) == 0 && builtin_constructors.count(function) == 0) {
+			assert(definitions.count(function) > 0);
+			
+			function_definition definition = definitions[function];
+			if (definition.is_unavailable()) {
+				throw mcrl2::runtime_error("Function " + data::pp(function) + " not available in pbes2yices, giving up.");
+			}
+			
+			if (definition.is_equations()) {
+				const std::vector<data_equation> &function_equations = definition.equations();
+				for (std::vector<data_equation>::const_iterator i = function_equations.begin(); i != function_equations.end(); ++i) {
+					std::set<mcrl2::data::function_symbol> equation_dependencies = find_function_symbols(i->rhs());
+					dependencies.insert(equation_dependencies.begin(), equation_dependencies.end());
+					equation_dependencies = find_function_symbols(i->condition());
+					dependencies.insert(equation_dependencies.begin(), equation_dependencies.end());
+				}
+				dependencies.erase(function);
+				
+				for (std::set<mcrl2::data::function_symbol>::iterator i = dependencies.begin(); i != dependencies.end(); ++i) {
+					if (definition_dependencies.count(*i) == 0) {
+						queue.insert(*i);
+					}
+				}
+			}
+		}
+		definition_dependencies[function] = dependencies;
+	}
+	
+	std::vector<data::function_symbol> function_order;
+	try {
+		function_order = tsort(definition_dependencies);
+	} catch(mcrl2::runtime_error e) {
+		throw mcrl2::runtime_error("Mutually recursive function definitions detected, giving up.");
+	}
+	
+	for (std::vector<data::function_symbol>::iterator i = function_order.begin(); i != function_order.end(); ++i) {
+		if (builtin_constructors.count(*i)) {
+			continue;
+		}
+		if (translation.function_names.count(*i)) {
+			continue;
+		}
+		assert(definitions.count(*i));
+		
+		function_definition definition = definitions[*i];
+		assert(!definition.is_unavailable());
+		
+		if (definition.is_builtin()) {
+			translation.function_names[*i] = definition.name();
+		} else if (definition.is_identity()) {
+			translation.function_names[*i] = "";
+		} else {
+			assert(definition.is_equations());
+			
+			std::string name = sanitize_term(i->name());
+			if (function_name_generator.has_identifier(name)) {
+				if (!function_sort(i->sort()).domain().empty()) {
+					name = mangle_sort_name(*function_sort(i->sort()).domain().begin()) + "-" + name;
+				}
+			}
+			name = function_name_generator(name);
+			
+			translation.function_names[*i] = name;
+			translation.definition += construct_function_definition(*i, definition.equations(), data, translation) + "\n";
+		}
+	}
+}

--- a/tools/experimental/pbes2yices/pbes2yices.cpp
+++ b/tools/experimental/pbes2yices/pbes2yices.cpp
@@ -1,0 +1,210 @@
+// Author(s): Ruud Koolen
+// Copyright: see the accompanying file COPYING or copy at
+// https://svn.win.tue.nl/trac/MCRL2/browser/trunk/COPYING
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+/// \file pbes2yices.cpp
+
+#define NAME "pbes2yices"
+#define AUTHOR "Ruud Koolen"
+
+#include "pbes2yices.h"
+
+#include "mcrl2/utilities/input_output_tool.h"
+#include "mcrl2/bes/pbes_input_tool.h"
+
+#include "mcrl2/pbes/io.h"
+#include "mcrl2/pbes/normalize.h"
+
+#include <fstream>
+
+
+using namespace mcrl2;
+using namespace mcrl2::log;
+using namespace mcrl2::pbes_system;
+using namespace mcrl2::utilities;
+using namespace mcrl2::utilities::tools;
+using namespace mcrl2::bes::tools;
+
+enum goal_t { disjunctiveWitness, disjunctiveAcyclicUnrolling, conjunctiveWitness, conjunctiveAcyclicUnrolling };
+
+inline std::istream& operator>>(std::istream& is, goal_t& goal)
+{
+  std::stringbuf buffer;
+  is >> &buffer;
+
+  if (buffer.str() == "disjunctiveWitness") goal = disjunctiveWitness;
+  else if (buffer.str() == "disjunctiveAcyclicUnrolling") goal = disjunctiveAcyclicUnrolling;
+  else if (buffer.str() == "conjunctiveWitness") goal = conjunctiveWitness;
+  else if (buffer.str() == "conjunctiveAcyclicUnrolling") goal = conjunctiveAcyclicUnrolling;
+  else is.setstate(std::ios_base::failbit);
+
+  return is;
+}
+
+inline std::ostream& operator<<(std::ostream& os, const goal_t goal)
+{
+  if (goal == disjunctiveWitness) os << "disjunctiveWitness";
+  else if (goal == disjunctiveAcyclicUnrolling) os << "disjunctiveAcyclicUnrolling";
+  else if (goal == conjunctiveWitness) os << "conjunctiveWitness";
+  else if (goal == conjunctiveAcyclicUnrolling) os << "conjunctiveAcyclicUnrolling";
+  return os;
+}
+
+
+inline std::string description(const goal_t goal)
+{
+  if (goal == disjunctiveWitness) return "a witness for a disjunctive PBES; if satisfiable, shows that the value of the PBES is true";
+  if (goal == disjunctiveAcyclicUnrolling) return "an acyclic unrolling for a disjunctive PBES; if unsatisfiable, shows that the value of the PBES is false";
+  if (goal == conjunctiveWitness) return "a witness for a conjunctive PBES; if satisfiable, shows that the value of the PBES is false";
+  if (goal == conjunctiveAcyclicUnrolling) return "an acyclic unrolling for a disjunctive PBES; if unsatisfiable, shows that the value of the PBES is true";
+  return "";
+}
+
+class pbes2yices_tool: public pbes_input_tool<input_output_tool>
+{
+  protected:
+    // Tool options.
+    unsigned int opt_levels; // Number of unrolling levels
+    bool opt_hasgoal;
+    goal_t opt_goal;
+
+    typedef pbes_input_tool<input_output_tool> super;
+
+  public:
+    pbes2yices_tool()
+      : super(
+        NAME,
+        AUTHOR,
+        "Generate a BES from a PBES and solve it. ",
+        "Solves (P)BES from INFILE. "
+        "If INFILE is not present, stdin is used. "),
+      opt_levels(10)
+    {}
+
+  protected:
+    void parse_options(const command_line_parser& parser)
+    {
+      super::parse_options(parser);
+
+      if (parser.options.count("levels"))
+      {
+        opt_levels = parser.option_argument_as< unsigned int > ("levels");
+      }
+
+      if (parser.options.count("goal") == 0)
+      {
+        opt_hasgoal = false;
+      }
+      else
+      {
+        opt_hasgoal = true;
+        opt_goal = parser.option_argument_as<goal_t>("goal");
+      }
+    }
+
+    void add_options(interface_description& desc)
+    {
+      super::add_options(desc);
+      desc.add_option("levels", make_mandatory_argument("NUM"), "unroll NUM levels", 'l');
+      desc.add_option("goal", make_enum_argument<goal_t>("GOAL").
+          add_value(disjunctiveWitness).
+          add_value(disjunctiveAcyclicUnrolling).
+          add_value(conjunctiveWitness).
+          add_value(conjunctiveAcyclicUnrolling),
+          "produce an SMT file for proving GOAL:", 'g');
+    }
+
+  public:
+    bool run()
+    {
+      // load the pbes
+      pbes p;
+      load_pbes(p, input_filename(), pbes_input_format());
+
+      normalize(p);
+
+      if (!opt_hasgoal)
+      {
+        parsed_pbes parsed;
+        if (parse_pbes(p, true, parsed))
+        {
+          std::cout << "disjunctive\n";
+          return true;
+        }
+        else if (parse_pbes(p, false, parsed))
+        {
+          std::cout << "conjunctive\n";
+          return true;
+        }
+        else
+        {
+          return false;
+        }
+      }
+
+      parsed_pbes parsed;
+      if (opt_goal == disjunctiveWitness || opt_goal == disjunctiveAcyclicUnrolling)
+      {
+        if (!parse_pbes(p, true, parsed))
+        {
+          mCRL2log(log::error) << "This is not a disjunctive PBES, giving up.\n";
+          return false;
+        }
+      }
+      else
+      {
+        if (!parse_pbes(p, false, parsed))
+        {
+          mCRL2log(log::error) << "This is not a conjunctive PBES, giving up.\n";
+          return false;
+        }
+      }
+
+      translated_data_specification specification;
+      translate_data_specification(p, specification);
+
+      std::string output;
+      if (opt_goal == disjunctiveWitness || opt_goal == conjunctiveWitness)
+      {
+        output = generate_witness_proposition(parsed, specification, opt_levels);
+      }
+      else
+      {
+        output = generate_acyclic_unrolling_proposition(parsed, specification, opt_levels);
+      }
+
+      if (output_filename().empty())
+      {
+        std::cout << output;
+        if (std::cout.fail())
+        {
+          std::cerr << "Could not write SMT problem to standard output\n";
+          return false;
+        }
+      }
+      else
+      {
+        std::ofstream outputfile;
+        outputfile.open(output_filename().c_str());
+        outputfile << output;
+        if (outputfile.fail())
+        {
+          std::cerr << "Could not write SMT problem to " << output_filename() << "\n";
+          return false;
+        }
+        outputfile.close();
+      }
+
+      return true;
+    }
+
+};
+
+int main(int argc, char* argv[])
+{
+  return pbes2yices_tool().execute(argc, argv);
+}

--- a/tools/experimental/pbes2yices/pbes2yices.h
+++ b/tools/experimental/pbes2yices/pbes2yices.h
@@ -1,0 +1,63 @@
+// Author(s): Ruud Koolen
+// Copyright: see the accompanying file COPYING or copy at
+// https://svn.win.tue.nl/trac/MCRL2/browser/trunk/COPYING
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef PBES2YICES_H
+#define PBES2YICES_H
+
+#include "mcrl2/data/data.h"
+#include "mcrl2/data/data_specification.h"
+#include "mcrl2/pbes/pbes.h"
+
+static inline std::string itoa(int number)
+{
+	char buffer[40];
+	snprintf(buffer, sizeof(buffer), "%d", number);
+	return std::string(buffer);
+}
+
+struct translated_data_specification
+{
+	std::string definition;
+	std::map<mcrl2::data::sort_expression, std::string> sort_names;
+	std::map<mcrl2::data::function_symbol, std::vector<std::string> > constructor_field_names;
+	std::map<mcrl2::data::function_symbol, std::string> function_names;
+};
+
+struct clause
+{
+	mcrl2::data::variable_vector quantification_domain;
+	mcrl2::data::data_expression predicate;
+	mcrl2::pbes_system::propositional_variable_instantiation instantiation;
+};
+
+struct equation
+{
+	mcrl2::pbes_system::fixpoint_symbol symbol;
+	mcrl2::pbes_system::propositional_variable variable;
+	std::vector<clause> clauses;
+};
+
+struct parsed_pbes
+{
+	std::set<mcrl2::data::variable> global_variables;
+	std::vector<equation> equations;
+	mcrl2::pbes_system::propositional_variable_instantiation initial_state;
+	bool disjunctive;
+};
+
+void translate_data_specification(const mcrl2::pbes_system::pbes &pbes, translated_data_specification &translation);
+
+std::string translate_expression(mcrl2::data::data_expression expression, const std::map<mcrl2::data::variable, std::string> &bound_variables, const translated_data_specification &translation);
+
+bool parse_pbes(const mcrl2::pbes_system::pbes &pbes, bool disjunctive, parsed_pbes &output);
+
+std::string generate_witness_proposition(const parsed_pbes &pbes, const translated_data_specification &translation, size_t levels);
+
+std::string generate_acyclic_unrolling_proposition(const parsed_pbes &pbes, const translated_data_specification &translation, size_t levels);
+
+#endif

--- a/tools/experimental/pbes2yices/pbesyicessolve.sh
+++ b/tools/experimental/pbes2yices/pbesyicessolve.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+PBES2YICES=pbes2yices
+YICES=yices
+
+die() {
+	echo "$1" >&2
+	exit 1
+}
+
+verbose=false
+if [[ $1 == -v ]]; then
+	verbose=true
+	shift
+fi
+
+pbes="$1"
+
+pbestype=$($PBES2YICES "$pbes") || die "Input PBES $pbes is not conjunctive or disjunctive, giving up."
+
+[[ $verbose == true ]] && [[ $pbestype == conjunctive ]] && echo "Found conjunctive PBES" >&2
+[[ $verbose == true ]] && [[ $pbestype == disjunctive ]] && echo "Found disjunctive PBES" >&2
+
+levels=1
+
+while true; do
+	[[ $verbose == true ]] && echo "Searching for witness of length $((levels * 2))..." >&2
+	yicesfile=$(mktemp pbesyicessolve.XXXXXXXXXXXX)
+	$PBES2YICES -g ${pbestype}Witness -l $((levels * 2)) $pbes $yicesfile || die "pbes2yices failure"
+	result=$($YICES $yicesfile) || die "yices failure"
+	rm -f $yicesfile
+	if [[ $result == sat ]]; then
+		[[ $verbose == true ]] && echo "Found!" >&2
+		if [[ $pbestype == disjunctive ]]; then
+			echo true
+		else
+			echo false
+		fi
+		exit 0
+	fi
+	
+	[[ $verbose == true ]] && echo "Searching for acyclic unrolling of length $levels..." >&2
+	yicesfile=$(mktemp pbesyicessolve.XXXXXXXXXXXX)
+	$PBES2YICES -g ${pbestype}AcyclicUnrolling -l $levels $pbes $yicesfile || die "pbes2yices failure"
+	result=$($YICES $yicesfile) || die "yices failure"
+	rm -f $yicesfile
+	if [[ $result == unsat ]]; then
+		[[ $verbose == true ]] && echo "Not found!" >&2
+		if [[ $pbestype == disjunctive ]]; then
+			echo false
+		else
+			echo true
+		fi
+		exit 0
+	fi
+	
+	levels=$((levels * 2))
+done

--- a/tools/experimental/pbes2yices/unrolling.cpp
+++ b/tools/experimental/pbes2yices/unrolling.cpp
@@ -1,0 +1,563 @@
+// Author(s): Ruud Koolen
+// Copyright: see the accompanying file COPYING or copy at
+// https://svn.win.tue.nl/trac/MCRL2/browser/trunk/COPYING
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#include "pbes2yices.h"
+
+using namespace mcrl2;
+using namespace mcrl2::data;
+using namespace mcrl2::pbes_system;
+
+static data_expression and_or(data_expression left, data_expression right, bool disjunction)
+{
+	if (disjunction) {
+		if (left == sort_bool::true_() || right == sort_bool::true_()) {
+			return sort_bool::true_();
+		} else if (left == sort_bool::false_()) {
+			return right;
+		} else if (right == sort_bool::false_()) {
+			return left;
+		} else {
+			return sort_bool::or_(left, right);
+		}
+	} else {
+		if (left == sort_bool::false_() || right == sort_bool::false_()) {
+			return sort_bool::false_();
+		} else if (left == sort_bool::true_()) {
+			return right;
+		} else if (right == sort_bool::true_()) {
+			return left;
+		} else {
+			return sort_bool::and_(left, right);
+		}
+	}
+}
+
+static bool parse_condition(pbes_expression expression, bool disjunctive, bool negate, data_expression &condition, variable_vector &quantification_domain)
+{
+	assert(find_propositional_variable_instantiations(expression).empty());
+	assert(quantification_domain.empty());
+	
+	while (is_pbes_not(expression)) {
+		negate = !negate;
+		expression = accessors::arg(expression);
+	}
+	if (is_pbes_imp(expression)) {
+		expression = or_(accessors::left(expression), not_(accessors::right(expression)));
+	}
+	
+	if (is_pbes_forall(expression) || is_pbes_exists(expression)) {
+		if (is_pbes_exists(expression) ^ disjunctive ^ negate) {
+			std::cerr << "Wat lastig, een verkeerde quantificatie\n";
+			return false;
+		}
+		
+		variable_list variables = accessors::var(expression);
+		bool result = parse_condition(accessors::arg(expression), disjunctive, negate, condition, quantification_domain);
+		quantification_domain.insert(quantification_domain.end(), variables.begin(), variables.end());
+		return result;
+	} else if (is_pbes_and(expression) || is_pbes_or(expression)) {
+		data_expression left_condition, right_condition;
+		variable_vector left_domain, right_domain;
+		
+		if (!parse_condition(accessors::left(expression), disjunctive, negate, left_condition, left_domain)) {
+			return false;
+		}
+		if (!parse_condition(accessors::right(expression), disjunctive, negate, right_condition, right_domain)) {
+			return false;
+		}
+		
+		quantification_domain.insert(quantification_domain.end(), left_domain.begin(), left_domain.end());
+		quantification_domain.insert(quantification_domain.end(), right_domain.begin(), right_domain.end());
+		condition = and_or(left_condition, right_condition, is_pbes_or(expression) ^ negate);
+		return true;
+	} else {
+		assert(is_data(expression));
+		condition = negate ? sort_bool::not_(data_expression(expression)) : data_expression(expression);
+		return true;
+	}
+}
+
+bool parse_clauses(pbes_expression expression, bool disjunctive, propositional_variable_instantiation constant_instantiation, variable_vector quantification_domain, data_expression condition, bool negate, std::vector<clause> &clauses)
+{
+	assert(clauses.empty());
+	
+	while (is_pbes_not(expression)) {
+		negate = !negate;
+		expression = accessors::arg(expression);
+	}
+	if (is_pbes_imp(expression)) {
+		expression = or_(accessors::left(expression), not_(accessors::right(expression)));
+	}
+	
+	if (is_data(expression)) {
+		data_expression new_condition = data_expression(expression);
+		if (negate) {
+			new_condition = sort_bool::not_(new_condition);
+		}
+		data_expression predicate = and_or(condition, new_condition, !disjunctive ^ negate);
+		
+		clause c;
+		c.quantification_domain = quantification_domain;
+		c.predicate = disjunctive ? predicate : sort_bool::not_(predicate);
+		c.instantiation = constant_instantiation;
+		clauses.push_back(c);
+		return true;
+	} else if (is_pbes_forall(expression) || is_pbes_exists(expression)) {
+		if (is_pbes_exists(expression) ^ disjunctive ^ negate) {
+			std::cerr << "Wat lastig, een verkeerde quantificatie\n";
+			return false;
+		}
+		
+		variable_list variables = accessors::var(expression);
+		quantification_domain.insert(quantification_domain.end(), variables.begin(), variables.end());
+		return parse_clauses(accessors::arg(expression), disjunctive, constant_instantiation, quantification_domain, condition, negate, clauses);
+	} else if (is_pbes_and(expression) || is_pbes_or(expression)) {
+		pbes_expression left = accessors::left(expression);
+		pbes_expression right = accessors::right(expression);
+		
+		if (is_pbes_and(expression) ^ disjunctive ^ negate) {
+			std::vector<clause> left_clauses, right_clauses;
+			if (!parse_clauses(left, disjunctive, constant_instantiation, quantification_domain, condition, negate, left_clauses)) {
+				return false;
+			}
+			if (!parse_clauses(right, disjunctive, constant_instantiation, quantification_domain, condition, negate, right_clauses)) {
+				return false;
+			}
+			clauses.insert(clauses.end(), left_clauses.begin(), left_clauses.end());
+			clauses.insert(clauses.end(), right_clauses.begin(), right_clauses.end());
+			return true;
+		}
+		
+		pbes_expression condition_part;
+		pbes_expression recurse_part;
+		
+		if (find_propositional_variable_instantiations(left).empty()) {
+			condition_part = left;
+			recurse_part = right;
+		} else if (find_propositional_variable_instantiations(right).empty()) {
+			condition_part = right;
+			recurse_part = left;
+		} else {
+			return false;
+		}
+		
+		data_expression new_condition;
+		variable_vector domain;
+		if (!parse_condition(condition_part, disjunctive, negate, new_condition, domain)) {
+			return false;
+		}
+		
+		quantification_domain.insert(quantification_domain.end(), domain.begin(), domain.end());
+		condition = and_or(condition, new_condition, !disjunctive ^ negate);
+		return parse_clauses(recurse_part, disjunctive, constant_instantiation, quantification_domain, condition, negate, clauses);
+	} else {
+		assert(is_propositional_variable_instantiation(expression));
+		propositional_variable_instantiation instantiation(expression);
+		
+		if (negate) {
+			mCRL2log(log::error) << "Found negatively occurring propositional variable instantiation " << pbes_system::pp(instantiation) << ", giving up.\n";
+			return false;
+		}
+		
+		clause c;
+		c.quantification_domain = quantification_domain;
+		c.predicate = disjunctive ? condition : sort_bool::not_(condition);
+		c.instantiation = instantiation;
+		clauses.push_back(c);
+		return true;
+	}
+}
+
+bool parse_pbes(const pbes &pbes, bool disjunctive, parsed_pbes &output)
+{
+	assert(output.equations.empty());
+	
+	// Create a TRUE variable or a FALSE variable.
+	core::identifier_string constant_variable_name(disjunctive ? "X_true" : "X_false");
+	
+	clause constant_clause;
+	constant_clause.predicate = sort_bool::true_();
+	constant_clause.instantiation = propositional_variable_instantiation(constant_variable_name, data_expression_list());
+	
+	equation constant_equation;
+	constant_equation.symbol = disjunctive ? fixpoint_symbol::nu() : fixpoint_symbol::mu();
+	constant_equation.variable = propositional_variable(constant_variable_name, variable_list());
+	constant_equation.clauses.push_back(constant_clause);
+	
+	for (std::vector<pbes_equation>::const_iterator i = pbes.equations().begin(); i != pbes.equations().end(); ++i) {
+		equation e;
+		e.symbol = i->symbol();
+		e.variable = i->variable();
+		if (!parse_clauses(i->formula(), disjunctive, constant_clause.instantiation, variable_vector(), disjunctive ? sort_bool::true_() : sort_bool::false_(), false, e.clauses)) {
+			output.equations.clear();
+			return false;
+		}
+		output.equations.push_back(e);
+	}
+	output.equations.push_back(constant_equation);
+	output.initial_state = pbes.initial_state();
+	output.disjunctive = disjunctive;
+	output.global_variables = pbes.global_variables();
+	
+/*	
+	std::cerr << "Parsed form:\n====================\n";
+	for (std::vector<equation>::iterator i = output.equations.begin(); i != output.equations.end(); ++i) {
+		std::cerr << pbes_system::pp(i->symbol) << " " << pbes_system::pp(i->variable) << " = \n";
+		for (std::vector<clause>::iterator j = i->clauses.begin(); j != i->clauses.end(); ++j) {
+			std::cerr << "    (";
+			if (!j->quantification_domain.empty()) {
+				std::cerr << "exists ";
+				for (variable_vector::iterator k = j->quantification_domain.begin(); k != j->quantification_domain.end(); ++k) {
+					std::cerr << data::pp(*k);
+					if (k != j->quantification_domain.end() - 1) {
+						std::cerr << ", ";
+					}
+				}
+				std::cerr << " . ";
+			}
+			std::cerr << data::pp(j->predicate);
+			std::cerr << (output.disjunctive ? " && " : " || ");
+			std::cerr << pbes_system::pp(j->instantiation);
+			std::cerr << ")";
+			if (j == i->clauses.end() - 1) {
+				std::cerr << ";";
+			} else {
+				std::cerr << (output.disjunctive ? " ||" : " &&");
+			}
+			std::cerr << "\n\n";
+		}
+	}
+*/	
+	return true;
+}
+
+struct unrolling_variables
+{
+	// Contains the name of PBES global variables.
+	std::map<data::variable, std::string> global_variables;
+	// Contains, for each propositional variable name, its index.
+	std::map<core::identifier_string, size_t> variable_indices;
+	// Contains, for each round i, the name of the variable T_i.
+	std::vector<std::string> equation_number_variables;
+	// Contains, for each round i, equation j, and data parameter k of equation j, the name of the variable d_i_j_k.
+	std::vector<std::vector<std::vector<std::string> > > parameter_variables;
+	// Contains, for each round i, equation j, clause k, and quantification variable E, the name of the variable E.
+	std::vector<std::vector<std::vector<std::vector<std::string> > > > quantification_variables;
+	
+	// The yices definition of the above variables.
+	std::string definition;
+};
+
+static void build_unrolling_variables(const parsed_pbes &pbes, const translated_data_specification &translation, size_t rounds, unrolling_variables &variables)
+{
+	assert(rounds > 0);
+	
+	std::string global_variable_base = "global";
+	std::string equation_number_base = "equation";
+	std::string parameter_base = "parameter";
+	std::string quantification_base = "quantification";
+	
+	for (std::set<data::variable>::const_iterator i = pbes.global_variables.begin(); i != pbes.global_variables.end(); ++i) {
+		std::string global_variable = global_variable_base + "-" + std::string(i->name());
+		variables.global_variables[*i] = global_variable;
+		variables.definition += "(define " + global_variable + "::" + translation.sort_names.at(i->sort()) + ")\n";
+	}
+	
+	for (size_t i = 0; i < pbes.equations.size(); ++i) {
+		variables.variable_indices[pbes.equations[i].variable.name()] = i;
+	}
+	
+	for (size_t round = 0; round < rounds; ++round) {
+		std::string equation_number_variable = equation_number_base + "-" + itoa(round);
+		variables.equation_number_variables.push_back(equation_number_variable);
+		variables.definition += "(define " + equation_number_variable + "::nat)\n";
+		
+		std::vector<std::vector<std::string> > round_parameter_variables;
+		std::vector<std::vector<std::vector<std::string> > > round_quantification_variables;
+		for (std::vector<equation>::const_iterator i = pbes.equations.begin(); i != pbes.equations.end(); ++i) {
+			std::vector<std::string> equation_parameter_variables;
+			for (variable_list::const_iterator j = i->variable.parameters().begin(); j != i->variable.parameters().end(); ++j) {
+				std::string parameter_variable =
+					parameter_base + "-" +
+					std::string(i->variable.name()) + "-" +
+					std::string(j->name()) + "-" +
+					itoa(round);
+				equation_parameter_variables.push_back(parameter_variable);
+				variables.definition += "(define " + parameter_variable + "::" + translation.sort_names.at(j->sort()) + ")\n";
+			}
+			round_parameter_variables.push_back(equation_parameter_variables);
+			
+			std::vector<std::vector<std::string> > equation_quantification_variables;
+			for (std::vector<clause>::const_iterator j = i->clauses.begin(); j != i->clauses.end(); ++j) {
+				std::vector<std::string> clause_quantification_variables;
+				for (variable_vector::const_iterator k = j->quantification_domain.begin(); k != j->quantification_domain.end(); ++k) {
+					std::string quantification_variable =
+						quantification_base + "-" +
+						std::string(i->variable.name()) + "-" +
+						itoa(equation_quantification_variables.size()) + "-" +
+						std::string(k->name()) + "-" +
+						itoa(round);
+					clause_quantification_variables.push_back(quantification_variable);
+					variables.definition += "(define " + quantification_variable + "::" + translation.sort_names.at(k->sort()) + ")\n";
+				}
+				equation_quantification_variables.push_back(clause_quantification_variables);
+			}
+			round_quantification_variables.push_back(equation_quantification_variables);
+		}
+		variables.parameter_variables.push_back(round_parameter_variables);
+		variables.quantification_variables.push_back(round_quantification_variables);
+	}
+}
+
+static std::string assert_initial_state(const parsed_pbes &pbes, const translated_data_specification &translation, const unrolling_variables &variables)
+{
+	std::string output;
+	size_t variable_index = variables.variable_indices.at(pbes.initial_state.name());
+	output += "(assert (= " + variables.equation_number_variables[0] + " " + itoa(variable_index) + "))\n";
+	
+	const std::vector<std::string> &equation_variables = variables.parameter_variables[0][variable_index];
+	data_expression_list values = pbes.initial_state.parameters();
+	size_t index = 0;
+	for (data_expression_list::const_iterator i = values.begin(); i != values.end(); ++i) {
+		output += "(assert (= " + equation_variables[index++] + " " + translate_expression(*i, variables.global_variables, translation) + "))\n";
+	}
+	
+	return output;
+}
+
+static std::string join(const std::vector<std::string> &clauses, const std::string &op, bool simplify = true)
+{
+	assert(clauses.size() > 0);
+	if (clauses.size() == 1 && simplify) {
+		return clauses[0];
+	}
+	std::string output = "(" + op;
+	for (std::vector<std::string>::const_iterator i = clauses.begin(); i != clauses.end(); ++i) {
+		output += " " + *i;
+	}
+	output += ")";
+	return output;
+}
+
+static std::string assert_occurs(const parsed_pbes &pbes, const translated_data_specification &translation, const unrolling_variables &variables, size_t from_round, size_t to_round)
+{
+	std::vector<std::string> possibilities;
+	for (std::vector<equation>::const_iterator i = pbes.equations.begin(); i != pbes.equations.end(); ++i) {
+		size_t from_variable_index = variables.variable_indices.at(i->variable.name());
+		for (std::vector<clause>::const_iterator j = i->clauses.begin(); j != i->clauses.end(); ++j) {
+			size_t to_variable_index = variables.variable_indices.at(j->instantiation.name());
+			std::vector<std::string> clauses;
+			
+			clauses.push_back("(= " + variables.equation_number_variables.at(from_round) + " " + itoa(from_variable_index) + ")");
+			clauses.push_back("(= " + variables.equation_number_variables.at(to_round) + " " + itoa(to_variable_index) + ")");
+			
+			std::map<mcrl2::data::variable, std::string> bound_variables = variables.global_variables;
+			size_t index = 0;
+			for (variable_list::const_iterator k = i->variable.parameters().begin(); k != i->variable.parameters().end(); ++k) {
+				bound_variables[*k] = variables.parameter_variables[from_round][from_variable_index][index++];
+			}
+			for (variable_vector::const_iterator k = j->quantification_domain.begin(); k != j->quantification_domain.end(); ++k) {
+				bound_variables[*k] = variables.quantification_variables[from_round][from_variable_index][j - i->clauses.begin()][k - j->quantification_domain.begin()];
+			}
+			
+			if (j->predicate != sort_bool::true_()) {
+				clauses.push_back(translate_expression(j->predicate, bound_variables, translation));
+			}
+			
+			index = 0;
+			for (data_expression_list::const_iterator k = j->instantiation.parameters().begin(); k != j->instantiation.parameters().end(); ++k) {
+				std::string rhs = translate_expression(*k, bound_variables, translation);
+				std::string lhs = variables.parameter_variables[to_round][to_variable_index][index++];
+				clauses.push_back("(= " + lhs + " " + rhs + ")");
+			}
+			
+			possibilities.push_back("\n  " + join(clauses, "and"));
+		}
+	}
+	
+	return "(assert " + join(possibilities, "or") + ")\n";
+}
+
+static std::string define_assert_witness(const parsed_pbes &pbes, const translated_data_specification &translation, const unrolling_variables &variables, size_t levels)
+{
+	std::string output;
+	
+	std::string base = "witness";
+	std::string start_round_variable = base + "-start";
+	std::string end_round_variable = base + "-end";
+	std::string equation_variable = base + "-equation";
+	
+	output += "(define " + start_round_variable + "::nat)\n";
+	output += "(define " + end_round_variable + "::nat)\n";
+	output += "(define " + equation_variable + "::nat)\n";
+	
+	std::vector<std::vector<std::string> > parameter_variables;
+	for (std::vector<equation>::const_iterator i = pbes.equations.begin(); i != pbes.equations.end(); ++i) {
+		std::vector<std::string> equation_parameter_variables;
+		for (variable_list::const_iterator j = i->variable.parameters().begin(); j != i->variable.parameters().end(); ++j) {
+			std::string parameter_variable =
+				base + "-parameter-" +
+				std::string(i->variable.name()) + "-" +
+				std::string(j->name());
+			equation_parameter_variables.push_back(parameter_variable);
+			output += "(define " + parameter_variable + "::" + translation.sort_names.at(j->sort()) + ")\n";
+		}
+		parameter_variables.push_back(equation_parameter_variables);
+	}
+	
+	output += "(assert (< " + start_round_variable + " " + end_round_variable + "))\n";
+	
+	std::vector<std::string> valid_equation_options;
+	for (std::vector<equation>::const_iterator i = pbes.equations.begin(); i != pbes.equations.end(); ++i) {
+		if (pbes.disjunctive ? i->symbol.is_nu() : i->symbol.is_mu()) {
+			std::string option = "(= " + equation_variable + " " + itoa(variables.variable_indices.at(i->variable.name())) + ")";
+			valid_equation_options.push_back(option);
+		}
+	}
+	output += "(assert " + join(valid_equation_options, "or") + ")\n";
+	
+	std::vector<std::string> start_round_options;
+	std::vector<std::string> end_round_options;
+	for (size_t round = 0; round < levels; ++round) {
+		output += "(assert (=> (and (<= " + start_round_variable + " " + itoa(round) + ") (<= " + itoa(round) + " " + end_round_variable + ")) (<= " + equation_variable + " " + variables.equation_number_variables[round] + ")))\n";
+		
+		std::vector<std::string> requirements;
+		requirements.push_back("(= " + equation_variable + " " + variables.equation_number_variables[round] + ")");
+		for (size_t i = 0; i < pbes.equations.size(); ++i) {
+			for (size_t j = 0; j < pbes.equations[i].variable.parameters().size(); ++j) {
+				requirements.push_back("(= " + parameter_variables[i][j] + " " + variables.parameter_variables[round][i][j] + ")");
+			}
+		}
+		
+		requirements.push_back("(= " + start_round_variable + " " + itoa(round) + ")");
+		start_round_options.push_back("\n  " + join(requirements, "and"));
+		
+		requirements.pop_back();
+		requirements.push_back("(= " + end_round_variable + " " + itoa(round) + ")");
+		end_round_options.push_back("\n  " + join(requirements, "and"));
+	}
+	
+	output += "(assert " + join(start_round_options, "or") + ")\n";
+	output += "(assert " + join(end_round_options, "or") + ")\n";
+	
+	return output;
+}
+
+std::string generate_witness_proposition(const parsed_pbes &pbes, const translated_data_specification &translation, size_t levels)
+{
+	std::string output;
+	output += translation.definition;
+	
+	unrolling_variables unrolling;
+	build_unrolling_variables(pbes, translation, levels, unrolling);
+	output += unrolling.definition;
+	
+	output += assert_initial_state(pbes, translation, unrolling);
+	
+	for (size_t i = 0; i < levels - 1; ++i) {
+		output += assert_occurs(pbes, translation, unrolling, i, i + 1);
+	}
+	
+	output += define_assert_witness(pbes, translation, unrolling, levels);
+	
+	output += "(check)\n";
+	return output;
+}
+
+static std::string assert_distinct(const parsed_pbes &pbes, const translated_data_specification &translation, const unrolling_variables &unrolling, size_t levels)
+{
+	std::string output;
+	
+	output += "(define-type pbes-state (datatype";
+	for (size_t i = 0; i < pbes.equations.size(); ++i) {
+		if (pbes.equations[i].variable.parameters().size() == 0) {
+			output += " pbes-state-" + itoa(i);
+		} else {
+			output += " (pbes-state-" + itoa(i);
+			size_t index = 0;
+			for (data::variable_list::const_iterator j = pbes.equations[i].variable.parameters().begin(); j != pbes.equations[i].variable.parameters().end(); ++j) {
+				output += " pbes-state-var-" + itoa(i) + "-" + itoa(index) + "::" + translation.sort_names.at(j->sort());
+				index++;
+			}
+			output += ")";
+		}
+	}
+	output += "))\n";
+	
+	output += "(define make-pbes-state::(-> nat";
+	for (size_t i = 0; i < pbes.equations.size(); ++i) {
+		for (data::variable_list::const_iterator j = pbes.equations[i].variable.parameters().begin(); j != pbes.equations[i].variable.parameters().end(); ++j) {
+			output += " " + translation.sort_names.at(j->sort());
+		}
+	}
+	output += " pbes-state) (lambda (equation::nat";
+	for (size_t i = 0; i < pbes.equations.size(); ++i) {
+		size_t index = 0;
+		for (data::variable_list::const_iterator j = pbes.equations[i].variable.parameters().begin(); j != pbes.equations[i].variable.parameters().end(); ++j) {
+			output += " var-" + itoa(i) + "-" + itoa(index) + "::" + translation.sort_names.at(j->sort());
+			index++;
+		}
+	}
+	output += ") ";
+	for (size_t i = 0; i < pbes.equations.size(); ++i) {
+		std::string term;
+		if (pbes.equations[i].variable.parameters().size() == 0) {
+			term = "pbes-state-" + itoa(i);
+		} else {
+			term = "(pbes-state-" + itoa(i);
+			for (size_t j = 0; j < pbes.equations[i].variable.parameters().size(); ++j) {
+				term += " var-" + itoa(i) + "-" + itoa(j);
+			}
+			term += ")";
+		}
+		
+		if (i == pbes.equations.size() - 1) {
+			output += " " + term;
+		} else {
+			output += "(if (= equation " + itoa(i) + ") " + term;
+		}
+	}
+	for (size_t i = 0; i < pbes.equations.size() - 1; ++i) {
+		output += ")";
+	}
+	output += "))\n";
+	
+	output += "(define pbes-state-number::(-> pbes-state nat))\n";
+	for (size_t i = 0; i < levels; ++i) {
+		output += "(assert (= " + itoa(i) + " (pbes-state-number (make-pbes-state " + unrolling.equation_number_variables[i];
+		for (size_t j = 0; j < unrolling.parameter_variables[i].size(); ++j) {
+			for (size_t k = 0; k < unrolling.parameter_variables[i][j].size(); ++k) {
+				output += " " + unrolling.parameter_variables[i][j][k];
+			}
+		}
+		output += "))))\n";
+	}
+	
+	return output;
+}
+
+std::string generate_acyclic_unrolling_proposition(const parsed_pbes &pbes, const translated_data_specification &translation, size_t levels)
+{
+	std::string output;
+	output += translation.definition;
+	
+	unrolling_variables unrolling;
+	build_unrolling_variables(pbes, translation, levels, unrolling);
+	output += unrolling.definition;
+	
+	output += assert_initial_state(pbes, translation, unrolling);
+	
+	for (size_t i = 0; i < levels - 1; ++i) {
+		output += assert_occurs(pbes, translation, unrolling, i, i + 1);
+	}
+	
+	output += assert_distinct(pbes, translation, unrolling, levels);
+	
+	output += "(check)\n";
+	return output;
+}


### PR DESCRIPTION
This includes two tools, pbes2cvc4 and pbes2yices, that are the work of Ruud Koolen.

The techniques used by the tools are described in the following paper:

  Koolen, R.P.J., Willemse, T.A.C., and Zantema, H.
  Using SMT for Solving Fragments of Parameterised Boolean Equation Systems.
  In: Automated Technology for Verification and Analysis. pp. 14–30 Springer, Cham (2015).
  https://doi.org/10.1007/978-3-319-24953-7_3.

I am adding these tools as experimental tools to make sure that the tools still compile.
Tim Beurskens is planning to experiment with these tools in his graduation project.

Note that I made small modifications to Ruud's original code to ensure that the tools compile.