### PR TITLE
Improvements to lpsparunfold

### DIFF
--- a/build/cmake/GenerateToolTests.cmake
+++ b/build/cmake/GenerateToolTests.cmake
@@ -218,7 +218,7 @@ endfunction()
 
 # lpsparunfold
 function(gen_lpsparunfold_release_tests LPSFILE)
-  set(ARGUMENTS "-l" "-n10" "-rjitty" "-rjittyp" ${_JITTYC})
+  set(ARGUMENTS "-a" "-p" "-n10" "-rjitty" "-rjittyp" ${_JITTYC})
   foreach(arglist ${ARGUMENTS})
     add_tool_test(lpsparunfold -sNat ${arglist} ${tagIN} ${LPSFILE})
   endforeach()

--- a/libraries/data/include/mcrl2/data/standard_utility.h
+++ b/libraries/data/include/mcrl2/data/standard_utility.h
@@ -172,6 +172,22 @@ inline data_expression not_equal_to(data_expression const& p, data_expression co
   return data::not_equal_to(p, q);
 }
 
+/// @brief Returns an expression equivalent to if(cond,then,else_)
+/// @return The value if(cond,then,else_)
+inline data_expression if_(const data_expression& cond, const data_expression& then, const data_expression& else_)
+{
+  if (cond == sort_bool::true_() || then == else_)
+  {
+    return then;
+  }
+  else if (cond == sort_bool::false_())
+  {
+    return else_;
+  }
+
+  return data::if_(cond, then, else_);
+}
+
 /// \brief Returns or applied to the sequence of data expressions [first, last)
 /// \param first Start of a sequence of data expressions
 /// \param last End of a sequence of data expressions

--- a/libraries/data/include/mcrl2/data/substitutions/map_substitution.h
+++ b/libraries/data/include/mcrl2/data/substitutions/map_substitution.h
@@ -72,6 +72,17 @@ make_map_substitution(const AssociativeContainer& m)
 }
 
 template <typename AssociativeContainer>
+std::set<data::variable> substitution_variables(const map_substitution<AssociativeContainer>& sigma)
+{
+  std::set<data::variable> result;
+  for (const auto& [key, value]: sigma.m_map)
+  {
+    data::find_free_variables(value, std::inserter(result, result.end()));
+  }
+  return result;
+}
+
+template <typename AssociativeContainer>
 bool is_simple_substitution(const map_substitution<AssociativeContainer>& sigma)
 {
   for (auto i = sigma.m_map.begin(); i != sigma.m_map.end(); ++i)

--- a/libraries/data/include/mcrl2/data/substitutions/map_substitution.h
+++ b/libraries/data/include/mcrl2/data/substitutions/map_substitution.h
@@ -26,6 +26,8 @@ struct map_substitution
 {
   typedef typename AssociativeContainer::key_type variable_type;
   typedef typename AssociativeContainer::mapped_type expression_type;
+  using argument_type = variable_type;
+  using result_type = expression_type;
 
   const AssociativeContainer& m_map;
 

--- a/libraries/data/include/mcrl2/data/substitutions/variable_substitution.h
+++ b/libraries/data/include/mcrl2/data/substitutions/variable_substitution.h
@@ -45,6 +45,13 @@ struct variable_substitution
   }
 };
 
+std::set<data::variable> substitution_variables(const variable_substitution& sigma)
+{
+  std::set<data::variable> result;
+  data::find_free_variables(sigma.rhs, std::inserter(result, result.end()));
+  return result;
+}
+
 } // namespace data
 
 } // namespace mcrl2

--- a/libraries/data/include/mcrl2/data/substitutions/variable_substitution.h
+++ b/libraries/data/include/mcrl2/data/substitutions/variable_substitution.h
@@ -13,6 +13,7 @@
 #define MCRL2_DATA_SUBSTITUTIONS_VARIABLE_SUBSTITUTION_H
 
 #include "mcrl2/data/is_simple_substitution.h"
+#include "mcrl2/data/find.h"
 #include "mcrl2/data/undefined.h"
 
 namespace mcrl2 {
@@ -45,6 +46,7 @@ struct variable_substitution
   }
 };
 
+inline
 std::set<data::variable> substitution_variables(const variable_substitution& sigma)
 {
   std::set<data::variable> result;

--- a/libraries/data/include/mcrl2/data/unfold_pattern_matching.h
+++ b/libraries/data/include/mcrl2/data/unfold_pattern_matching.h
@@ -255,8 +255,8 @@ data_expression construct_rhs(
   /*
    * For each constructor, find the set of rules that apply to it, rewritten to match the constructor.
    */
-  auto constructors = ssf.get_constructors(matching_target.sort());
-  std::set<function_symbol> match_constructors(constructors.begin(), constructors.end());
+  // type below depends on the type of ssf
+  const auto& match_constructors = ssf.get_constructors(matching_target.sort());
   std::map<function_symbol, std::vector<rule> > constructor_rules;
   for (const rule& r: rules)
   {
@@ -276,7 +276,7 @@ data_expression construct_rhs(
         parameters.insert(parameters.end(), pattern_appl.begin(), pattern_appl.end());
       }
 
-      assert(match_constructors.count(constructor) != 0);
+      assert(utilities::detail::contains(match_constructors, constructor));
       rule rule = r;
       rule.match_criteria.erase(matching_target);
       for (std::size_t j = 0; j < parameters.size(); j++)
@@ -333,7 +333,7 @@ data_expression construct_rhs(
   /*
    * Construct an rhs of the form if(is_cons1, rhs_cons1, if(is_cons2, rhs_cons2, ...))
    */
-  std::set<function_symbol>::const_iterator i = match_constructors.begin();
+  auto i = match_constructors.begin();
   data_expression result = construct_rhs(ssf, gen, constructor_rules[*i], sort);
   for (i++; i != match_constructors.end(); i++)
   {

--- a/libraries/data/include/mcrl2/data/unfold_pattern_matching.h
+++ b/libraries/data/include/mcrl2/data/unfold_pattern_matching.h
@@ -374,6 +374,11 @@ bool is_pattern_matching_rule(StructInfo& ssf, const data_equation& rewrite_rule
   {
     return false;
   }
+  if (std::all_of(subexpressions.begin(), subexpressions.end(), [](const data_expression& x){ return is_variable(x); }))
+  {
+    // Each argument is a variable, this is just an ordinarily defined function
+    return false;
+  }
 
   // Check whether each variable occurs at most once
   std::set<variable> variable_set;

--- a/libraries/data/include/mcrl2/data/unfold_pattern_matching.h
+++ b/libraries/data/include/mcrl2/data/unfold_pattern_matching.h
@@ -104,6 +104,7 @@ function_symbol get_top_fs(const data_expression& expr)
  * the right hand sides of match_criteria, construct a right hand side based on the
  * conditions and right hand sides of the rules.
  */
+static
 data_expression construct_condition_rhs(const std::vector<rule>& rules, const data_expression& representative)
 {
   // data_expression_vector negated_conditions;

--- a/libraries/data/include/mcrl2/data/unfold_pattern_matching.h
+++ b/libraries/data/include/mcrl2/data/unfold_pattern_matching.h
@@ -341,17 +341,15 @@ data_expression construct_rhs(
   }
 
   /*
-   * Construct an rhs of the form if(is_cons1, rhs_cons1, if(is_cons2, rhs_cons2, ...))
+   * Construct an rhs of the form if(is_cons1, rhs_cons1, if(is_cons2, rhs_cons2, ...)) or equivalent
+   * The exact form depends on the implementation in ssf
    */
-  auto i = match_constructors.begin();
-  data_expression result = construct_rhs(ssf, gen, constructor_rules[*i], sort);
-  for (i++; i != match_constructors.end(); i++)
+  data_expression_vector rhs;
+  for (const auto& f: match_constructors)
   {
-    data_expression term = construct_rhs(ssf, gen, constructor_rules[*i], sort);
-    data_expression condition = ssf.create_recogniser_expr(*i, matching_target);
-    result = lazy::if_(condition, term, result);
+    rhs.push_back(construct_rhs(ssf, gen, constructor_rules[f], sort));
   }
-  return result;
+  return ssf.create_cases(matching_target, rhs);
 }
 
 } // namespace detail

--- a/libraries/data/include/mcrl2/data/unfold_pattern_matching.h
+++ b/libraries/data/include/mcrl2/data/unfold_pattern_matching.h
@@ -1,0 +1,484 @@
+// Author(s): Ruud Koolen, Thomas Neele
+// Copyright: see the accompanying file COPYING or copy at
+// https://github.com/mCRL2org/mCRL2/blob/master/COPYING
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef MCRL2_DATA_UNFOLD_PATTERN_MATCHING_H
+#define MCRL2_DATA_UNFOLD_PATTERN_MATCHING_H
+
+#include "mcrl2/data/join.h"
+#include "mcrl2/data/replace.h"
+#include "mcrl2/data/representative_generator.h"
+#include "mcrl2/data/substitutions/map_substitution.h"
+#include "mcrl2/data/substitutions/variable_substitution.h"
+
+namespace mcrl2::data
+{
+
+namespace detail
+{
+/**
+ * \brief A rule describes a partially pattern-matched rewrite rule.
+ * \details match_criteria is a set of data_expression pairs (A, B)
+ * where A is a data_expression over variables in the left hand
+ * side of a function definition, and B is a pattern consisting of
+ * constructor applications over free variables.
+ *
+ * The rule match_criteria = { (A, B), (C, D) }, condition = E, rhs = R
+ * describes the following rewrite proposition:
+ *
+ *  "if the data expression A pattern-matches to pattern B, and the
+ *   data expression C pattern-matches to pattern D, and the condition
+ *   E is true after substituting the proper pattern-matching variables,
+ *   then the right hand side R applies (again with substitution of
+ *   pattern-matched variables."
+ *
+ * Pattern matching can then be performed by deconstructing the patterns
+ * in the right hand sides of match_criteria, and rewriting rules accordingly.
+ * As an example, the following rewrite rule:
+ *
+ *   is_even(n) -> sign_of_list_sum(n |> l) = sign_of_list_sum(l)
+ *
+ * Can be represented as the following rule:
+ *
+ *   match_criteria = { v1 -> n |> l }, condition = is_even(n), rhs = sign_of_list_sum(l)
+ *
+ * Which, after one step of pattern matching, gets simplified to the following rule:
+ *
+ *   match_criteria = { head(v1) -> n, tail(v1) -> l }, condition = is_even(n), rhs = sign_of_list_sum(l)
+ */
+struct rule
+{
+  std::map<data_expression, data_expression> match_criteria;
+  data_expression rhs;
+  data_expression condition;
+  variable_list variables;
+
+  rule(const std::map<data_expression, data_expression>& mc,
+       const data_expression& r,
+       const data_expression& c,
+       const variable_list& v)
+  : match_criteria(mc)
+  , rhs(r)
+  , condition(c)
+  , variables(v)
+  {
+    assert(condition.sort() == sort_bool::bool_());
+  }
+
+};
+
+inline
+std::ostream& operator<<(std::ostream& out, const rule& r)
+{
+  return out << core::detail::print_list(r.variables) << ". " << r.condition << " -> " << core::detail::print_map(r.match_criteria) << " = " << r.rhs;
+}
+
+
+/// @brief Get the top level function symbol f if expr is of the shape f or f(t1,...,tn)
+/// @param expr The expression from which to extract the top function symbol
+/// @return The top function symbol, or function_symbol() if it has none
+inline
+function_symbol get_top_fs(const data_expression& expr)
+{
+  if (is_function_symbol(expr))
+  {
+    return atermpp::down_cast<function_symbol>(expr);
+  }
+  if (is_application(expr))
+  {
+    const application& expr_appl = atermpp::down_cast<application>(expr);
+    if (is_function_symbol(expr_appl.head()))
+    {
+      return atermpp::down_cast<function_symbol>(expr_appl.head());
+    }
+  }
+  return function_symbol();
+}
+
+/**
+ * \brief For a list of rules with equal left hand sides of match_criteria and only variables in
+ * the right hand sides of match_criteria, construct a right hand side based on the
+ * conditions and right hand sides of the rules.
+ */
+data_expression construct_condition_rhs(const std::vector<rule>& rules, const data_expression& representative)
+{
+  // data_expression_vector negated_conditions;
+  // for (const rule& r: rules)
+  // {
+  //   negated_conditions.push_back(sort_bool::not_(r.condition));
+  // }
+  // data_expression else_clause = join_and(negated_conditions.begin(), negated_conditions.end());
+
+  // TODO: Check whether else_clause is equivalent to false. Can we use the enumerator for this?
+  bool conditions_are_complete = false;
+  if (rules.size() == 1 && rules[0].condition == sort_bool::true_())
+  {
+    conditions_are_complete = true;
+  }
+  data_expression result;
+  if (!conditions_are_complete)
+  {
+    result = representative;
+  }
+
+  for (const rule& r: rules)
+  {
+    std::map<variable, data_expression> substitution_map;
+    for (const auto& [var_expr, pattern]: r.match_criteria)
+    {
+      assert(is_variable(pattern));
+      substitution_map[atermpp::down_cast<variable>(pattern)] = var_expr;
+    }
+    map_substitution<std::map<variable, data_expression> > substitution(substitution_map);
+
+    data_expression condition = replace_free_variables(r.condition, substitution);
+    data_expression rhs = replace_free_variables(r.rhs, substitution);
+
+    if (result == data_expression())
+    {
+      result = rhs;
+    }
+    else
+    {
+      result = lazy::if_(condition, rhs, result);
+    }
+  }
+
+  return result;
+}
+
+/**
+ * \brief For a list of rules with equal left hand sides of match_criteria, construct a right hand side.
+ */
+template <typename StructInfo>
+data_expression construct_rhs(
+  const StructInfo& ssf,
+  representative_generator& gen,
+  const std::vector<rule>& rules,
+  const sort_expression& sort
+)
+{
+  if (rules.empty())
+  {
+    return construct_condition_rhs(rules, gen(sort));
+  }
+
+  /*
+   * For each matching rule LHS, check whether pattern matching needs to happen on that LHS.
+   *
+   * We prefer to match on an expression such that *all* rules perform matching on that expression.
+   * For example, for a ruleset representing the following rewrite rules:
+   *
+   *   optionally_remove_first_element(false, l) = l
+   *   optionally_remove_first_element(true, []) = []
+   *   optionally_remove_first_element(true, x |> l) = l
+   *
+   * We prefer to pattern match on the first parameter, not the second. Pattern matching on the
+   * second parameter will (recursively) happen only on the true-branch, not the false-branch.
+   * Pattern matching on the second parameter is still possible if there is no other option, but
+   * it requires splitting the first rewrite rule into different cases for different
+   * constructors -- suboptimal.
+   */
+  data_expression matching_target;
+  enum class MatchType
+  {
+    NONE, INCOMPLETE, PARTIAL, FULL
+  };
+  MatchType matching_type = MatchType::NONE;
+  // iterate over newly-created variable names
+  for (const auto& [var_expr, _]: rules[0].match_criteria)
+  {
+    bool variable_seen = false;
+    std::set<function_symbol> constructors_seen;
+    for (const rule& r: rules)
+    {
+      data_expression pattern = r.match_criteria.at(var_expr);
+      if (is_variable(pattern))
+      {
+        variable_seen = true;
+      }
+      else
+      {
+        // either function symbol or application of function symbol
+        function_symbol fs = get_top_fs(pattern);
+        // this also means fs != function_symbol()
+        assert(ssf.is_constructor(fs));
+        constructors_seen.insert(fs);
+      }
+    }
+
+    MatchType new_matching_type;
+    if (constructors_seen.empty())
+    {
+      // No pattern matching is possible on this variable.
+      new_matching_type = MatchType::NONE;
+    }
+    else if (variable_seen)
+    {
+      // There are both rules that match on this variable and rules that do not.
+      // That's better than an incomplete matching but worse than a full matching.
+      new_matching_type = MatchType::PARTIAL;
+    }
+    else if (constructors_seen.size() != ssf.get_constructors(var_expr.sort()).size())
+    {
+      // There are constructors for which there are no rules.
+      // Thus, we have an incomplete function definition, that needs to be completed artificially.
+      // A partial matching would be a better choice.
+      new_matching_type = MatchType::INCOMPLETE;
+    }
+    else
+    {
+      // There is a matching rule for each constructor, and no rule with a plain variable.
+      // This variable is a perfect pattern matching candidate.
+      new_matching_type = MatchType::FULL;
+    }
+    if (new_matching_type > matching_type)
+    {
+      matching_target = var_expr;
+      matching_type = new_matching_type;
+    }
+    if (matching_type == MatchType::FULL)
+    {
+      break;
+    }
+  }
+
+  if (matching_type == MatchType::NONE)
+  {
+    // No constructor-based matching needs to happen.
+    // All that needs to happen is incorporating the rule conditions.
+    return construct_condition_rhs(rules, gen(sort));
+  }
+
+  /*
+   * For each constructor, find the set of rules that apply to it, rewritten to match the constructor.
+   */
+  std::set<function_symbol> match_constructors(ssf.get_constructors(matching_target.sort()));
+  std::map<function_symbol, std::vector<rule> > constructor_rules;
+  for (const rule& r: rules)
+  {
+    data_expression pattern = r.match_criteria.at(matching_target);
+    if (is_function_symbol(pattern) || is_application(pattern))
+    {
+      /*
+       * For a rule with a constructor pattern, strip the constructor and
+       * introduce patterns for the constructor parameters.
+       */
+      function_symbol constructor = get_top_fs(pattern);
+      assert(constructor != function_symbol());
+      data_expression_vector parameters;
+      if (is_application(pattern))
+      {
+        const application& pattern_appl = atermpp::down_cast<application>(pattern);
+        parameters.insert(parameters.end(), pattern_appl.begin(), pattern_appl.end());
+      }
+
+      assert(match_constructors.count(constructor) != 0);
+      rule rule = r;
+      rule.match_criteria.erase(matching_target);
+      for (std::size_t j = 0; j < parameters.size(); j++)
+      {
+        function_symbol projection_function = ssf.get_projection_funcs(constructor)[j];
+        data_expression lhs_expression = application(projection_function, matching_target);
+        rule.match_criteria[lhs_expression] = parameters[j];
+      }
+      constructor_rules[constructor].push_back(rule);
+    }
+    else
+    {
+      /*
+       * For a rule with a variable pattern that nonetheless needs to pattern match
+       * against the possible constructors for that variable, copy the rule for each
+       * possible constructor. Substitute the original un-matched term for the pattern
+       * variable that disappears.
+       */
+      assert(is_variable(pattern));
+      variable_substitution sigma(atermpp::down_cast<variable>(pattern), matching_target);
+      data_expression condition = replace_free_variables(r.condition, sigma);
+      data_expression rhs = replace_free_variables(r.rhs, sigma);
+
+      for (const function_symbol& f: match_constructors)
+      {
+        rule rule(r.match_criteria, rhs, condition, r.variables);
+        rule.match_criteria.erase(matching_target);
+
+        set_identifier_generator generator;
+        for (const variable& v: r.variables)
+        {
+          generator.add_identifier(v.name());
+        }
+
+        if (is_function_sort(f.sort()))
+        {
+          function_sort sort(f.sort());
+          std::size_t index = 0;
+          for (const sort_expression& s: sort.domain())
+          {
+            variable variable(generator("v"), s);
+            function_symbol projection_function = ssf.get_projection_funcs(f)[index];
+            data_expression lhs_expression = application(projection_function, matching_target);
+            rule.match_criteria[lhs_expression] = variable;
+            index++;
+          }
+        }
+
+        constructor_rules[f].push_back(rule);
+      }
+    }
+  }
+
+  /*
+   * Construct an rhs of the form if(is_cons1, rhs_cons1, if(is_cons2, rhs_cons2, ...))
+   */
+  std::set<function_symbol>::const_iterator i = match_constructors.begin();
+  data_expression result = construct_rhs(ssf, gen, constructor_rules[*i], sort);
+  for (i++; i != match_constructors.end(); i++)
+  {
+    data_expression term = construct_rhs(ssf, gen, constructor_rules[*i], sort);
+    data_expression condition = ssf.create_recogniser_expr(*i, matching_target);
+    result = lazy::if_(condition, term, result);
+  }
+  return result;
+}
+
+} // namespace detail
+
+/**
+ * \brief Check whether the given rewrite rule can be classified as a pattern matching rule.
+ * \details That is, its arguments are constructed only out of unique variable occurrences and
+ * constructor function symbols and constructor function applications.
+ */
+template <typename StructInfo>
+bool is_pattern_matching_rule(const StructInfo& ssf, const data_equation& rewrite_rule)
+{
+  // For this rewrite rule to be usable in pattern matching, its lhs must only contain
+  // constructor functions and variables that occur at most once.
+
+  std::set<data_expression> subexpressions = find_data_expressions(rewrite_rule.lhs());
+  subexpressions.erase(rewrite_rule.lhs());
+  if (is_application(rewrite_rule.lhs()))
+  {
+    subexpressions.erase(application(rewrite_rule.lhs()).head());
+  }
+
+  bool all_pattern = std::all_of(subexpressions.begin(), subexpressions.end(), [&ssf](const data_expression& expr) {
+    return
+      is_variable(expr) ||
+      (is_function_symbol(expr) && ssf.is_constructor(atermpp::down_cast<function_symbol>(expr))) ||
+      (is_application(expr) && is_function_symbol(atermpp::down_cast<application>(expr).head()) &&
+                          ssf.is_constructor(function_symbol(atermpp::down_cast<application>(expr).head())));
+  });
+  if (!all_pattern)
+  {
+    return false;
+  }
+
+  // Check whether each variable occurs at most once
+  std::set<variable> variable_set;
+  std::multiset<variable> variable_multiset;
+  find_all_variables(rewrite_rule.lhs(), std::inserter(variable_set, variable_set.end()));
+  find_all_variables(rewrite_rule.lhs(), std::inserter(variable_multiset, variable_multiset.end()));
+  return variable_set.size() == variable_multiset.size();
+}
+
+/**
+ * \brief This converts a collection of rewrite rules for a give function symbol into a
+ * one-rule specification of the function, using recogniser and projection functions
+ * to implement pattern matching.
+ * \details For example, the collection of rewrite rules below:
+ *
+ *   sign_of_list_sum([]) = false;
+ *   is_even(n) -> sign_of_list_sum(n |> l) = sign_of_list_sum(l);
+ *   !is_even(n) -> sign_of_list_sum(n |> l) = !sign_of_list_sum(l);
+ *
+ * gets translated into the following function specification:
+ *
+ *   sign_of_list_sum(l) = if(is_emptylist(l), false,
+ *                            if(is_even(head(l)), sign_of_list_sum(tail(l)),
+ *                               !sign_of_list_sum(tail(l))))
+ *
+ * Two complications can arise. The rewrite rule set may contain rules that do not
+ * pattern-match on the function parameters, such as 'not(not(b)) = b`; rules like
+ * these are discarded.
+ * More problematically, the set of rewrite rules may not be complete, or may not
+ * easily be proven complete; in the example above, if the rewriter cannot rewrite
+ * 'is_even(n) || !is_even(n)' to 'true', the translation cannot tell that the
+ * rewrite rule set is complete.
+ * In cases where a (non-constructor )function invocation can genuinely not be
+ * rewritten any further, the MCRL2 semantics are unspecified (TODO check this);
+ * the translation resolves this situation by returning an arbitrary value in this
+ * case. Thus, in practice, the function definion above might well be translated
+ * into the following:
+ *
+ *   sign_of_list_sum(l) = if(is_emptylist(l), false,
+ *                            if(is_even(head(l)), sign_of_list_sum(tail(l)),
+ *                               if(!is_even(head(l)), !sign_of_list_sum(tail(l)),
+ *                                  false)))
+ *
+ * Where 'false' is a representative of sort_bool.
+ */
+template <typename StructInfo>
+data_equation unfold_pattern_matching(
+  const function_symbol& mapping,
+  const data_equation_vector& rewrite_rules,
+  const StructInfo& ssf,
+  representative_generator& gen,
+  set_identifier_generator& id_gen
+)
+{
+  sort_expression codomain = mapping.sort().target_sort();
+  variable_vector temp_par;
+  if (is_function_sort(mapping.sort()))
+  {
+    const function_sort& sort = atermpp::down_cast<function_sort>(mapping.sort());
+    for (sort_expression s: sort.domain())
+    {
+      temp_par.push_back(variable(id_gen("x"), s));
+    }
+  }
+  variable_list new_parameters(temp_par.begin(), temp_par.end());
+
+  // Create a rule for each data_equation
+  std::vector<detail::rule> rules;
+  for (const data_equation& eq: rewrite_rules)
+  {
+    assert(is_pattern_matching_rule(ssf, eq));
+
+    std::map<data_expression, data_expression> match_criteria;
+    if (is_application(eq.lhs()))
+    {
+      const application& lhs_appl = atermpp::down_cast<application>(eq.lhs());
+
+      assert(lhs_appl.head() == mapping);
+      assert(new_parameters.size() == lhs_appl.size());
+
+      // Simultaneously iterate the parameters defined by the mapping and this
+      // left-hand side to determine how matching occurs
+      auto mappar_it = new_parameters.begin();
+      auto lhspar_it = lhs_appl.begin();
+      while(mappar_it != new_parameters.end())
+      {
+        match_criteria[*mappar_it] = *lhspar_it;
+        ++mappar_it, ++lhspar_it;
+      }
+
+      assert(lhspar_it == lhs_appl.end());
+    }
+
+    detail::rule rule(match_criteria, eq.rhs(), eq.condition(), eq.variables());
+    rules.push_back(rule);
+  }
+  assert(rules.size() != 0);
+
+  data_expression new_lhs(application(mapping, new_parameters));
+  data_expression new_rhs(construct_rhs(ssf, gen, rules, codomain));
+  return data_equation(new_parameters, new_lhs, new_rhs);
+}
+
+} // namespace mcrl2::data
+
+#endif

--- a/libraries/lps/include/mcrl2/lps/lps_rewriter_tool.h
+++ b/libraries/lps/include/mcrl2/lps/lps_rewriter_tool.h
@@ -41,6 +41,7 @@ class lps_rewriter_tool: public Tool
       std::set<lps::lps_rewriter_type> result;
       result.insert(lps::simplify);
       result.insert(lps::quantifier_one_point);
+      result.insert(lps::condition_one_point);
       return result;
     }
 

--- a/libraries/lps/include/mcrl2/lps/lps_rewriter_type.h
+++ b/libraries/lps/include/mcrl2/lps/lps_rewriter_type.h
@@ -23,7 +23,8 @@ namespace lps {
 enum lps_rewriter_type
 {
   simplify,
-  quantifier_one_point
+  quantifier_one_point,
+  condition_one_point
 };
 
 /// \brief Parses a lps rewriter type
@@ -38,6 +39,10 @@ lps_rewriter_type parse_lps_rewriter_type(const std::string& type)
   {
     return quantifier_one_point;
   }
+  if (type == "condition-one-point")
+  {
+    return condition_one_point;
+  }
   throw mcrl2::runtime_error("unknown lps rewriter option " + type);
 }
 
@@ -51,6 +56,8 @@ std::string print_lps_rewriter_type(const lps_rewriter_type type)
       return "simplify";
     case quantifier_one_point:
       return "quantifier-one-point";
+    case condition_one_point:
+      return "condition-one-point";
     default:
     return "unknown lps rewriter";
   }
@@ -66,6 +73,8 @@ std::string description(const lps_rewriter_type type)
       return "for simplification";
     case quantifier_one_point :
       return "for one point rule quantifier elimination";
+    case condition_one_point :
+      return "simplify summands using equalities appearing in condition";
   }
   throw mcrl2::runtime_error("unknown lps rewriter");
 }

--- a/libraries/lps/include/mcrl2/lps/lpsparunfoldlib.h
+++ b/libraries/lps/include/mcrl2/lps/lpsparunfoldlib.h
@@ -326,13 +326,12 @@ Binder<Builder, parunfold_replacement<Builder, Binder>, parunfold_replacement<Bu
     else
     {
       // place the case functions here
-      result = apply_case_function(x);
+      apply_case_function(result, x);
     }
   }
 
-  data::data_expression apply_case_function(const data::application& expr)
+  void apply_case_function(data::data_expression& result, const data::data_expression& expr)
   {
-    data::data_expression result = expr;
     auto& [par, case_f, det_f, replacements] = case_funcs;
 
     if (find_free_variables(result).count(par) == 0)
@@ -341,28 +340,28 @@ Binder<Builder, parunfold_replacement<Builder, Binder>, parunfold_replacement<Bu
       // make sure to still apply the substitutions necessary for the capture avoiding tricks
       // NB: stack overflow happens if type of second argument is 'data::data_expression'.
       super::apply(result, expr);
-      return result;
     }
-
-    data::data_expression_vector args;
-    args.push_back(det_f);
-
-    for (const data::data_expression& r: replacements)
+    else
     {
-      current_replacement = r;
-      data::data_expression arg;
-      super::apply(arg, result);
-      args.push_back(arg);
-    }
-    current_replacement = data::data_expression();
+      data::data_expression_vector args;
+      args.push_back(det_f);
 
-    if(case_f.find(expr.sort()) == case_f.end())
-    {
-      throw mcrl2::runtime_error("Case function with target sort " + data::pp(expr.sort()) + " not declared.");
-    }
-    result = data::application(case_f[expr.sort()], args);
+      for (const data::data_expression& r : replacements)
+      {
+        current_replacement = r;
+        data::data_expression arg;
+        super::apply(arg, expr);
+        args.push_back(arg);
+      }
+      current_replacement = data::data_expression();
 
-    return result;
+      if (case_f.find(expr.sort()) == case_f.end())
+      {
+        throw mcrl2::runtime_error("Case function with target sort " +
+                                   data::pp(expr.sort()) + " not declared.");
+      }
+      result = data::application(case_f[expr.sort()], args);
+    }
   }
 
   // Substitution application

--- a/libraries/lps/include/mcrl2/lps/lpsparunfoldlib.h
+++ b/libraries/lps/include/mcrl2/lps/lpsparunfoldlib.h
@@ -269,10 +269,6 @@ class lpsparunfold: public detail::lps_algorithm<lps::stochastic_specification>
       return in;
     }
 
-    /** \brief Add a new equation to m_data_specification.
-    **/
-    void add_new_equation(const mcrl2::data::data_expression& lhs, const mcrl2::data::data_expression& rhs);
-
     // Applies 'process unfolding' to a sequence of summands.
     void unfold_summands(mcrl2::lps::stochastic_action_summand_vector& summands);
 };

--- a/libraries/lps/include/mcrl2/lps/lpsparunfoldlib.h
+++ b/libraries/lps/include/mcrl2/lps/lpsparunfoldlib.h
@@ -73,19 +73,16 @@ class lpsparunfold: public detail::lps_algorithm<lps::stochastic_specification>
 
     std::map< mcrl2::data::sort_expression , unfold_cache_element >* m_cache;
 
-    /// \brief The sort of the process parameter that needs to be unfold.
-    mcrl2::data::sort_expression m_unfold_process_parameter;
+    /// \brief The process parameter that needs to be unfold.
+    mcrl2::data::variable m_unfold_parameter;
 
     data::function_symbol_vector m_affected_constructors;
-
-    /// \brief The name of the process parameter that needs to be unfold.
-    std::string unfold_parameter_name;
 
     /// a generator for default data expressions of a give sort;
     mcrl2::data::representative_generator m_representative_generator;
 
     /// \brief The fresh sort of the unfolded process parameter used the case function.
-    mcrl2::data::basic_sort fresh_basic_sort;
+    mcrl2::data::basic_sort m_fresh_basic_sort;
 
     /// \brief Mapping of the unfold process parameter to a vector process parameters.
     std::map<mcrl2::data::variable, mcrl2::data::variable_vector > proc_par_to_proc_par_inj;
@@ -98,13 +95,15 @@ class lpsparunfold: public detail::lps_algorithm<lps::stochastic_specification>
     data::data_expression apply_case_function(const data::data_expression& expr, const case_func_vector& case_funcs);
     case_func_vector parameter_case_function(const std::map<data::variable, data::variable_vector >& proc_par_to_proc_par_inj, const data::function_symbol& case_function);
 
+    std::string sort_expression_to_basic_sort_hint(const data::sort_expression& sort);
+
     /** \brief  Generates a fresh basic sort given an string.
       * \param  str a string value. The value is used to generate a fresh
       *         basic sort.
       * \post   A fresh basic sort is generated.
       * \return A fresh basic sort.
     **/
-    mcrl2::data::basic_sort generate_fresh_basic_sort(const std::string& str);
+    mcrl2::data::basic_sort generate_fresh_basic_sort(const data::sort_expression& sort);
 
     /** \brief  Generates a fresh name for a constructor or mapping.
       * \param  str a string value. The value is used to generate a fresh
@@ -123,13 +122,13 @@ class lpsparunfold: public detail::lps_algorithm<lps::stochastic_specification>
     **/
     mcrl2::data::variable generate_fresh_variable(std::string str, const data::sort_expression& sort);
 
-    /** \brief  Creates the case function.
-      * \param  k a integer value. The value represents the number of
-      *         constructors of the unfolded process parameter.
+    /** \brief  Creates the case function with number of arguments determined by
+     *          the number of affected constructors.
+     *  \param  sort The sort of the arguments and return sort of the case function
       * \return A function that returns the corresponding constructor given the
       *         case selector and constructors.
     **/
-    mcrl2::data::function_symbol create_case_function(std::size_t k);
+    mcrl2::data::function_symbol create_case_function(const data::sort_expression& sort);
 
     /** \brief  Creates the determine function.
       * \return A function that maps a constructor to the fresh basic sort
@@ -169,11 +168,11 @@ class lpsparunfold: public detail::lps_algorithm<lps::stochastic_specification>
     **/
     mcrl2::data::function_symbol_vector new_constructors();
 
-    /** \brief  Get the sort of the process parameter at given index
-      * \param  parameter_at_index The index of the parameter for which the sort must be obtained.
-      * \return the sort of the process parameter at given index.
+    /** \brief  Get the process parameter at given index
+      * \param  index The index of the parameter which must be obtained.
+      * \return the process parameter at given index.
     **/
-    mcrl2::data::sort_expression sort_at_process_parameter_index(std::size_t parameter_at_index);
+    mcrl2::data::variable process_parameter_at(const std::size_t index);
 
     /** \brief  substitute function for replacing process parameters with unfolded process parameters functions.
       * \return substitute function for replacing process parameters with unfolded process parameters functions.

--- a/libraries/lps/include/mcrl2/lps/lpsparunfoldlib.h
+++ b/libraries/lps/include/mcrl2/lps/lpsparunfoldlib.h
@@ -97,12 +97,6 @@ class lpsparunfold
     /// \brief The fresh sort of the unfolded process parameter used the case function.
     mcrl2::data::basic_sort fresh_basic_sort;
 
-    /// \brief The set of sort names occurring in the process specification.
-    std::set<mcrl2::core::identifier_string> sort_names;
-
-    /// \brief The set of constructor and mapping names occurring in the process specification.
-    std::set<mcrl2::core::identifier_string> mapping_and_constructor_names;
-
     /// \brief Mapping of the unfold process parameter to a vector process parameters.
     std::map<mcrl2::data::variable, mcrl2::data::variable_vector > proc_par_to_proc_par_inj;
 
@@ -117,8 +111,7 @@ class lpsparunfold
     /** \brief  Generates a fresh basic sort given an string.
       * \param  str a string value. The value is used to generate a fresh
       *         basic sort.
-      * \post   A fresh basic sort is generated, for which the name is unique
-      *         with respect to the set of sort names (sort_names).
+      * \post   A fresh basic sort is generated.
       * \return A fresh basic sort.
     **/
     mcrl2::data::basic_sort generate_fresh_basic_sort(const std::string& str);
@@ -126,9 +119,7 @@ class lpsparunfold
     /** \brief  Generates a fresh name for a constructor or mapping.
       * \param  str a string value. The value is used to generate a fresh
       *         name for a constructor or mapping.
-      * \post   A fresh name for a constructor or mapping is generated, for
-      *         which the name is unique with respect to the set of mapping
-      *         and constructors  (mapping_and_constructor_names).
+      * \post   A fresh name for a constructor or mapping is generated.
       * \return A fresh name for a constructor or mapping.
     **/
     mcrl2::core::identifier_string generate_fresh_constructor_and_mapping_name(std::string str);

--- a/libraries/lps/include/mcrl2/lps/lpsparunfoldlib.h
+++ b/libraries/lps/include/mcrl2/lps/lpsparunfoldlib.h
@@ -101,12 +101,13 @@ class lpsparunfold: public detail::lps_algorithm<lps::stochastic_specification>
       * \param[in,out] cache Cache to store information for reuse.
       * \param[in] add_distribution_laws If true, additional rewrite rules are introduced.
       * \param[in] alt_case_placement If true, case functions are placed at a higher level.
+      * \param[in] globvars If true, global variables are unfolded into a list of global variables.
       * \post   The content of mCRL2 process specification analysed for useful information and class variables are set.
       **/
     lpsparunfold(lps::stochastic_specification& spec,
                  std::map< data::sort_expression , unfold_cache_element >& cache,
                  bool add_distribution_laws = false, bool alt_case_placement = false,
-                 bool possibly_inconsistent = false);
+                 bool possibly_inconsistent = false, bool globvars = false);
 
     /** \brief  Applies lpsparunfold algorithm on a process parameter of an mCRL2 process specification .
      *  \pre algorithm has not been called before.
@@ -149,9 +150,16 @@ class lpsparunfold: public detail::lps_algorithm<lps::stochastic_specification>
     /// \brief Boolean to indicate if alternative placement of case functions should be used.
     bool m_alt_case_placement;
 
-    /// \brief Boolean indicated whether rewrite rules may be added that could make
+    /// \brief Boolean indicating whether rewrite rules may be added that could make
     ///        the data specification inconsistent.
     bool m_possibly_inconsistent;
+
+    /// \brief Boolean indicating how global variables should be unfolded.
+    ///        if true, global variables are unfolded into a vector of global variables,
+    ///        if false, global variable dc is unfolded into Det(dc), pi_0(dc), ..., pi_n(dc)
+    bool m_globvars;
+
+
 
     //data::data_expression apply_case_function(const data::data_expression& expr, const case_func_replacement& case_funcs);
     case_func_replacement parameter_case_function();

--- a/libraries/lps/include/mcrl2/lps/lpsparunfoldlib.h
+++ b/libraries/lps/include/mcrl2/lps/lpsparunfoldlib.h
@@ -99,15 +99,15 @@ class lpsparunfold: public detail::lps_algorithm<lps::stochastic_specification>
     /** \brief  Constructor for lpsparunfold algorithm.
       * \param[in] spec which is a valid mCRL2 process specification.
       * \param[in,out] cache Cache to store information for reuse.
-      * \param[in] add_distribution_laws If true, additional rewrite rules are introduced.
       * \param[in] alt_case_placement If true, case functions are placed at a higher level.
-      * \param[in] globvars If true, global variables are unfolded into a list of global variables.
+      * \param[in] possibly_inconsistent If true, case functions over Booleans are replaced by a disjunction of conjunctions.
+      *                 For this to be correct, the unfolded sort needs to satisfy some restrictions.
       * \post   The content of mCRL2 process specification analysed for useful information and class variables are set.
       **/
     lpsparunfold(lps::stochastic_specification& spec,
                  std::map< data::sort_expression , unfold_cache_element >& cache,
-                 bool add_distribution_laws = false, bool alt_case_placement = false,
-                 bool possibly_inconsistent = false, bool globvars = false);
+                 bool alt_case_placement = false,
+                 bool possibly_inconsistent = false);
 
     /** \brief  Applies lpsparunfold algorithm on a process parameter of an mCRL2 process specification .
      *  \pre algorithm has not been called before.

--- a/libraries/lps/include/mcrl2/lps/lpsparunfoldlib.h
+++ b/libraries/lps/include/mcrl2/lps/lpsparunfoldlib.h
@@ -541,13 +541,7 @@ namespace detail
     }
   };
 
-  void unfold_pattern_matching(data::data_expression& x,
-                               pattern_match_unfolder& unfolder
-                              )
-  {
-    replace_pattern_match_builder<data::data_expression_builder>(unfolder).update(x);
-  }
-
+  inline
   data::data_expression unfold_pattern_matching(const data::data_expression& x,
                                pattern_match_unfolder& unfolder
                               )

--- a/libraries/lps/include/mcrl2/lps/lpsparunfoldlib.h
+++ b/libraries/lps/include/mcrl2/lps/lpsparunfoldlib.h
@@ -13,8 +13,10 @@
 //Fileinfo
 #define MCRL2_LPS_LPSPARUNFOLDLIB_H
 
+#include "mcrl2/data/consistency.h"
 #include "mcrl2/data/representative_generator.h"
 #include "mcrl2/lps/stochastic_specification.h"
+#include "mcrl2/lps/replace_capture_avoiding.h"
 
 namespace mcrl2::lps
 {
@@ -34,6 +36,9 @@ struct unfold_cache_element
 class lpsparunfold
 {
   public:
+
+    // old parameter, case function, determinizing parameter, replacement expressions
+    typedef std::vector<std::tuple<data::variable, data::function_symbol, data::variable, data::data_expression_vector>> case_func_vector;
 
     /** \brief  Constructor for lpsparunfold algorithm.
       * \param[in] spec which is a valid mCRL2 process specification.
@@ -266,6 +271,123 @@ class lpsparunfold
     // Applies 'process unfolding' to a sequence of summands.
     void unfold_summands(mcrl2::lps::stochastic_action_summand_vector& summands, const mcrl2::data::function_symbol& determine_function, const mcrl2::data::function_symbol_vector& pi);
 };
+
+
+template <template <class> class Builder, template <template <class> class, class, class> class Binder>
+struct parunfold_replacement: public
+Binder<Builder, parunfold_replacement<Builder, Binder>, parunfold_replacement<Builder, Binder>>
+{
+  typedef Binder<Builder, parunfold_replacement<Builder, Binder>, parunfold_replacement<Builder, Binder>> super;
+  using super::enter;
+  using super::leave;
+  using super::apply;
+  using super::update;
+
+  data::detail::capture_avoiding_substitution_updater<parunfold_replacement<Builder, Binder>> sigma1;
+  lpsparunfold::case_func_vector case_funcs;
+  data::data_expression current_replacement;
+
+  parunfold_replacement(const lpsparunfold::case_func_vector& case_funcs,
+                        data::set_identifier_generator& id_generator)
+  : super(sigma1)
+  , sigma1(*this, id_generator)
+  {
+    this->case_funcs = case_funcs;
+    if (case_funcs.size() != 1)
+    {
+      mCRL2log(log::verbose) << "Unfolding more than one parameter somehow" << std::endl;
+    }
+  }
+
+  template <class T>
+  void apply(T& result, const data::application& x)
+  {
+    if (current_replacement != data::data_expression() || data::is_and(x) || data::is_or(x) || data::is_not(x))
+    {
+      // if no placement of case functions is underway, or we are still traversing the regular boolean operators, we continue as usual
+      super::apply(result, x);
+    }
+    else
+    {
+      // place the case functions here
+      result = apply_case_function(x);
+    }
+  }
+
+  data::data_expression apply_case_function(const data::data_expression& expr)
+  {
+    data::data_expression result = expr;
+    for (auto& [par, case_f, det_f, replacements]: case_funcs)
+    {
+      data::data_expression_vector args;
+      args.push_back(det_f);
+
+      for (const data::data_expression& r: replacements)
+      {
+        current_replacement = r;
+        data::data_expression arg;
+        super::apply(arg, result);
+        args.push_back(arg);
+      }
+      current_replacement = data::data_expression();
+
+      result = data::application(case_f, args);
+    }
+    return result;
+  }
+
+  // Substitution application
+  data::data_expression operator()(const data::variable& x)
+  {
+    if (current_replacement == data::data_expression())
+    {
+      return x;
+    }
+    if (std::get<0>(*case_funcs.begin()) != x)
+    {
+      throw mcrl2::runtime_error("Unexpected variable at this point");
+    }
+    return current_replacement;
+  }
+};
+
+template <template <class> class Builder, template <template <class> class, class, class> class Binder>
+parunfold_replacement<Builder, Binder>
+apply_parunfold_replacement_builder(const lpsparunfold::case_func_vector& case_funcs,
+                                    data::set_identifier_generator& id_generator)
+{
+  return parunfold_replacement<Builder, Binder>(case_funcs, id_generator);
+}
+
+template <typename T>
+void insert_case_functions(T& x,
+                           const lpsparunfold::case_func_vector& cfv,
+                           data::set_identifier_generator& id_generator,
+                           typename std::enable_if<!std::is_base_of<atermpp::aterm, T>::value>::type* = nullptr
+)
+{
+  apply_parunfold_replacement_builder<lps::data_expression_builder, lps::detail::add_capture_avoiding_replacement>(cfv, id_generator).update(x);
+}
+
+template <typename T>
+void insert_case_functions(T& x,
+                           const lpsparunfold::case_func_vector& cfv,
+                           typename std::enable_if<!std::is_base_of<atermpp::aterm, T>::value>::type* = nullptr
+)
+{
+  data::set_identifier_generator id_generator;
+  id_generator.add_identifiers(lps::find_identifiers(x));
+  for (auto& [par, case_f, det_f, replacements]: cfv)
+  {
+    id_generator.add_identifier(case_f.name());
+    id_generator.add_identifier(det_f.name());
+    for (const data::data_expression& r: replacements)
+    {
+      id_generator.add_identifiers(data::find_identifiers(r));
+    }
+  }
+  insert_case_functions(x, cfv, id_generator);
+}
 
 } // namespace mcrl2::lps
 

--- a/libraries/lps/include/mcrl2/lps/lpsparunfoldlib.h
+++ b/libraries/lps/include/mcrl2/lps/lpsparunfoldlib.h
@@ -153,16 +153,19 @@ namespace detail
       return get_cache_element(sort).affected_constructors;
     }
 
-    data::data_expression create_recogniser_expr(const data::function_symbol& f, const data::data_expression& expr)
+    data::data_expression create_cases(const data::data_expression& target, const data::data_expression_vector& rhss)
     {
-      unfold_cache_element& cache_elem = get_cache_element(f.sort().target_sort());
-      auto it1 = cache_elem.affected_constructors.begin();
-      auto it2 = cache_elem.new_constructors.begin();
-      while (*it1 != f)
+      unfold_cache_element& cache_elem = get_cache_element(target.sort());
+      data::application first_arg(cache_elem.determine_function, target);
+
+      data::data_expression_vector args;
+      args.push_back(first_arg);
+      for (const data::data_expression& rhs: rhss)
       {
-        ++it1; ++it2;
+        args.push_back(rhs);
       }
-      return equal_to(data::application(cache_elem.determine_function, expr), *it2);
+
+      return data::application(cache_elem.case_functions.at(rhss.front().sort()), args);
     }
 
     const data::function_symbol_vector& get_projection_funcs(const data::function_symbol& f)

--- a/libraries/lps/include/mcrl2/lps/lpsparunfoldlib.h
+++ b/libraries/lps/include/mcrl2/lps/lpsparunfoldlib.h
@@ -31,6 +31,7 @@ namespace lspparunfold
   };
 } // namespace lspparunfold
 
+using namespace mcrl2;
 class lpsparunfold
 {
   public:

--- a/libraries/lps/include/mcrl2/lps/lpsparunfoldlib.h
+++ b/libraries/lps/include/mcrl2/lps/lpsparunfoldlib.h
@@ -15,7 +15,7 @@
 
 #include "mcrl2/data/consistency.h"
 #include "mcrl2/data/representative_generator.h"
-#include "mcrl2/lps/stochastic_specification.h"
+#include "mcrl2/lps/detail/lps_algorithm.h"
 #include "mcrl2/lps/replace_capture_avoiding.h"
 
 namespace mcrl2::lps
@@ -33,8 +33,10 @@ struct unfold_cache_element
   //mcrl2::data::data_equation_vector data_equations;
 };
 
-class lpsparunfold
+class lpsparunfold: public detail::lps_algorithm<lps::stochastic_specification>
 {
+  typedef typename detail::lps_algorithm<lps::stochastic_specification> super;
+
   public:
 
     // old parameter, case function, determinizing parameter, replacement expressions
@@ -46,23 +48,19 @@ class lpsparunfold
       * \param[in] add_distribution_laws If true, additional rewrite rules are introduced.
       * \post   The content of mCRL2 process specification analysed for useful information and class variables are set.
       **/
-    lpsparunfold(mcrl2::lps::stochastic_specification spec,
-        std::map< mcrl2::data::sort_expression , unfold_cache_element > *cache,
-        bool add_distribution_laws=false,
-        bool alt_case_placement=false
-    );
-
+    lpsparunfold(lps::stochastic_specification& spec,
+                 std::map< data::sort_expression , unfold_cache_element > *cache,
+                 bool add_distribution_laws = false, bool alt_case_placement = false);
 
     /** \brief  Destructor for lpsparunfold algorithm.
       **/
     ~lpsparunfold() {};
 
-    /** \brief  Applies lpsparunfold algorithm on a process parameter an mCRL2 process specification .
+    /** \brief  Applies lpsparunfold algorithm on a process parameter of an mCRL2 process specification .
       * \param[in] parameter_at_index An integer value that represents the index value of an process parameter.
-      * \post   The process parameter at index parameter_at_index is unfolded in the mCRL process specification.
-      * \return The process specification in which the process parameter at parameter_at_index is unfolded.
+      * \post   The process parameter at index parameter_at_index is unfolded in the mCRL2 process specification.
     **/
-    mcrl2::lps::stochastic_specification algorithm(std::size_t parameter_at_index);
+    void algorithm(std::size_t parameter_at_index);
 
   private:
     /// set of identifiers to use during fresh variable generation
@@ -76,23 +74,8 @@ class lpsparunfold
     /// \brief The name of the process parameter that needs to be unfold.
     std::string unfold_parameter_name;
 
-    /// \brief The data_specification used for manipulation
-    mcrl2::data::data_specification m_data_specification;
-
     /// a generator for default data expressions of a give sort;
     mcrl2::data::representative_generator m_representative_generator;
-
-    /// \brief The linear process used for manipulation
-    mcrl2::lps::stochastic_linear_process m_lps;
-
-    /// \brief The global variables of the specification
-    std::set< mcrl2::data::variable > m_glob_vars;
-
-    /// \brief The initialization of a linear process used for manipulation
-    mcrl2::lps::stochastic_process_initializer m_init_process;
-
-    /// \brief The initialization of a linear process
-    mcrl2::process::action_label_list m_action_label_list;
 
     /// \brief The fresh sort of the unfolded process parameter used the case function.
     mcrl2::data::basic_sort fresh_basic_sort;

--- a/libraries/lps/include/mcrl2/lps/lpsparunfoldlib.h
+++ b/libraries/lps/include/mcrl2/lps/lpsparunfoldlib.h
@@ -16,22 +16,21 @@
 #include "mcrl2/data/representative_generator.h"
 #include "mcrl2/lps/stochastic_specification.h"
 
-namespace lspparunfold
+namespace mcrl2::lps
 {
-  struct unfold_cache_element
-  {
-    mcrl2::data::basic_sort cached_fresh_basic_sort;
-    mcrl2::data::function_symbol cached_case_function;
-    mcrl2::data::function_symbol cached_determine_function;
-    mcrl2::data::function_symbol_vector cached_k;
-    mcrl2::data::function_symbol_vector cached_projection_functions;
 
-    //mcrl2::data::function_symbol_vector elements_of_new_sorts;
-    //mcrl2::data::data_equation_vector data_equations;
-  };
-} // namespace lspparunfold
+struct unfold_cache_element
+{
+  mcrl2::data::basic_sort cached_fresh_basic_sort;
+  mcrl2::data::function_symbol cached_case_function;
+  mcrl2::data::function_symbol cached_determine_function;
+  mcrl2::data::function_symbol_vector cached_k;
+  mcrl2::data::function_symbol_vector cached_projection_functions;
 
-using namespace mcrl2;
+  //mcrl2::data::function_symbol_vector elements_of_new_sorts;
+  //mcrl2::data::data_equation_vector data_equations;
+};
+
 class lpsparunfold
 {
   public:
@@ -43,7 +42,7 @@ class lpsparunfold
       * \post   The content of mCRL2 process specification analysed for useful information and class variables are set.
       **/
     lpsparunfold(mcrl2::lps::stochastic_specification spec,
-        std::map< mcrl2::data::sort_expression , lspparunfold::unfold_cache_element > *cache,
+        std::map< mcrl2::data::sort_expression , unfold_cache_element > *cache,
         bool add_distribution_laws=false
     );
 
@@ -63,7 +62,7 @@ class lpsparunfold
     /// set of identifiers to use during fresh variable generation
     mcrl2::data::set_identifier_generator m_identifier_generator;
 
-    std::map< mcrl2::data::sort_expression , lspparunfold::unfold_cache_element >* m_cache;
+    std::map< mcrl2::data::sort_expression , unfold_cache_element >* m_cache;
 
     /// \brief The sort of the process parameter that needs to be unfold.
     mcrl2::data::sort_expression m_unfold_process_parameter;
@@ -103,6 +102,9 @@ class lpsparunfold
 
     /// \brief Boolean to indicate if additional distribution laws need to be generated.
     bool m_add_distribution_laws;
+
+    data::data_expression apply_case_function(const data::data_expression& expr, const case_func_vector& case_funcs);
+    case_func_vector parameter_case_function(const std::map<data::variable, data::variable_vector >& proc_par_to_proc_par_inj, const data::function_symbol_vector& affected_constructors, const data::function_symbol& case_function);
 
     /** \brief  Generates a fresh basic sort given an string.
       * \param  str a string value. The value is used to generate a fresh
@@ -252,19 +254,20 @@ class lpsparunfold
              || c=='%' || c=='&' || c=='*' || c=='!'
              ;
     }
-    /** \brief Add a new equation to m_data_specification. 
+    /** \brief Add a new equation to m_data_specification.
     **/
     void add_new_equation(const mcrl2::data::data_expression& lhs, const mcrl2::data::data_expression& rhs);
 
-    /** \brief Create a mapping from function symbols to a list of fresh variables that can act as its arguments 
+    /** \brief Create a mapping from function symbols to a list of fresh variables that can act as its arguments
     **/
-    std::map<mcrl2::data::function_symbol, mcrl2::data::data_expression_vector> 
+    std::map<mcrl2::data::function_symbol, mcrl2::data::data_expression_vector>
               create_arguments_map(const mcrl2::data::function_symbol_vector& functions);
 
     // Applies 'process unfolding' to a sequence of summands.
     void unfold_summands(mcrl2::lps::stochastic_action_summand_vector& summands, const mcrl2::data::function_symbol& determine_function, const mcrl2::data::function_symbol_vector& pi);
 };
 
+} // namespace mcrl2::lps
 
 
 #endif

--- a/libraries/lps/include/mcrl2/lps/lpsparunfoldlib.h
+++ b/libraries/lps/include/mcrl2/lps/lpsparunfoldlib.h
@@ -144,21 +144,12 @@ class lpsparunfold: public detail::lps_algorithm<lps::stochastic_specification>
     /// \brief a generator for default data expressions of a give sort;
     mcrl2::data::representative_generator m_representative_generator;
 
-    /// \brief Boolean to indicate if additional distribution laws need to be generated.
-    bool m_add_distribution_laws;
-
     /// \brief Boolean to indicate if alternative placement of case functions should be used.
     bool m_alt_case_placement;
 
     /// \brief Boolean indicating whether rewrite rules may be added that could make
     ///        the data specification inconsistent.
     bool m_possibly_inconsistent;
-
-    /// \brief Boolean indicating how global variables should be unfolded.
-    ///        if true, global variables are unfolded into a vector of global variables,
-    ///        if false, global variable dc is unfolded into Det(dc), pi_0(dc), ..., pi_n(dc)
-    bool m_globvars;
-
 
 
     //data::data_expression apply_case_function(const data::data_expression& expr, const case_func_replacement& case_funcs);

--- a/libraries/lps/include/mcrl2/lps/lpsparunfoldlib.h
+++ b/libraries/lps/include/mcrl2/lps/lpsparunfoldlib.h
@@ -355,7 +355,7 @@ Binder<Builder, parunfold_replacement<Builder, Binder>, parunfold_replacement<Bu
     }
     if (std::get<0>(case_funcs) != x)
     {
-      throw mcrl2::runtime_error("Unexpected variable at this point");
+      return x;
     }
     return current_replacement;
   }

--- a/libraries/lps/include/mcrl2/lps/lpsparunfoldlib.h
+++ b/libraries/lps/include/mcrl2/lps/lpsparunfoldlib.h
@@ -572,7 +572,8 @@ class lpsparunfold: public detail::lps_algorithm<lps::stochastic_specification>
     lpsparunfold(lps::stochastic_specification& spec,
                  std::map< data::sort_expression , unfold_cache_element >& cache,
                  bool alt_case_placement = false,
-                 bool possibly_inconsistent = false);
+                 bool possibly_inconsistent = false,
+                 bool unfold_pattern_matching = true);
 
     /** \brief  Applies lpsparunfold algorithm on a process parameter of an mCRL2 process specification .
      *  \pre algorithm has not been called before.
@@ -598,6 +599,10 @@ class lpsparunfold: public detail::lps_algorithm<lps::stochastic_specification>
 
     /// \brief Boolean to indicate if alternative placement of case functions should be used.
     bool m_alt_case_placement;
+
+    /// \brief Indicates whether functions defined by pattern matching that occur in the scope of
+    /// a Det or pi in a state update should be unfolded.
+    bool m_unfold_pattern_matching;
 
 
     //data::data_expression apply_case_function(const data::data_expression& expr, const case_func_replacement& case_funcs);

--- a/libraries/lps/include/mcrl2/lps/lpsparunfoldlib.h
+++ b/libraries/lps/include/mcrl2/lps/lpsparunfoldlib.h
@@ -321,7 +321,7 @@ Binder<Builder, parunfold_replacement<Builder, Binder>, parunfold_replacement<Bu
     }
   }
 
-  void apply_case_function(data::data_expression& result, const data::data_expression& expr)
+  void apply_case_function(data::data_expression& result, const data::application& expr)
   {
     auto& [par, case_f, det_f, replacements] = case_funcs;
 

--- a/libraries/lps/include/mcrl2/lps/lpsparunfoldlib.h
+++ b/libraries/lps/include/mcrl2/lps/lpsparunfoldlib.h
@@ -48,7 +48,8 @@ class lpsparunfold
       **/
     lpsparunfold(mcrl2::lps::stochastic_specification spec,
         std::map< mcrl2::data::sort_expression , unfold_cache_element > *cache,
-        bool add_distribution_laws=false
+        bool add_distribution_laws=false,
+        bool alt_case_placement=false
     );
 
 
@@ -107,6 +108,8 @@ class lpsparunfold
 
     /// \brief Boolean to indicate if additional distribution laws need to be generated.
     bool m_add_distribution_laws;
+
+    bool m_alt_case_placement;
 
     data::data_expression apply_case_function(const data::data_expression& expr, const case_func_vector& case_funcs);
     case_func_vector parameter_case_function(const std::map<data::variable, data::variable_vector >& proc_par_to_proc_par_inj, const data::function_symbol_vector& affected_constructors, const data::function_symbol& case_function);

--- a/libraries/lps/include/mcrl2/lps/lpsparunfoldlib.h
+++ b/libraries/lps/include/mcrl2/lps/lpsparunfoldlib.h
@@ -330,10 +330,19 @@ Binder<Builder, parunfold_replacement<Builder, Binder>, parunfold_replacement<Bu
     }
   }
 
-  data::data_expression apply_case_function(const data::data_expression& expr)
+  data::data_expression apply_case_function(const data::application& expr)
   {
     data::data_expression result = expr;
     auto& [par, case_f, det_f, replacements] = case_funcs;
+
+    if (find_free_variables(result).count(par) == 0)
+    {
+      // variable to be replaced does not occur here
+      // make sure to still apply the substitutions necessary for the capture avoiding tricks
+      // NB: stack overflow happens if type of second argument is 'data::data_expression'.
+      super::apply(result, expr);
+      return result;
+    }
 
     data::data_expression_vector args;
     args.push_back(det_f);

--- a/libraries/lps/include/mcrl2/lps/lpsparunfoldlib.h
+++ b/libraries/lps/include/mcrl2/lps/lpsparunfoldlib.h
@@ -325,7 +325,7 @@ Binder<Builder, parunfold_replacement<Builder, Binder>, parunfold_replacement<Bu
   {
     auto& [par, case_f, det_f, replacements] = case_funcs;
 
-    if (find_free_variables(result).count(par) == 0)
+    if (data::find_free_variables(expr).count(par) == 0)
     {
       // variable to be replaced does not occur here
       // make sure to still apply the substitutions necessary for the capture avoiding tricks

--- a/libraries/lps/include/mcrl2/lps/lpsparunfoldlib.h
+++ b/libraries/lps/include/mcrl2/lps/lpsparunfoldlib.h
@@ -232,6 +232,8 @@ class lpsparunfold: public detail::lps_algorithm<lps::stochastic_specification>
     **/
     std::map<mcrl2::data::variable, mcrl2::data::data_expression> parameter_substitution();
 
+    data::data_expression apply_function(const data::function_symbol& f, const data::data_expression& de) const;
+
     /** \brief unfolds a data expression into a vector of process parameters
       * \param  de the data expression
       * \return The following vector: < det(de), pi_0(de), ... ,pi_n(de) >
@@ -316,7 +318,7 @@ Binder<Builder, parunfold_replacement<Builder, Binder>, parunfold_replacement<Bu
   template <class T>
   void apply(T& result, const data::application& x)
   {
-    if (current_replacement != data::data_expression() || data::is_and(x) || data::is_or(x) || data::is_not(x))
+    if (current_replacement != data::data_expression() || data::is_and(x) || data::is_or(x) || data::is_not(x) || data::is_imp(x) || data::is_if_application(x))
     {
       // if no placement of case functions is underway, or we are still traversing the regular boolean operators, we continue as usual
       super::apply(result, x);

--- a/libraries/lps/include/mcrl2/lps/lpsparunfoldlib.h
+++ b/libraries/lps/include/mcrl2/lps/lpsparunfoldlib.h
@@ -76,6 +76,8 @@ class lpsparunfold: public detail::lps_algorithm<lps::stochastic_specification>
     /// \brief The sort of the process parameter that needs to be unfold.
     mcrl2::data::sort_expression m_unfold_process_parameter;
 
+    data::function_symbol_vector m_affected_constructors;
+
     /// \brief The name of the process parameter that needs to be unfold.
     std::string unfold_parameter_name;
 
@@ -94,7 +96,7 @@ class lpsparunfold: public detail::lps_algorithm<lps::stochastic_specification>
     bool m_alt_case_placement;
 
     data::data_expression apply_case_function(const data::data_expression& expr, const case_func_vector& case_funcs);
-    case_func_vector parameter_case_function(const std::map<data::variable, data::variable_vector >& proc_par_to_proc_par_inj, const data::function_symbol_vector& affected_constructors, const data::function_symbol& case_function);
+    case_func_vector parameter_case_function(const std::map<data::variable, data::variable_vector >& proc_par_to_proc_par_inj, const data::function_symbol& case_function);
 
     /** \brief  Generates a fresh basic sort given an string.
       * \param  str a string value. The value is used to generate a fresh
@@ -140,13 +142,12 @@ class lpsparunfold: public detail::lps_algorithm<lps::stochastic_specification>
       * \return A function that returns the projection functions for the
       *         constructor of the unfolded process parameter.
     **/
-    mcrl2::data::function_symbol_vector create_projection_functions(mcrl2::data::function_symbol_vector k);
+    mcrl2::data::function_symbol_vector create_projection_functions();
 
     /** \brief  Creates the needed equations for the unfolded process parameter. The equations are added to m_data_specification.
       * \param  projection_functions a vector with projection functions.
       * \param  case_function the case function.
       * \param  elements_of_new_sorts set of fresh sorts.
-      * \param  affected_constructors vector of affected constructors.
       * \param  determine_function the determine function.
       * \return A set of equations for the unfolded process parameter.
     **/
@@ -154,20 +155,19 @@ class lpsparunfold: public detail::lps_algorithm<lps::stochastic_specification>
       const mcrl2::data::function_symbol_vector& projection_functions,
       const mcrl2::data::function_symbol& case_function,
       mcrl2::data::function_symbol_vector elements_of_new_sorts,
-      const mcrl2::data::function_symbol_vector& affected_constructors,
       const mcrl2::data::function_symbol& determine_function);
 
     /** \brief  Determines the constructors that are affected with the unfold
       *         process parameter.
-      * \return The constructors that are affected with the unfold
-      *         process parameter
+      * \post The constructors that are affected with the unfold
+      *         process parameter are stored in m_affected_constructors
     **/
-    mcrl2::data::function_symbol_vector determine_affected_constructors();
+    void determine_affected_constructors();
 
     /** \brief  Creates a set of constructors for the fresh basic sort
       * \return The constructors that are created for the fresh basic sort
     **/
-    mcrl2::data::function_symbol_vector new_constructors(mcrl2::data::function_symbol_vector k);
+    mcrl2::data::function_symbol_vector new_constructors();
 
     /** \brief  Get the sort of the process parameter at given index
       * \param  parameter_at_index The index of the parameter for which the sort must be obtained.
@@ -180,7 +180,6 @@ class lpsparunfold: public detail::lps_algorithm<lps::stochastic_specification>
     **/
     std::map<mcrl2::data::variable, mcrl2::data::data_expression> parameter_substitution(
       std::map<mcrl2::data::variable, mcrl2::data::variable_vector > proc_par_to_proc_par_inj,
-      mcrl2::data::function_symbol_vector k,
       const mcrl2::data::function_symbol& case_function);
 
     /** \brief unfolds a data expression into a vector of process parameters
@@ -196,7 +195,6 @@ class lpsparunfold: public detail::lps_algorithm<lps::stochastic_specification>
 
     /** \brief substitute unfold process parameter in the linear process
       * \param  case_function the case function
-      * \param  affected_constructors vector of affected constructors
       * \param  determine_function the determine function
       * \param  parameter_at_index the parameter index
       * \param  pi the projection functions
@@ -204,7 +202,6 @@ class lpsparunfold: public detail::lps_algorithm<lps::stochastic_specification>
     **/
     mcrl2::lps::stochastic_linear_process update_linear_process(
       const mcrl2::data::function_symbol& case_function,
-      mcrl2::data::function_symbol_vector affected_constructors,
       const mcrl2::data::function_symbol& determine_function,
       std::size_t parameter_at_index,
       const mcrl2::data::function_symbol_vector& pi);
@@ -247,7 +244,7 @@ class lpsparunfold: public detail::lps_algorithm<lps::stochastic_specification>
     /** \brief Create a mapping from function symbols to a list of fresh variables that can act as its arguments
     **/
     std::map<mcrl2::data::function_symbol, mcrl2::data::data_expression_vector>
-              create_arguments_map(const mcrl2::data::function_symbol_vector& functions);
+              create_arguments_map();
 
     // Applies 'process unfolding' to a sequence of summands.
     void unfold_summands(mcrl2::lps::stochastic_action_summand_vector& summands, const mcrl2::data::function_symbol& determine_function, const mcrl2::data::function_symbol_vector& pi);

--- a/libraries/lps/include/mcrl2/lps/lpsparunfoldlib.h
+++ b/libraries/lps/include/mcrl2/lps/lpsparunfoldlib.h
@@ -32,7 +32,7 @@ struct unfold_cache_element
   // case functions for sort s. Note this may be more due to, e.g., adding distribution rules.
   // invariant: case_functions.front() is the case function
   // C: fresh_basic_sort # s # ... # s -> s
-  mcrl2::data::function_symbol_vector case_functions;
+  std::map<mcrl2::data::sort_expression, mcrl2::data::function_symbol> case_functions;
   mcrl2::data::function_symbol determine_function;  // Det function for s
   mcrl2::data::function_symbol_vector projection_functions; // pi functions for s
 };
@@ -109,17 +109,17 @@ class lpsparunfold: public detail::lps_algorithm<lps::stochastic_specification>
 
     /** \brief  Applies lpsparunfold algorithm on a process parameter of an mCRL2 process specification .
      *  \pre algorithm has not been called before.
-     * \param[in] parameter_at_index An integer value that represents the index value of an process parameter.
-     * \post   The process parameter at index parameter_at_index is unfolded in the mCRL2 process specification.
+     *  \param[in] parameter_at_index An integer value that represents the index value of an process parameter.
+     *  \post   The process parameter at index parameter_at_index is unfolded in the mCRL2 process specification.
     **/
-    void algorithm(std::size_t parameter_at_index);
+    void algorithm(const std::size_t parameter_at_index);
 
   private:
-    /// set to true when the algorithm has been run once; as the algorithm should
+    /// \brief set to true when the algorithm has been run once; as the algorithm should
     /// run only once...
     bool m_run_before;
 
-    /// set of identifiers to use during fresh variable generation
+    /// \brief set of identifiers to use during fresh variable generation
     mcrl2::data::set_identifier_generator m_identifier_generator;
 
     /// \brief generator for arguments in left hand side of data equations
@@ -167,7 +167,7 @@ class lpsparunfold: public detail::lps_algorithm<lps::stochastic_specification>
     **/
     mcrl2::core::identifier_string generate_fresh_function_symbol_name(const std::string& str);
 
-    /** \brief  Generates variable of type sort based on a given string str.
+    /** \brief Generates variable of type sort based on a given string str.
       * \param str a string value. The value is used to generate a fresh
       *         variable name.
       * \param sort The sort of the variable to generate.
@@ -177,7 +177,8 @@ class lpsparunfold: public detail::lps_algorithm<lps::stochastic_specification>
     mcrl2::data::variable generate_fresh_variable(std::string str, const data::sort_expression& sort);
 
     /** \brief  Creates the case function with number of arguments determined by
-     *          the number of affected constructors.
+     *          the number of affected constructors, the sort of the arguments and
+     *          result are determined by sort..
      *  \param  sort The sort of the arguments and return sort of the case function
       * \return A function that returns the corresponding constructor given the
       *         case selector and constructors.
@@ -185,15 +186,13 @@ class lpsparunfold: public detail::lps_algorithm<lps::stochastic_specification>
     data::function_symbol create_case_function(const data::sort_expression& sort);
 
     /** \brief  Creates the determine function.
-      * \return A function that maps a constructor to the fresh basic sort
+      * \return A function that maps constructors to the fresh basic sort
     **/
     void create_determine_function();
 
     /** \brief  Creates projection functions for the unfolded process parameter.
-      * \param  k a integer value. The value represents the number of
-      *         constructors of the unfolded process parameter.
       * \return A function that returns the projection functions for the
-      *         constructor of the unfolded process parameter.
+      *         constructors of the unfolded process parameter.
     **/
     void create_projection_functions();
 
@@ -228,19 +227,14 @@ class lpsparunfold: public detail::lps_algorithm<lps::stochastic_specification>
       const mcrl2::data::data_expression& de);
 
     /** \brief substitute unfold process parameter in the linear process
-      * \param  case_function the case function
-      * \param  determine_function the determine function
       * \param  parameter_at_index the parameter index
-      * \param  pi the projection functions
-      * \return a new linear process in which the process parameter at given index is unfolded
+      * \post the process parameter at given index is unfolded in the the linear process
     **/
     void update_linear_process(std::size_t parameter_at_index);
 
     /** \brief substitute unfold process parameter in the initialization of the linear process
-      * \param  determine_function the determine function
       * \param  parameter_at_index the parameter index
-      * \param  pi the projection functions
-      * \return a new initialization for the linear process in which the process parameter at given index is unfolded
+      * \post the initialization for the linear process is updated by unfolding the parameter at given index is unfolded
     **/
    void update_linear_process_initialization(
       std::size_t parameter_at_index);
@@ -249,7 +243,7 @@ class lpsparunfold: public detail::lps_algorithm<lps::stochastic_specification>
     **/
     void create_distribution_law_over_case(
       const mcrl2::data::function_symbol& function_for_distribution,
-      const mcrl2::data::function_symbol& case_function);
+      const mcrl2::data::function_symbol case_function);
 
     void generate_case_function_equations(
       const mcrl2::data::function_symbol& case_function);

--- a/libraries/lps/include/mcrl2/lps/lpsparunfoldlib.h
+++ b/libraries/lps/include/mcrl2/lps/lpsparunfoldlib.h
@@ -245,11 +245,15 @@ class lpsparunfold: public detail::lps_algorithm<lps::stochastic_specification>
       const mcrl2::data::function_symbol& function_for_distribution,
       const mcrl2::data::function_symbol case_function);
 
+
+    /** \brief Create the data equations for case functions */
     void generate_case_function_equations(
       const mcrl2::data::function_symbol& case_function);
 
+    /** \brief Create the data equations for the determine function */
     void generate_determine_function_equations();
 
+    /** \brief Create the data equations for the projection functions */
     void generate_projection_function_equations();
 
     static bool char_filter(char c)

--- a/libraries/lps/include/mcrl2/lps/lpsparunfoldlib.h
+++ b/libraries/lps/include/mcrl2/lps/lpsparunfoldlib.h
@@ -163,7 +163,7 @@ class lpsparunfold: public detail::lps_algorithm<lps::stochastic_specification>
       *         with respect to the set of process parameters (process_parameter_names).
       * \return A fresh process parameter name.
     **/
-    mcrl2::core::identifier_string generate_fresh_process_parameter_name(std::string str, std::set<mcrl2::core::identifier_string>& process_parameter_names);
+    mcrl2::core::identifier_string generate_fresh_process_parameter_name(std::string str);
 
     /** \brief  Get the sort of the process parameter at given index
       * \param  parameter_at_index The index of the parameter for which the sort must be obtained.

--- a/libraries/lps/include/mcrl2/lps/lpsparunfoldlib.h
+++ b/libraries/lps/include/mcrl2/lps/lpsparunfoldlib.h
@@ -100,24 +100,21 @@ class lpsparunfold: public detail::lps_algorithm<lps::stochastic_specification>
       * \param[in] spec which is a valid mCRL2 process specification.
       * \param[in,out] cache Cache to store information for reuse.
       * \param[in] add_distribution_laws If true, additional rewrite rules are introduced.
+      * \param[in] alt_case_placement If true, case functions are placed at a higher level.
       * \post   The content of mCRL2 process specification analysed for useful information and class variables are set.
       **/
     lpsparunfold(lps::stochastic_specification& spec,
                  std::map< data::sort_expression , unfold_cache_element >& cache,
                  bool add_distribution_laws = false, bool alt_case_placement = false);
 
-    /** \brief  Destructor for lpsparunfold algorithm.
-      **/
-    ~lpsparunfold() {};
-
     /** \brief  Applies lpsparunfold algorithm on a process parameter of an mCRL2 process specification .
-      * \param[in] parameter_at_index An integer value that represents the index value of an process parameter.
-      * \post   The process parameter at index parameter_at_index is unfolded in the mCRL2 process specification.
+     *  \pre algorithm has not been called before.
+     * \param[in] parameter_at_index An integer value that represents the index value of an process parameter.
+     * \post   The process parameter at index parameter_at_index is unfolded in the mCRL2 process specification.
     **/
     void algorithm(std::size_t parameter_at_index);
 
   private:
-
     /// set to true when the algorithm has been run once; as the algorithm should
     /// run only once...
     bool m_run_before;
@@ -125,10 +122,10 @@ class lpsparunfold: public detail::lps_algorithm<lps::stochastic_specification>
     /// set of identifiers to use during fresh variable generation
     mcrl2::data::set_identifier_generator m_identifier_generator;
 
-    /// generator for arguments in left hand side of data equations
+    /// \brief generator for arguments in left hand side of data equations
     detail::data_equation_argument_generator m_data_equation_argument_generator;
 
-    /// cache for previously unfolded sorts.
+    /// \brief cache for previously unfolded sorts.
     /// facilitates reuse of previously introduced sorts and function symbols.
     std::map< mcrl2::data::sort_expression , unfold_cache_element >& m_cache;
 
@@ -142,21 +139,19 @@ class lpsparunfold: public detail::lps_algorithm<lps::stochastic_specification>
     /// \brief The process parameters that are inserted.
     mcrl2::data::variable_vector m_injected_parameters;
 
-    /// a generator for default data expressions of a give sort;
+    /// \brief a generator for default data expressions of a give sort;
     mcrl2::data::representative_generator m_representative_generator;
-
-    /// \brief Mapping of the unfold process parameter to a vector process parameters.
-    std::map<mcrl2::data::variable, mcrl2::data::variable_vector > proc_par_to_proc_par_inj;
 
     /// \brief Boolean to indicate if additional distribution laws need to be generated.
     bool m_add_distribution_laws;
 
+    /// \brief Boolean to indicate if alternative placement of case functions should be used.
     bool m_alt_case_placement;
 
     //data::data_expression apply_case_function(const data::data_expression& expr, const case_func_vector& case_funcs);
     case_func_vector parameter_case_function();
 
-    /** \brief  Generates a fresh basic sort given an string.
+    /** \brief  Generates a fresh basic sort given a sort expression.
       * \param  str a string value. The value is used to generate a fresh
       *         basic sort.
       * \post   A fresh basic sort is generated.
@@ -270,6 +265,7 @@ class lpsparunfold: public detail::lps_algorithm<lps::stochastic_specification>
              || c=='>' || c=='[' || c==']' || c=='@'
              || c=='.' || c=='{' || c=='}' || c=='#'
              || c=='%' || c=='&' || c=='*' || c=='!'
+             || c=='(' || c==')'
              ;
     }
 

--- a/libraries/lps/include/mcrl2/lps/lpsparunfoldlib.h
+++ b/libraries/lps/include/mcrl2/lps/lpsparunfoldlib.h
@@ -63,6 +63,11 @@ class lpsparunfold: public detail::lps_algorithm<lps::stochastic_specification>
     void algorithm(std::size_t parameter_at_index);
 
   private:
+
+    /// set to true when the algorithm has been run once; as the algorithm should
+    /// run only once...
+    bool m_run_before;
+
     /// set of identifiers to use during fresh variable generation
     mcrl2::data::set_identifier_generator m_identifier_generator;
 
@@ -105,7 +110,16 @@ class lpsparunfold: public detail::lps_algorithm<lps::stochastic_specification>
       * \post   A fresh name for a constructor or mapping is generated.
       * \return A fresh name for a constructor or mapping.
     **/
-    mcrl2::core::identifier_string generate_fresh_constructor_and_mapping_name(std::string str);
+    mcrl2::data::function_symbol generate_fresh_function_symbol(std::string str, const data::sort_expression& sort);
+
+    /** \brief  Generates variable of type sort based on a given string str.
+      * \param str a string value. The value is used to generate a fresh
+      *         variable name.
+      * \param sort The sort of the variable to generate.
+      * \post   A fresh variable is generated, which has an unique name.
+      * \return A fresh variable.
+    **/
+    mcrl2::data::variable generate_fresh_variable(std::string str, const data::sort_expression& sort);
 
     /** \brief  Creates the case function.
       * \param  k a integer value. The value represents the number of
@@ -154,16 +168,6 @@ class lpsparunfold: public detail::lps_algorithm<lps::stochastic_specification>
       * \return The constructors that are created for the fresh basic sort
     **/
     mcrl2::data::function_symbol_vector new_constructors(mcrl2::data::function_symbol_vector k);
-
-    /** \brief  Generates a process parameter name given an string.
-      * \param str a string value. The value is used to generate a fresh
-      *         process parameter name.
-      * \param process_parameter_names The context to use for generating fresh names.
-      * \post   A fresh process parameter name is generated, which has an unique name
-      *         with respect to the set of process parameters (process_parameter_names).
-      * \return A fresh process parameter name.
-    **/
-    mcrl2::core::identifier_string generate_fresh_process_parameter_name(std::string str);
 
     /** \brief  Get the sort of the process parameter at given index
       * \param  parameter_at_index The index of the parameter for which the sort must be obtained.

--- a/libraries/lps/include/mcrl2/lps/lpsparunfoldlib.h
+++ b/libraries/lps/include/mcrl2/lps/lpsparunfoldlib.h
@@ -105,7 +105,8 @@ class lpsparunfold: public detail::lps_algorithm<lps::stochastic_specification>
       **/
     lpsparunfold(lps::stochastic_specification& spec,
                  std::map< data::sort_expression , unfold_cache_element >& cache,
-                 bool add_distribution_laws = false, bool alt_case_placement = false);
+                 bool add_distribution_laws = false, bool alt_case_placement = false,
+                 bool possibly_inconsistent = false);
 
     /** \brief  Applies lpsparunfold algorithm on a process parameter of an mCRL2 process specification .
      *  \pre algorithm has not been called before.
@@ -147,6 +148,10 @@ class lpsparunfold: public detail::lps_algorithm<lps::stochastic_specification>
 
     /// \brief Boolean to indicate if alternative placement of case functions should be used.
     bool m_alt_case_placement;
+
+    /// \brief Boolean indicated whether rewrite rules may be added that could make
+    ///        the data specification inconsistent.
+    bool m_possibly_inconsistent;
 
     //data::data_expression apply_case_function(const data::data_expression& expr, const case_func_replacement& case_funcs);
     case_func_replacement parameter_case_function();

--- a/libraries/lps/include/mcrl2/lps/one_point_rule_rewrite.h
+++ b/libraries/lps/include/mcrl2/lps/one_point_rule_rewrite.h
@@ -21,6 +21,8 @@ namespace lps {
 
 namespace detail {
 
+
+
 struct one_point_rule_rewrite_builder: public lps::data_expression_builder<one_point_rule_rewrite_builder>
 {
   typedef lps::data_expression_builder<one_point_rule_rewrite_builder> super;

--- a/libraries/lps/include/mcrl2/lps/rewriters/one_point_condition_rewrite.h
+++ b/libraries/lps/include/mcrl2/lps/rewriters/one_point_condition_rewrite.h
@@ -1,0 +1,189 @@
+// Author(s): Jeroen Keiren
+// Copyright: see the accompanying file COPYING or copy at
+// https://github.com/mCRL2org/mCRL2/blob/master/COPYING
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+/// \file mcrl2/lps/rewriters/one_point_condition_rewrite.h
+/// \brief Rewriter for LPSs that takes equalities of the form p_i == c, where
+///        p_i is a process parameter, and c is a constant, into account when
+///        simplifying the remainder of a summand.
+
+#ifndef MCRL2_LPS_REWRITERS_ONE_POINT_CONDITION_REWRITE_H
+#define MCRL2_LPS_REWRITERS_ONE_POINT_CONDITION_REWRITE_H
+
+#include "mcrl2/data/join.h"
+#include "mcrl2/data/substitutions/mutable_map_substitution.h"
+#include "mcrl2/data/rewriter.h"
+#include "mcrl2/lps/rewriters/data_rewriter.h"
+#include "mcrl2/lps/builder.h"
+
+namespace mcrl2 {
+
+namespace lps {
+
+namespace detail {
+
+// Extracts all conjuncts d == e from the data expression x, for variables d, and with e a constant.
+void find_equality_conjuncts(const data::data_expression& x, std::map<data::variable, data::data_expression>& result)
+{
+  std::set<data::data_expression> conjuncts = data::split_and(x);
+  for (const data::data_expression& expr: conjuncts)
+  {
+    const auto& v_i = expr;
+    if (data::is_equal_to_application(v_i))
+    {
+      const data::data_expression& left = data::binary_left1(v_i);
+      const data::data_expression& right = data::binary_right1(v_i);
+      if (data::is_variable(left) && data::is_constant(right))
+      {
+        const auto& vleft = atermpp::down_cast<data::variable>(left);
+        result[vleft] = right;
+      }
+      else if (data::is_variable(right) && data::is_constant(left))
+      {
+        const auto& vright = atermpp::down_cast<data::variable>(right);
+        result[vright] = left;
+      }
+    }
+    // handle conjuncts b and !b, with b a variable with sort Bool
+    else if (data::is_variable(v_i) && data::sort_bool::is_bool(v_i.sort()))
+    {
+      const auto& v = atermpp::down_cast<data::variable>(v_i);
+      result[v] = data::sort_bool::true_();
+    }
+    else if (data::sort_bool::is_not_application(v_i))
+    {
+      const data::data_expression& narg = data::sort_bool::arg(v_i);
+      if (data::is_variable(narg) && data::sort_bool::is_bool(v_i.sort()))
+      {
+        const auto& v = atermpp::down_cast<data::variable>(narg);
+        result[v] = data::sort_bool::false_();
+      }
+    }
+  }
+  mCRL2log(log::debug2, "one_point_condition_rewriter") << "  computing one point variables: expression = " << x << ", result = " << core::detail::print_map(result) << std::endl;
+}
+
+template <typename DataRewriter>
+struct one_point_condition_rewrite_builder: public lps::data_expression_builder<one_point_condition_rewrite_builder<DataRewriter> >
+{
+  typedef lps::data_expression_builder<one_point_condition_rewrite_builder<DataRewriter> > super;
+  using super::enter;
+  using super::leave;
+  using super::apply;
+  using super::update;
+
+  const DataRewriter& R;
+  data::mutable_map_substitution<> sigma; // substitution is only used for variables that appear condition of summand, and is cleared after.
+
+  one_point_condition_rewrite_builder(const DataRewriter& R_)
+      : R(R_)
+  {}
+
+  void calculate_substitutions(const data::data_expression& x)
+  {
+    // calculate substitutions
+    std::map<data::variable, data::data_expression> assignments; // TODO: adapt to substitution
+    detail::find_equality_conjuncts(x, assignments);
+    for (const auto& [k,v]: assignments)
+    {
+      sigma[k] = v;
+    }
+  }
+
+  void reset_substitutions()
+  {
+    sigma.clear();
+  }
+
+  void update(lps::action_summand& x)
+  {
+    enter(x);
+    calculate_substitutions(x.condition());
+
+    // rewrite summand
+    lps::multi_action result_multi_action;
+    apply(result_multi_action, x.multi_action());
+    x.multi_action() = result_multi_action;
+    data::assignment_list result_assignments;
+    apply(result_assignments, x.assignments());
+    x.assignments() = result_assignments;
+
+    reset_substitutions();
+    leave(x);
+  }
+
+  void update(lps::deadlock_summand& x)
+  {
+    enter(x);
+    calculate_substitutions(x.condition());
+
+    // rewrite summand
+    update(x.deadlock());
+
+    // reset substitution
+    reset_substitutions();
+    leave(x);
+  }
+
+  // TODO: should the stochastic distribution be rewritten or not?
+  void update(lps::stochastic_action_summand& x)
+  {
+    enter(x);
+    calculate_substitutions(x.condition());
+
+    // rewrite summand
+    lps::multi_action result_multi_action;
+    apply(result_multi_action, x.multi_action());
+    x.multi_action() = result_multi_action;
+    data::assignment_list result_assignments;
+    apply(result_assignments, x.assignments());
+    x.assignments() = result_assignments;
+    stochastic_distribution result_distribution;
+    apply(result_distribution, x.distribution());
+    x.distribution() = result_distribution;
+
+    reset_substitutions();
+    leave(x);
+  }
+
+  template <class T>
+  void apply(T& result, const data::data_expression& x)
+  {
+    result = R(x, sigma);
+  }
+};
+
+} // namespace detail
+
+/// \brief Applies the one point condition rewriter to all embedded data expressions in an object x
+/// \param x an object containing data expressions
+template <typename T, typename DataRewriter>
+void one_point_condition_rewrite(T& x, const DataRewriter& R, typename std::enable_if<!std::is_base_of<atermpp::aterm, T>::value>::type* = nullptr)
+{
+  detail::one_point_condition_rewrite_builder<DataRewriter>  f(R);
+  f.update(x);
+}
+
+/// \brief Applies the one point condition rewriter to all embedded data expressions in an object x
+/// \param x an object containing data expressions
+/// \return the rewrite result
+template <typename T, typename DataRewriter>
+T one_point_condition_rewrite(const T& x, const DataRewriter& R, typename std::enable_if<std::is_base_of<atermpp::aterm, T>::value>::type* = nullptr)
+{
+  T result;
+  detail::one_point_condition_rewrite_builder<DataRewriter> f(R);
+  f.apply(result, x);
+  return result;
+}
+
+} // namespace lps
+
+} // namespace mcrl2
+
+#endif // MCRL2_LPS_DETAIL_ONE_POINT_CONDITION_REWRITE_H
+
+

--- a/libraries/lps/source/lpsparunfoldlib.cpp
+++ b/libraries/lps/source/lpsparunfoldlib.cpp
@@ -420,7 +420,7 @@ void lpsparunfold::update_linear_process(std::size_t parameter_at_index)
     }
 
     // place the case functions
-    insert_case_functions(m_spec.process(), parameter_case_function());
+    insert_case_functions(m_spec.process(), parameter_case_function(), m_identifier_generator);
   }
   else
   {
@@ -786,6 +786,9 @@ void lpsparunfold::algorithm(const std::size_t parameter_at_index)
     update_linear_process(parameter_at_index);
     update_linear_process_initialization(parameter_at_index);
   }
+
+  /* Updating cache*/
+  m_cache[m_unfold_parameter.sort()] = m_new_cache_element;
 
   assert(check_well_typedness(m_spec));
 }

--- a/libraries/lps/source/lpsparunfoldlib.cpp
+++ b/libraries/lps/source/lpsparunfoldlib.cpp
@@ -634,6 +634,7 @@ void lpsparunfold::update_linear_process(std::size_t parameter_at_index)
     lps::replace_variables_capture_avoiding(m_spec.process(), s);
   }
 
+  // Unfold pattern matching mappings in parameter updates, requires intermediate rewriting
   data::rewriter rewr(m_spec.data());
   for (action_summand& sum: m_spec.process().action_summands())
   {

--- a/libraries/lps/source/lpsparunfoldlib.cpp
+++ b/libraries/lps/source/lpsparunfoldlib.cpp
@@ -280,9 +280,9 @@ void lpsparunfold::unfold_summands(lps::stochastic_action_summand_vector& summan
   }
 }
 
-lpsparunfold::case_func_vector lpsparunfold::parameter_case_function()
+lpsparunfold::case_func_replacement lpsparunfold::parameter_case_function()
 {
-  lpsparunfold::case_func_vector result;
+  lpsparunfold::case_func_replacement result;
   data_expression_vector dev;
 
   auto new_pars_it = m_injected_parameters.cbegin();
@@ -309,10 +309,10 @@ lpsparunfold::case_func_vector lpsparunfold::parameter_case_function()
     }
 
     dev.push_back(case_func_arg);
-
-    result.push_back(std::make_tuple(m_unfold_parameter, m_new_cache_element.case_functions[m_unfold_parameter.sort()], m_injected_parameters[0], dev));
   }
-  return result;
+
+  return std::make_tuple(m_unfold_parameter, m_new_cache_element.case_functions, m_injected_parameters[0], dev);
+
 }
 
 void lpsparunfold::update_linear_process(std::size_t parameter_at_index)
@@ -390,6 +390,11 @@ void lpsparunfold::update_linear_process(std::size_t parameter_at_index)
   m_spec.process().process_parameters() = data::variable_list();
   if (m_alt_case_placement)
   {
+    create_case_function(data::sort_bool::bool_());
+    for(const data::variable& param: new_process_parameters)
+    {
+      create_case_function(param.sort());
+    }
     insert_case_functions(m_spec.process(), parameter_case_function());
   }
   else

--- a/libraries/lps/source/lpsparunfoldlib.cpp
+++ b/libraries/lps/source/lpsparunfoldlib.cpp
@@ -501,6 +501,20 @@ std::map<data::variable, data::data_expression> lpsparunfold::parameter_substitu
   return result;
 }
 
+data::data_expression lpsparunfold::apply_function(const function_symbol& f, const data_expression& de) const
+{
+  if(m_alt_case_placement && is_if_application(de))
+  {
+    return data::if_(arg1(de),
+                     apply_function(f, arg2(de)),
+                     apply_function(f, arg3(de)));
+  }
+  else
+  {
+    return application(f, de);
+  }
+}
+
 data::data_expression_vector lpsparunfold::unfold_constructor(const data_expression& de)
 {
   assert(de.sort() == m_unfold_parameter.sort());
@@ -527,11 +541,11 @@ data::data_expression_vector lpsparunfold::unfold_constructor(const data_express
   else
   {
     /* Det function */
-    result.emplace_back(application(m_new_cache_element.determine_function, de)) ;
+    result.emplace_back(apply_function(m_new_cache_element.determine_function, de));
 
     for (const function_symbol& f: m_new_cache_element.projection_functions)
     {
-      result.emplace_back(application(f, de)) ;
+      result.emplace_back(apply_function(f, de)) ;
     }
   }
 

--- a/libraries/lps/source/lpsparunfoldlib.cpp
+++ b/libraries/lps/source/lpsparunfoldlib.cpp
@@ -392,11 +392,25 @@ void lpsparunfold::update_linear_process(std::size_t parameter_at_index)
   m_spec.process().process_parameters() = data::variable_list();
   if (m_alt_case_placement)
   {
-    create_case_function(data::sort_bool::bool_());
-    for(const data::variable& param: new_process_parameters)
+    create_case_function(data::sort_bool::bool_()); // conditions
+    create_case_function(data::sort_real::real_()); // time/distributions
+
+    // process parameters
+    for (const data::variable& param : new_process_parameters)
     {
       create_case_function(param.sort());
     }
+
+    // parameters of actions
+    for (const process::action_label& action_label : m_spec.action_labels())
+    {
+      for (const sort_expression& s : action_label.sorts())
+      {
+        create_case_function(s);
+      }
+    }
+
+    // place the case functions
     insert_case_functions(m_spec.process(), parameter_case_function());
   }
   else

--- a/libraries/lps/source/lpsparunfoldlib.cpp
+++ b/libraries/lps/source/lpsparunfoldlib.cpp
@@ -623,9 +623,10 @@ void lpsparunfold::generate_case_function_equations(const data::function_symbol&
 
 void lpsparunfold::generate_determine_function_equations()
 {
-  const function_symbol_vector::const_iterator constructor_it = m_new_cache_element.new_constructors.begin();
+  function_symbol_vector::const_iterator constructor_it = m_new_cache_element.new_constructors.begin();
   for (const function_symbol& f: m_new_cache_element.affected_constructors)
   {
+    assert(constructor_it != m_new_cache_element.new_constructors.end());
     /* Creating an equation for the detector function */
     const variable_vector function_arguments = m_data_equation_argument_generator.arguments(f);
     if(function_arguments.empty())
@@ -643,6 +644,7 @@ void lpsparunfold::generate_determine_function_equations()
                       application(f,args)),
           *constructor_it));
     }
+    ++constructor_it;
   }
 
   if (m_add_distribution_laws)

--- a/libraries/lps/source/lpsparunfoldlib.cpp
+++ b/libraries/lps/source/lpsparunfoldlib.cpp
@@ -510,9 +510,9 @@ data::data_expression lpsparunfold::apply_function(const function_symbol& f, con
 {
   if(m_alt_case_placement && is_if_application(de))
   {
-    return data::if_(arg1(de),
-                     apply_function(f, arg2(de)),
-                     apply_function(f, arg3(de)));
+    return data::if_(atermpp::down_cast<data::application>(de)[0],
+                     apply_function(f, atermpp::down_cast<data::application>(de)[1]),
+                     apply_function(f, atermpp::down_cast<data::application>(de)[2]));
   }
   else
   {

--- a/libraries/lps/source/lpsparunfoldlib.cpp
+++ b/libraries/lps/source/lpsparunfoldlib.cpp
@@ -638,9 +638,12 @@ void lpsparunfold::generate_case_function_equations(const data::function_symbol&
     {
       for(const function_symbol& right: m_new_cache_element.new_constructors)
       {
-        const application lhs = data::equal_to(left, right);
-        const data_expression rhs = (left == right) ? data::true_() : data::false_();
-        m_spec.data().add_equation(data_equation(lhs, rhs));
+        if (left != right)
+        {
+          const application lhs = data::equal_to(left, right);
+          const data_expression rhs = data::false_();
+          m_spec.data().add_equation(data_equation(lhs, rhs));
+        }
       }
     }
   }

--- a/libraries/lps/source/lpsparunfoldlib.cpp
+++ b/libraries/lps/source/lpsparunfoldlib.cpp
@@ -341,13 +341,13 @@ void lpsparunfold::update_linear_process(std::size_t parameter_at_index)
   /* Create new process parameters */
   data::variable_vector new_process_parameters;
 
+  /* Expand unfold_parameter */
+  mCRL2log(log::verbose) << "  Unfolding parameter " << unfold_parameter_it->name() << " at index " << parameter_at_index << "..." << std::endl;
+
   /* First copy the initial part of the parameters */
   new_process_parameters.insert(new_process_parameters.end(),
                                 process_parameters.begin(),
                                 unfold_parameter_it);
-
-  /* Expand unfold_parameter */
-  mCRL2log(log::verbose) << "Unfolding parameter " << unfold_parameter_it->name() << " at index " << parameter_at_index << "..." << std::endl;
 
   const data::variable param = generate_fresh_variable(m_unfold_parameter.name(), m_new_cache_element.fresh_basic_sort );
   m_injected_parameters.push_back(param);
@@ -419,11 +419,13 @@ void lpsparunfold::update_linear_process(std::size_t parameter_at_index)
       }
     }
 
+    mCRL2log(log::verbose) << "- Inserting case functions into the process using alternative case placement";
     // place the case functions
     insert_case_functions(m_spec.process(), parameter_case_function(), m_identifier_generator);
   }
   else
   {
+    mCRL2log(log::verbose) << "- Inserting case functions into the process using default case placement" << std::endl;
     //Prepare parameter substitution
     const mutable_map_substitution< std::map< data::variable , data::data_expression > > s{parameter_substitution()};
     lps::replace_variables_capture_avoiding(m_spec.process(), s);

--- a/libraries/lps/source/lpsparunfoldlib.cpp
+++ b/libraries/lps/source/lpsparunfoldlib.cpp
@@ -46,6 +46,14 @@ lpsparunfold::lpsparunfold(lps::stochastic_specification& spec,
 {
   m_identifier_generator.add_identifiers(lps::find_identifiers(spec));
   m_identifier_generator.add_identifiers(data::find_identifiers(spec.data()));
+  for (const function_symbol& f : spec.data().constructors())
+  {
+    m_identifier_generator.add_identifier(f.name());
+  }
+  for (const function_symbol& f : spec.data().mappings())
+  {
+    m_identifier_generator.add_identifier(f.name());
+  }
 }
 
 data::basic_sort lpsparunfold::generate_fresh_basic_sort(const data::sort_expression& sort)

--- a/libraries/lps/source/lpsparunfoldlib.cpp
+++ b/libraries/lps/source/lpsparunfoldlib.cpp
@@ -632,6 +632,17 @@ void lpsparunfold::generate_case_function_equations(const data::function_symbol&
     }
 
     m_spec.data().add_equation(data_equation(args, lhs, lazy::join_or(disjuncts.begin(), disjuncts.end())));
+
+    // We also need to add rules for equality on the new sort.
+    for(const function_symbol& left: m_new_cache_element.new_constructors)
+    {
+      for(const function_symbol& right: m_new_cache_element.new_constructors)
+      {
+        const application lhs = data::equal_to(left, right);
+        const data_expression rhs = (left == right) ? data::true_() : data::false_();
+        m_spec.data().add_equation(data_equation(lhs, rhs));
+      }
+    }
   }
 }
 

--- a/libraries/lps/source/lpsparunfoldlib.cpp
+++ b/libraries/lps/source/lpsparunfoldlib.cpp
@@ -46,36 +46,7 @@ lpsparunfold::lpsparunfold(lps::stochastic_specification spec,
   mCRL2log(debug) << "Processing" << std::endl;
 
   m_identifier_generator.add_identifiers(lps::find_identifiers(spec));
-
-  for (const sort_expression& s:  m_data_specification.sorts())
-  {
-    if (is_basic_sort(s))
-    {
-      sort_names.insert((basic_sort(s)).name());
-    }
-  };
-
-  m_identifier_generator.add_identifiers(sort_names);
-
-  {
-    std::size_t size = mapping_and_constructor_names.size();
-    for (const function_symbol& f: m_data_specification.constructors())
-    {
-      mapping_and_constructor_names.insert(f.name());
-    };
-    mCRL2log(debug) << "- Specification has " <<   mapping_and_constructor_names.size() - size << " constructors" << std::endl;
-  }
-
-  {
-    std::size_t size = mapping_and_constructor_names.size();
-    for (const function_symbol& f: m_data_specification.mappings())
-    {
-      mapping_and_constructor_names.insert(f.name());
-    };
-    mCRL2log(debug) << "- Specification has " <<  mapping_and_constructor_names.size() - size << " mappings " << std::endl;
-  }
-
-  m_identifier_generator.add_identifiers(mapping_and_constructor_names);
+  m_identifier_generator.add_identifiers(data::find_identifiers(m_data_specification));
 }
 
 data::basic_sort lpsparunfold::generate_fresh_basic_sort(const std::string& str)
@@ -83,7 +54,6 @@ data::basic_sort lpsparunfold::generate_fresh_basic_sort(const std::string& str)
   //Generate a fresh Basic Sort
   core::identifier_string nstr = m_identifier_generator(str);
   mCRL2log(verbose) << "Generated fresh sort \"" <<  std::string(nstr) << "\" for \"" <<  str << "\"" << std::endl;
-  sort_names.insert(nstr);
   return basic_sort(std::string(nstr));
 }
 
@@ -95,7 +65,6 @@ core::identifier_string lpsparunfold::generate_fresh_constructor_and_mapping_nam
 
   core::identifier_string nstr = m_identifier_generator(str);
   mCRL2log(debug) << "Generated a fresh mapping: " <<  std::string(nstr) << std::endl;
-  mapping_and_constructor_names.insert(nstr);
   return nstr;
 }
 
@@ -130,8 +99,6 @@ function_symbol_vector lpsparunfold::new_constructors(data::function_symbol_vect
     elements_of_new_sorts.push_back(f);
     m_data_specification.add_constructor(f);
     mCRL2log(debug) << "\t" << data::function_symbol(fresh_name , fresh_basic_sort) << std::endl;
-    mapping_and_constructor_names.insert(fresh_name);
-
   }
   mCRL2log(debug) << "- Created " <<  elements_of_new_sorts.size() << " fresh \" c_ \" constructor(s)" << std::endl;
   return elements_of_new_sorts;
@@ -692,7 +659,6 @@ data::sort_expression lpsparunfold::sort_at_process_parameter_index(std::size_t 
   {
     core::identifier_string nstr;
     nstr = m_identifier_generator("S");
-    sort_names.insert(nstr);
     unfold_parameter_name = nstr;
   }
 
@@ -700,7 +666,6 @@ data::sort_expression lpsparunfold::sort_at_process_parameter_index(std::size_t 
   {
     core::identifier_string nstr;
     nstr = m_identifier_generator("S");
-    sort_names.insert(nstr);
     unfold_parameter_name = nstr;
   }
 

--- a/libraries/lps/source/lpsparunfoldlib.cpp
+++ b/libraries/lps/source/lpsparunfoldlib.cpp
@@ -454,6 +454,7 @@ lpsparunfold::lpsparunfold(lps::stochastic_specification& spec,
     : lps::detail::lps_algorithm<lps::stochastic_specification>(spec),
       m_run_before(false),
       m_datamgr(cache, spec.data(), possibly_inconsistent),
+      m_pattern_unfolder(m_datamgr),
       m_alt_case_placement(alt_case_placement)
 {
   m_datamgr.add_used_identifiers(lps::find_identifiers(spec));
@@ -757,11 +758,11 @@ data::data_expression_vector lpsparunfold::unfold_constructor(const data_express
   else
   {
     /* Det function */
-    result.emplace_back(apply_function(new_cache_element.determine_function, de));
+    result.emplace_back(unfold_pattern_matching(apply_function(new_cache_element.determine_function, de), m_pattern_unfolder));
 
     for (const function_symbol& f: new_cache_element.projection_functions)
     {
-      result.emplace_back(apply_function(f, de)) ;
+      result.emplace_back(unfold_pattern_matching(apply_function(f, de), m_pattern_unfolder));
     }
   }
 

--- a/libraries/lps/source/tools.cpp
+++ b/libraries/lps/source/tools.cpp
@@ -20,6 +20,7 @@
 #include "mcrl2/lps/tools.h"
 #include "mcrl2/lps/untime.h"
 #include "mcrl2/lps/one_point_rule_rewrite.h"
+#include "mcrl2/lps/rewriters/one_point_condition_rewrite.h"
 
 namespace mcrl2
 {
@@ -228,6 +229,12 @@ void lpsrewr(const std::string& input_filename,
     case quantifier_one_point:
     {
       one_point_rule_rewrite(spec);
+      break;
+    }
+    case condition_one_point:
+    {
+      mcrl2::data::rewriter R(spec.data(), rewrite_strategy);
+      lps::one_point_condition_rewrite(spec, R);
       break;
     }
   }

--- a/libraries/lps/test/lpsparunfold_test.cpp
+++ b/libraries/lps/test/lpsparunfold_test.cpp
@@ -68,7 +68,7 @@ BOOST_AUTO_TEST_CASE(test_main)
     /* Return */
 
     std::map< mcrl2::data::sort_expression , lps::unfold_cache_element > unfold_cache;
-    lpsparunfold lpsparunfold(s0, &unfold_cache);
+    lpsparunfold lpsparunfold(s0, unfold_cache);
     lpsparunfold.algorithm(0);
     variable_list p1 = s0.process().process_parameters();
     if (p1.size() != 3)

--- a/libraries/lps/test/lpsparunfold_test.cpp
+++ b/libraries/lps/test/lpsparunfold_test.cpp
@@ -67,7 +67,7 @@ BOOST_AUTO_TEST_CASE(test_main)
 
     /* Return */
 
-    std::map< mcrl2::data::sort_expression , lspparunfold::unfold_cache_element > unfold_cache;
+    std::map< mcrl2::data::sort_expression , lps::unfold_cache_element > unfold_cache;
     lpsparunfold lpsparunfold(s0, &unfold_cache);
     stochastic_specification s1 = lpsparunfold.algorithm(0);
     variable_list p1 = s1.process().process_parameters();

--- a/libraries/lps/test/lpsparunfold_test.cpp
+++ b/libraries/lps/test/lpsparunfold_test.cpp
@@ -69,8 +69,8 @@ BOOST_AUTO_TEST_CASE(test_main)
 
     std::map< mcrl2::data::sort_expression , lps::unfold_cache_element > unfold_cache;
     lpsparunfold lpsparunfold(s0, &unfold_cache);
-    stochastic_specification s1 = lpsparunfold.algorithm(0);
-    variable_list p1 = s1.process().process_parameters();
+    lpsparunfold.algorithm(0);
+    variable_list p1 = s0.process().process_parameters();
     if (p1.size() != 3)
     {
       std::clog << "--- failed test ---" << std::endl;
@@ -84,7 +84,7 @@ BOOST_AUTO_TEST_CASE(test_main)
       if (std::distance(p1.begin(), i) == 1 && data::pp(i->sort()).compare("Bool") != 0)
       {
         std::clog << "--- failed test ---" << std::endl;
-        std::clog << lps::pp(s1) << std::endl;
+        std::clog << lps::pp(s0) << std::endl;
         std::clog << "expected 2nd process parameter to be of type Bool" << std::endl;
         std::clog << "computed process parameter of type "  << data::pp(i->sort()) << std::endl;
       }
@@ -93,7 +93,7 @@ BOOST_AUTO_TEST_CASE(test_main)
       if (std::distance(p1.begin(), i) == 2 && data::pp(i->sort()).compare("Pos") != 0)
       {
         std::clog << "--- failed test ---" << std::endl;
-        std::clog << lps::pp(s1) << std::endl;
+        std::clog << lps::pp(s0) << std::endl;
         std::clog << "expected 3th process parameter to be of type Pos " << std::endl;
         std::clog << "computed process parameter of type "  << data::pp(i->sort()) << std::endl;
       }

--- a/libraries/lps/test/one_point_condition_rewriter_test.cpp
+++ b/libraries/lps/test/one_point_condition_rewriter_test.cpp
@@ -1,0 +1,169 @@
+// Author(s): Jeroen Keiren
+// Copyright: see the accompanying file COPYING or copy at
+// https://github.com/mCRL2org/mCRL2/blob/master/COPYING
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+/// \file one_point_condition_rewriter_test.cpp
+/// \brief Tests for rewriter that uses LPS condition to simplify the right
+/// hand side of a summand.
+
+#define BOOST_TEST_MODULE one_point_condition_rewriter_test
+#include <boost/test/included/unit_test.hpp>
+
+#include "mcrl2/data/detail/parse_substitution.h"
+#include "mcrl2/lps/detail/specification_property_map.h"
+#include "mcrl2/lps/rewriters/one_point_condition_rewrite.h"
+#include "mcrl2/lps/parse.h"
+#include "mcrl2/lps/rewrite.h"
+
+using namespace mcrl2;
+using namespace mcrl2::data;
+using namespace mcrl2::data::detail;
+using namespace mcrl2::lps;
+using namespace mcrl2::lps::detail;
+
+// Checks if rewriting the specification src with the substitutions sigma
+// results in the specification dest.
+void test_one_point_condition_rewriter(const std::string& src_text, const std::string& dest_text)
+{
+  lps::specification src  = parse_linear_process_specification(src_text);
+  lps::specification dest = parse_linear_process_specification(dest_text);
+
+  // rewrite the specification src
+  data::rewriter R(src.data());
+  lps::one_point_condition_rewrite(src, R);
+
+  if (src != dest)
+  {
+    std::cerr << "--- test failed ---" << std::endl;
+    std::cerr << lps::pp(src) << std::endl;
+    std::cerr << "-------------------" << std::endl;
+    std::cerr << lps::pp(dest) << std::endl;
+  }
+  BOOST_CHECK(src == dest);
+}
+
+void test_one_point_condition_rule_rewriter()
+{
+  std::string src =
+      "act a: Nat;\n"
+      "\n"
+      "proc P(n: Nat) = (n == 0) -> a(n + 1). P(n + 2);\n"
+      "\n"
+      "init P(0);\n";
+
+  std::string expected_result =
+      "act a: Nat;\n"
+      "\n"
+      "proc P(n: Nat) = (n == 0) -> a(1). P(2);\n"
+      "\n"
+      "init P(0);\n";
+
+  test_one_point_condition_rewriter(src, expected_result);
+}
+
+void test_parunfold_example()
+{
+  std::string src =
+    "sort ListNat;\n"
+    "\n"
+    "cons c_,c_1: ListNat;\n"
+    "\n"
+    "map  C_ListNat: ListNat # List(Nat) # List(Nat) -> List(Nat);\n"
+    "Det_ListNat: List(Nat) -> ListNat;\n"
+    "pi_ListNat: List(Nat) -> Nat;\n"
+    "pi_ListNat1: List(Nat) -> List(Nat);\n"
+    "C_ListNat: ListNat # Bool # Bool -> Bool;\n"
+    "C_ListNat: ListNat # ListNat # ListNat -> ListNat;\n"
+    "C_ListNat: ListNat # Nat # Nat -> Nat;\n"
+    "\n"
+    "var  d1,d2: List(Nat);\n"
+    "d,d6,d7: ListNat;\n"
+    "d3,d8: Nat;\n"
+    "d4,d5: Bool;\n"
+    "eqn  C_ListNat(c_, d1, d2)  =  d1;\n"
+    "C_ListNat(c_1, d1, d2)  =  d2;\n"
+    "C_ListNat(d, d2, d2)  =  d2;\n"
+    "Det_ListNat([])  =  c_;\n"
+    "Det_ListNat(d3 |> d1)  =  c_1;\n"
+    "pi_ListNat(d3 |> d1)  =  d3;\n"
+    "pi_ListNat([])  =  0;\n"
+    "pi_ListNat1(d3 |> d1)  =  d1;\n"
+    "pi_ListNat1([])  =  [];\n"
+    "C_ListNat(c_, d4, d5)  =  d4;\n"
+    "C_ListNat(c_1, d4, d5)  =  d5;\n"
+    "C_ListNat(d, d5, d5)  =  d5;\n"
+    "C_ListNat(d, d4, d5)  =  d4 && d == c_ || d5 && d == c_1;\n"
+    "C_ListNat(c_, d6, d7)  =  d6;\n"
+    "C_ListNat(c_1, d6, d7)  =  d7;\n"
+    "C_ListNat(d, d7, d7)  =  d7;\n"
+    "C_ListNat(c_, d3, d8)  =  d3;\n"
+    "C_ListNat(c_1, d3, d8)  =  d8;\n"
+    "C_ListNat(d, d8, d8)  =  d8;\n"
+    "\n"
+    "act  a: Nat;\n"
+    "\n"
+    "proc P(stack_pp: ListNat, stack_pp1: Nat, stack_pp2: List(Nat)) =\n"
+    "    (stack_pp == c_1) ->\n"
+    "    a(C_ListNat(stack_pp, head([]), stack_pp1)) .\n"
+    "    P(stack_pp = C_ListNat(stack_pp, Det_ListNat(tail([])), Det_ListNat(stack_pp2)), stack_pp1 = C_ListNat(stack_pp, pi_ListNat(tail([])), pi_ListNat(stack_pp2)), stack_pp2 = C_ListNat(stack_pp, pi_ListNat1(tail([])), pi_ListNat1(stack_pp2)));\n"
+    "\n"
+    "init P(c_1, 1, []);\n";
+
+    std::string expected_result =
+      "sort ListNat;\n"
+      "\n"
+      "cons c_,c_1: ListNat;\n"
+      "\n"
+      "map  C_ListNat: ListNat # List(Nat) # List(Nat) -> List(Nat);\n"
+      "Det_ListNat: List(Nat) -> ListNat;\n"
+      "pi_ListNat: List(Nat) -> Nat;\n"
+      "pi_ListNat1: List(Nat) -> List(Nat);\n"
+      "C_ListNat: ListNat # Bool # Bool -> Bool;\n"
+      "C_ListNat: ListNat # ListNat # ListNat -> ListNat;\n"
+      "C_ListNat: ListNat # Nat # Nat -> Nat;\n"
+      "\n"
+      "var  d1,d2: List(Nat);\n"
+      "d,d6,d7: ListNat;\n"
+      "d3,d8: Nat;\n"
+      "d4,d5: Bool;\n"
+      "eqn  C_ListNat(c_, d1, d2)  =  d1;\n"
+      "C_ListNat(c_1, d1, d2)  =  d2;\n"
+      "C_ListNat(d, d2, d2)  =  d2;\n"
+      "Det_ListNat([])  =  c_;\n"
+      "Det_ListNat(d3 |> d1)  =  c_1;\n"
+      "pi_ListNat(d3 |> d1)  =  d3;\n"
+      "pi_ListNat([])  =  0;\n"
+      "pi_ListNat1(d3 |> d1)  =  d1;\n"
+      "pi_ListNat1([])  =  [];\n"
+      "C_ListNat(c_, d4, d5)  =  d4;\n"
+      "C_ListNat(c_1, d4, d5)  =  d5;\n"
+      "C_ListNat(d, d5, d5)  =  d5;\n"
+      "C_ListNat(d, d4, d5)  =  d4 && d == c_ || d5 && d == c_1;\n"
+      "C_ListNat(c_, d6, d7)  =  d6;\n"
+      "C_ListNat(c_1, d6, d7)  =  d7;\n"
+      "C_ListNat(d, d7, d7)  =  d7;\n"
+      "C_ListNat(c_, d3, d8)  =  d3;\n"
+      "C_ListNat(c_1, d3, d8)  =  d8;\n"
+      "C_ListNat(d, d8, d8)  =  d8;\n"
+      "\n"
+      "act  a: Nat;\n"
+      "\n"
+      "proc P(stack_pp: ListNat, stack_pp1: Nat, stack_pp2: List(Nat)) =\n"
+      "    (stack_pp == c_1) ->\n"
+      "    a(stack_pp1) .\n"
+      "    P(stack_pp = Det_ListNat(stack_pp2), stack_pp1 = pi_ListNat(stack_pp2), stack_pp2 = pi_ListNat1(stack_pp2));\n"
+      "\n"
+      "init P(c_1, 1, []);\n";
+
+    test_one_point_condition_rewriter(src, expected_result);
+}
+
+BOOST_AUTO_TEST_CASE(test_main)
+{
+  test_one_point_condition_rule_rewriter();
+  test_parunfold_example();
+}

--- a/libraries/smt/example/run_solver.cpp
+++ b/libraries/smt/example/run_solver.cpp
@@ -19,15 +19,24 @@ int main(int /*argc*/, char** /*argv*/)
 {
   // note that the newline characters are significant
   data::data_specification data_spec = data::parse_data_specification(
-                                   "sort                      \n"
-                                   "  Bit   = struct b0 | b1; \n"
-                                   "                          \n"
-                                   "map                       \n"
-                                   "  invert: Bit -> Bit;     \n"
-                                   "                          \n"
-                                   "eqn                       \n"
-                                   "  invert(b1)= b0;         \n"
-                                   "  invert(b0)= b1;         \n"
+                                   "sort                                                              \n"
+                                   "  Bit   = struct b0 | b1;                                         \n"
+                                   "                                                                  \n"
+                                   "map                                                               \n"
+                                   "  invert: Bit -> Bit;                                             \n"
+                                   "                                                                  \n"
+                                   "eqn                                                               \n"
+                                   "  invert(b1)= b0;                                                 \n"
+                                   "  invert(b0)= b1;                                                 \n"
+                                   "                                                                  \n"
+                                   "map                                                               \n"
+                                   "  insertB: Bool # Nat # List(Bool) -> List(Bool);                 \n"
+                                   "var                                                               \n"
+                                   "  d,d': Bool; i: Nat; q: List(Bool);                              \n"
+                                   "eqn                                                               \n"
+                                   "  i == 0 -> insertB(d,i,q)     = d  |> tail(q);                   \n"
+                                   "  i > 0  -> insertB(d,i,d'|>q) = d' |> insertB(d,Int2Nat(i-1),q); \n"
+                                   "                                                                  \n"
                                  );
   smt::native_translations ntm = smt::initialise_native_translation(data_spec);
 

--- a/libraries/smt/include/mcrl2/smt/unfold_pattern_matching.h
+++ b/libraries/smt/include/mcrl2/smt/unfold_pattern_matching.h
@@ -49,6 +49,21 @@ struct structured_sort_functions
     return data::application(recogniser_func.at(f), expr);
   }
 
+  data::data_expression create_cases(const data::data_expression& target, const data::data_expression_vector& rhss)
+  {
+    std::set<data::function_symbol> constr = get_constructors(target.sort());
+    auto const_it = constr.begin();
+    auto rhs_it = rhss.begin();
+    data::data_expression result = *rhs_it++;
+    for (const_it++; const_it != constr.end(); ++const_it, ++rhs_it)
+    {
+      data::data_expression term = *rhs_it;
+      data::data_expression condition = create_recogniser_expr(*const_it, target);
+      result = data::lazy::if_(condition, term, result);
+    }
+    return result;
+  }
+
   const data::function_symbol_vector& get_projection_funcs(const data::function_symbol& f) const
   {
     return projection_func.at(f);

--- a/tools/release/lpsparunfold/lpsparunfold.cpp
+++ b/tools/release/lpsparunfold/lpsparunfold.cpp
@@ -196,7 +196,7 @@ class lpsparunfold_tool: public  rewriter_tool<input_output_tool>
 
         while (!h_set_index.empty())
         {
-          lps::lpsparunfold lpsparunfold(spec, &unfold_cache, m_add_distribution_laws, m_alt_case_placement);
+          lps::lpsparunfold lpsparunfold(spec, unfold_cache, m_add_distribution_laws, m_alt_case_placement);
           std::size_t index = *(max_element(h_set_index.begin(), h_set_index.end()));
           lpsparunfold.algorithm(index);
           h_set_index.erase(index);

--- a/tools/release/lpsparunfold/lpsparunfold.cpp
+++ b/tools/release/lpsparunfold/lpsparunfold.cpp
@@ -46,6 +46,7 @@ class lpsparunfold_tool: public  rewriter_tool<input_output_tool>
     std::size_t m_repeat_unfold;
     bool m_alt_case_placement;
     bool m_possibly_inconsistent;
+    bool m_disable_pattern_unfolding;
 
     void add_options(interface_description& desc)
     {
@@ -60,6 +61,8 @@ class lpsparunfold_tool: public  rewriter_tool<input_output_tool>
                       "use an alternative placement method for case functions", 'a');
       desc.add_option("possibly-inconsistent",
                       "add rewrite rules that can make a data specification inconsistent", 'p');
+      desc.add_option("no-pattern",
+                      "do not unfold pattern matching functions in state updates", 'x');
     }
 
     void parse_options(const command_line_parser& parser)
@@ -117,6 +120,7 @@ class lpsparunfold_tool: public  rewriter_tool<input_output_tool>
 
       m_alt_case_placement = parser.options.count("alt-case") > 0;
       m_possibly_inconsistent = parser.options.count("possibly-inconsistent") > 0;
+      m_disable_pattern_unfolding = parser.options.count("no-pattern") > 0;
 
     }
 
@@ -192,7 +196,7 @@ class lpsparunfold_tool: public  rewriter_tool<input_output_tool>
 
         while (!h_set_index.empty())
         {
-          lps::lpsparunfold lpsparunfold(spec, unfold_cache, m_alt_case_placement, m_possibly_inconsistent);
+          lps::lpsparunfold lpsparunfold(spec, unfold_cache, m_alt_case_placement, m_possibly_inconsistent, !m_disable_pattern_unfolding);
           std::size_t index = *(max_element(h_set_index.begin(), h_set_index.end()));
           lpsparunfold.algorithm(index);
           // Rewriting intermediate results helps counteract blowup of the intermediate results

--- a/tools/release/lpsparunfold/lpsparunfold.cpp
+++ b/tools/release/lpsparunfold/lpsparunfold.cpp
@@ -148,7 +148,7 @@ class lpsparunfold_tool: public  rewriter_tool<input_output_tool>
       load_lps(spec, input_filename());
 
       /* lpsparunfold-cache is used to avoid the introduction of equations for already unfolded sorts */
-      std::map< mcrl2::data::sort_expression , lspparunfold::unfold_cache_element  >  unfold_cache;
+      std::map< mcrl2::data::sort_expression, lps::unfold_cache_element>  unfold_cache;
 
       for (std::size_t i =0; i != m_repeat_unfold; ++i)
       {
@@ -191,7 +191,7 @@ class lpsparunfold_tool: public  rewriter_tool<input_output_tool>
 
         while (!h_set_index.empty())
         {
-          lpsparunfold lpsparunfold(spec, &unfold_cache, m_add_distribution_laws);
+          lps::lpsparunfold lpsparunfold(spec, &unfold_cache, m_add_distribution_laws);
           std::size_t index = *(max_element(h_set_index.begin(), h_set_index.end()));
           spec = lpsparunfold.algorithm(index);
           h_set_index.erase(index);

--- a/tools/release/lpsparunfold/lpsparunfold.cpp
+++ b/tools/release/lpsparunfold/lpsparunfold.cpp
@@ -198,7 +198,7 @@ class lpsparunfold_tool: public  rewriter_tool<input_output_tool>
         {
           lps::lpsparunfold lpsparunfold(spec, &unfold_cache, m_add_distribution_laws, m_alt_case_placement);
           std::size_t index = *(max_element(h_set_index.begin(), h_set_index.end()));
-          spec = lpsparunfold.algorithm(index);
+          lpsparunfold.algorithm(index);
           h_set_index.erase(index);
         }
       }

--- a/tools/release/lpsparunfold/lpsparunfold.cpp
+++ b/tools/release/lpsparunfold/lpsparunfold.cpp
@@ -45,6 +45,7 @@ class lpsparunfold_tool: public  rewriter_tool<input_output_tool>
     std::string m_unfoldsort;
     std::size_t m_repeat_unfold;
     bool m_add_distribution_laws;
+    bool m_alt_case_placement;
 
     void add_options(interface_description& desc)
     {
@@ -57,6 +58,8 @@ class lpsparunfold_tool: public  rewriter_tool<input_output_tool>
                       "repeat unfold NUM times", 'n');
       desc.add_option("laws",
                       "generates additional distribution laws for projection and determine functions", 'l');
+      desc.add_option("alt-case",
+                      "use an alternative placement method for case functions", 'a');
     }
 
     void parse_options(const command_line_parser& parser)
@@ -117,6 +120,8 @@ class lpsparunfold_tool: public  rewriter_tool<input_output_tool>
       {
         m_add_distribution_laws = true;
       }
+
+      m_alt_case_placement = parser.options.count("alt-case") > 0;
     }
 
   public:
@@ -191,7 +196,7 @@ class lpsparunfold_tool: public  rewriter_tool<input_output_tool>
 
         while (!h_set_index.empty())
         {
-          lps::lpsparunfold lpsparunfold(spec, &unfold_cache, m_add_distribution_laws);
+          lps::lpsparunfold lpsparunfold(spec, &unfold_cache, m_add_distribution_laws, m_alt_case_placement);
           std::size_t index = *(max_element(h_set_index.begin(), h_set_index.end()));
           spec = lpsparunfold.algorithm(index);
           h_set_index.erase(index);

--- a/tools/release/lpsparunfold/lpsparunfold.cpp
+++ b/tools/release/lpsparunfold/lpsparunfold.cpp
@@ -47,6 +47,7 @@ class lpsparunfold_tool: public  rewriter_tool<input_output_tool>
     bool m_add_distribution_laws;
     bool m_alt_case_placement;
     bool m_possibly_inconsistent;
+    bool m_globvars;
 
     void add_options(interface_description& desc)
     {
@@ -63,6 +64,9 @@ class lpsparunfold_tool: public  rewriter_tool<input_output_tool>
                       "use an alternative placement method for case functions", 'a');
       desc.add_option("possibly-inconsistent",
                       "add rewrite rules that can make a data specification inconsistent", 'p');
+      desc.add_option("preserve-global-variables",
+                      "unfold global variables into a list of global variables, instead of applications of determiniser"
+                      " and projection functions to a single global variable", 'g');
     }
 
     void parse_options(const command_line_parser& parser)
@@ -126,6 +130,7 @@ class lpsparunfold_tool: public  rewriter_tool<input_output_tool>
 
       m_alt_case_placement = parser.options.count("alt-case") > 0;
       m_possibly_inconsistent = parser.options.count("possibly-inconsistent") > 0;
+      m_globvars = parser.options.count("preserve-global-variables") > 0;
 
     }
 
@@ -201,7 +206,7 @@ class lpsparunfold_tool: public  rewriter_tool<input_output_tool>
 
         while (!h_set_index.empty())
         {
-          lps::lpsparunfold lpsparunfold(spec, unfold_cache, m_add_distribution_laws, m_alt_case_placement, m_possibly_inconsistent);
+          lps::lpsparunfold lpsparunfold(spec, unfold_cache, m_add_distribution_laws, m_alt_case_placement, m_possibly_inconsistent, m_globvars);
           std::size_t index = *(max_element(h_set_index.begin(), h_set_index.end()));
           lpsparunfold.algorithm(index);
           h_set_index.erase(index);

--- a/tools/release/lpsparunfold/lpsparunfold.cpp
+++ b/tools/release/lpsparunfold/lpsparunfold.cpp
@@ -46,6 +46,7 @@ class lpsparunfold_tool: public  rewriter_tool<input_output_tool>
     std::size_t m_repeat_unfold;
     bool m_add_distribution_laws;
     bool m_alt_case_placement;
+    bool m_possibly_inconsistent;
 
     void add_options(interface_description& desc)
     {
@@ -60,6 +61,8 @@ class lpsparunfold_tool: public  rewriter_tool<input_output_tool>
                       "generates additional distribution laws for projection and determine functions", 'l');
       desc.add_option("alt-case",
                       "use an alternative placement method for case functions", 'a');
+      desc.add_option("possibly-inconsistent",
+                      "add rewrite rules that can make a data specification inconsistent", 'p');
     }
 
     void parse_options(const command_line_parser& parser)
@@ -122,6 +125,8 @@ class lpsparunfold_tool: public  rewriter_tool<input_output_tool>
       }
 
       m_alt_case_placement = parser.options.count("alt-case") > 0;
+      m_possibly_inconsistent = parser.options.count("possibly-inconsistent") > 0;
+
     }
 
   public:
@@ -196,7 +201,7 @@ class lpsparunfold_tool: public  rewriter_tool<input_output_tool>
 
         while (!h_set_index.empty())
         {
-          lps::lpsparunfold lpsparunfold(spec, unfold_cache, m_add_distribution_laws, m_alt_case_placement);
+          lps::lpsparunfold lpsparunfold(spec, unfold_cache, m_add_distribution_laws, m_alt_case_placement, m_possibly_inconsistent);
           std::size_t index = *(max_element(h_set_index.begin(), h_set_index.end()));
           lpsparunfold.algorithm(index);
           h_set_index.erase(index);

--- a/tools/release/lpsparunfold/lpsparunfold.cpp
+++ b/tools/release/lpsparunfold/lpsparunfold.cpp
@@ -44,10 +44,8 @@ class lpsparunfold_tool: public  rewriter_tool<input_output_tool>
     std::set< std::size_t > m_set_index; ///< Options of the algorithm
     std::string m_unfoldsort;
     std::size_t m_repeat_unfold;
-    bool m_add_distribution_laws;
     bool m_alt_case_placement;
     bool m_possibly_inconsistent;
-    bool m_globvars;
 
     void add_options(interface_description& desc)
     {
@@ -58,15 +56,10 @@ class lpsparunfold_tool: public  rewriter_tool<input_output_tool>
                       "unfolds all process parameters of sort NAME", 's');
       desc.add_option("repeat", make_mandatory_argument("NUM"),
                       "repeat unfold NUM times", 'n');
-      desc.add_option("laws",
-                      "generates additional distribution laws for projection and determine functions", 'l');
       desc.add_option("alt-case",
                       "use an alternative placement method for case functions", 'a');
       desc.add_option("possibly-inconsistent",
                       "add rewrite rules that can make a data specification inconsistent", 'p');
-      desc.add_option("preserve-global-variables",
-                      "unfold global variables into a list of global variables, instead of applications of determiniser"
-                      " and projection functions to a single global variable", 'g');
     }
 
     void parse_options(const command_line_parser& parser)
@@ -122,15 +115,8 @@ class lpsparunfold_tool: public  rewriter_tool<input_output_tool>
         m_repeat_unfold = parser.option_argument_as< std::size_t  >("repeat");
       }
 
-      m_add_distribution_laws = false;
-      if (0 < parser.options.count("laws"))
-      {
-        m_add_distribution_laws = true;
-      }
-
       m_alt_case_placement = parser.options.count("alt-case") > 0;
       m_possibly_inconsistent = parser.options.count("possibly-inconsistent") > 0;
-      m_globvars = parser.options.count("preserve-global-variables") > 0;
 
     }
 
@@ -206,9 +192,10 @@ class lpsparunfold_tool: public  rewriter_tool<input_output_tool>
 
         while (!h_set_index.empty())
         {
-          lps::lpsparunfold lpsparunfold(spec, unfold_cache, m_add_distribution_laws, m_alt_case_placement, m_possibly_inconsistent, m_globvars);
+          lps::lpsparunfold lpsparunfold(spec, unfold_cache, m_alt_case_placement, m_possibly_inconsistent);
           std::size_t index = *(max_element(h_set_index.begin(), h_set_index.end()));
           lpsparunfold.algorithm(index);
+          // Rewriting intermediate results helps counteract blowup of the intermediate results
           rewriter R = create_rewriter(spec.data());
           lps::rewrite(spec, R);
           h_set_index.erase(index);

--- a/tools/release/lpsparunfold/lpsparunfold.cpp
+++ b/tools/release/lpsparunfold/lpsparunfold.cpp
@@ -209,6 +209,8 @@ class lpsparunfold_tool: public  rewriter_tool<input_output_tool>
           lps::lpsparunfold lpsparunfold(spec, unfold_cache, m_add_distribution_laws, m_alt_case_placement, m_possibly_inconsistent, m_globvars);
           std::size_t index = *(max_element(h_set_index.begin(), h_set_index.end()));
           lpsparunfold.algorithm(index);
+          rewriter R = create_rewriter(spec.data());
+          lps::rewrite(spec, R);
           h_set_index.erase(index);
         }
       }


### PR DESCRIPTION
In this branch we implement several improvements to lpsparunfold.

- Ability to place case functions at a more outermost scope, aiding rewriting.
- Ability to deal with global (don't care) variables.
- Ability to replace occurrences of functions defined by pattern matching with case-function-based expressions. This also helps rewriting.
- Make the addition of distribution laws standard behaviour.