### PR TITLE
Improved counterexample for branching bisimulation counter examples added in ltscompare

### DIFF
--- a/doc/sphinx/developer_manual/libraries/lts/latex/bisimulation-partitioner-notes.tex
+++ b/doc/sphinx/developer_manual/libraries/lts/latex/bisimulation-partitioner-notes.tex
@@ -1,10 +1,19 @@
 \documentclass{article}
 \usepackage{fullpage}
+\usepackage{tikz}
+\usepackage{ stmaryrd }
+\usepackage{algpseudocode}
+
+\usetikzlibrary{automata, positioning, arrows}
+
 \usepackage{amsfonts}
 \newcommand{\pijl}[1]{\stackrel{#1}{\longrightarrow}}
 \newcommand{\notpijl}[1]{\stackrel{#1}{\not\longrightarrow}}
+\newcommand{\sem}[1]{\llbracket #1 \rrbracket}
+
 \title{Notes on the bisimulation partitioner}
-\author{Jan Friso Groote}
+% Original by Jan Friso, Jan added information on distinguishing formulas.
+\author{Jan Friso Groote and Jan Martens}
 \begin{document}
 \section{Introduction}
 This document describes the algorithm for branching bisimulation reduction,
@@ -32,53 +41,110 @@ partitioned into blocks. Initially, all states are put in one block. Repeatedly,
 a block is split in two blocks until the partitioning has become stable. For
 details see \cite{GV90}.
 
-Furthermore, there is an option to obtain counter traces or counter formulas
-for two non bisimilar state. The algorithm for this is inspired by \cite{C90,K91}.
+Furthermore, there is an option to obtain counter formulas for two non bisimilar
+state. The algorithm for this is inspired by \cite{C90,K91}.
 
 Given two non bisimilar states $s,t\in S$, where $S$ is the set of all states. A
-{\it distinguishing formula} is a formula $\phi$ in Hennessy-Milner logic such that
-$s\models\phi$ and $t\not\models\phi$. A {\it counter trace} is a trace $\sigma a$ such
-that $s\pijl{\sigma}s'\pijl{a}$ for some state $s'$, and $t\pijl{\sigma}t'\notpijl{a}$ for
-some $t'$, or vice versa. For two states there is always a distinghuishing formula iff these states
-are not bisimilar. For counter traces, the situation is not as straightforward.
-There are bisimilar states for which counter traces exist, e.g.\ $a{\cdot}b+a{\cdot}c$
-has counter traces $a\,b$ and $a\,c$ for its initial state. Also, the set of all counter
-traces for non bisimilar states can be the same as the set of counter traces between
-two non bisimilar processes. E.g.\ comparing $a{\cdot}b+a{\cdot}c$ with itself yields
-the same countertraces as comparing it with $a{\cdot}b+a{\cdot}c+a{\cdot}(b+c)$. Yet,
-countertraces might be useful, as they provide some hint as why two states may not
-be bisimilar in situations where Hennessy-Milner formulas cannot be used.
+{\it distinguishing formula} is a formula $\phi$ in Hennessy-Milner logic such
+that $s\models\phi$ and $t\not\models\phi$. For branching bisimulation there is
+always a distinguishing formula in the Hennessy-Milner logic extended with the
+regular $\langle \tau^* \rangle$, and using the regular formula $\langle \tau +
+\mathit{nil} \rangle \phi := \langle\tau\rangle \phi \vee \phi $. 
 
-Following \cite{C90,K91} we extend the algorithm in \cite{GV90} as follows. 
-Each $B$ block that is split is annotated with its parents block $B'$ and 
-with the pair $\langle a,B''\rangle$ that was used to split it. 
+Following \cite{M23, M24} we implement the computation of minimal depth
+distinguishing formulas. In the implementation two things can be noted different
+from the references with the theoretical background.
 
-Given two non-bisimilar states $s$ and $t$ first the smallest block is found
-that contains both $s$ and $t$. Initially, it is known which stable block $s$ and
-$t$ are in. By traversing the parent relation of the blocks, the common block $B_C$ is 
-found (in time proportional to the length of the parent relation, which is bounded
-by the number of blocks, which again is bounded by the number of states). Block
-$B_C$ is split by $\langle a,B''\rangle$
-into a block $B_s$ containing $s$ and a different block $B_t$ containing $t$.
+\paragraph*{Filtering}
+\begin{figure}[b]
+  \begin{center}
+  \begin{tikzpicture}[node distance=2.5cm]
+      % States
+      \node[state]   (s)                      {$s$};
+      \node[state]   (s1)  [below of=s] {$s_1$};
+      \node[state]   (t)  [right= 5cm of s] {$t$};
+      \node[state]   (t1)  [below of=t] {$t_1$};
+      \node[state]   (t2)  [ right of=t1] {$t_2$};
+      % Transitions
+      \path[->]
+        (s)  edge node[left] {$a$} (s1)
+        (t) edge node[left] {$a$} (t1)
+        (t) edge node[right] {$a$} (t2)
+        (s1) edge[loop below] node[below] {$a,b$} (s1)
+        (t2) edge [loop below] node [below] {$a$} (t2);
+  \end{tikzpicture}
+  \end{center}
+  \caption{Two LTSs with initial state $s$ and $t$ respectively.\label{fig:filtering}}
+  \end{figure}
 
-Now construct four sets of states:
-\[\begin{array}{l}
-B^s_{\it reacha}=\{s'|s\pijl{a}s'~{\rm and}~s'\in B''\}\\
-B^s_{\it nonreacha}=\{s'|s\pijl{a}s'~{\rm and}~s'\in B''\}\\
-B^t_{\it reacha}=\{t'|t\pijl{a}t'~{\rm and}~t'\in B''\}\\
-B^t_{\it nonreacha}=\{t'|t\pijl{a}t'~{\rm and}~t'\in B''\}
-\end{array}\]
-As $B''$ was a splitter for $B_C$, exactly one of $B^s_{\it reacha}$ and $B^t_{\it reacha}$ is
-empty, while the other is not empty. Assume without loss of generality that $B^s_{\it reacha}$ is
-not empty. If $B^t_{\it nonreacha}$ is empty, the counter trace is $a$. If $B^t_{\it nonreacha}$
-is not empty construct a set of counter traces $\sigma b$ for each pair of state $\langle u,u'\rangle
-\in B^s_{\it reacha}\times B^t_{\it nonreacha}$. The counter traces
-for $\langle s,t\rangle$ are the traces $a\sigma b$ obtained in this way.
+There is one post-processing step we call backwards filtering. It deals with the
+following scenario. 
+
+Consider the transition systems depicted in Figure~\ref{fig:filtering}. We
+consider the scenario of computing a distinguishing formula $\phi(s,t)$ for the
+states $s$ and $t$. By the partitioning algorithm we know that the transition
+$s\pijl{a}s_1$ is a distinguishing observation. The algorithm has to recursively
+find the distinguishing formula $\phi'$ such that $s_1 \in \sem{\phi'}$ and
+$t_1,t_2 \not\in \sem{\phi'}$. This way $s\in\sem{\langle a\rangle \phi'}$ and
+$t\not\in\sem{\langle a \rangle \phi'}$.
+
+The algorithm starts by recursively computing a distinguishing formula for $s_1$
+and $t_1$. It might compute $\phi(s_1, t_1) = \langle a \rangle \mathrm{true}$.
+Since $t_2 \in \sem{ \langle a \rangle \mathrm{true}}$, it also computes the
+distinguishing formula $\phi(s_1,t_2) = \langle b\rangle \mathrm{true}$. This
+results in the formula $\phi(s,t) = \langle a \rangle (\langle a \rangle
+\mathrm{true} \wedge \langle b \rangle \mathrm{true})$. We see that the addition
+of the conjunct $\phi(s_1, t_2) = \langle b \rangle \mathrm{true}$ made the
+first conjunct $\phi(s_1, t_1)$ obsolete (since $t_1\not\in\sem{\langle b\rangle
+\mathrm{true}}$). This scenario is very hard to prevent a priori.  
+
+To prevent a distinguishing formula with unnecessary conjuncts each conjunct is
+reconsidered in a FIFO style. We compute the semantics of all other conjuncts
+and see if it still achieves the goal. If this is the case, we can safely remove
+that specific conjunct.
+
+\paragraph*{Minimal depth partitioning for branching bisimulation}
+According to~\cite{M24} we compute the partitions conform the correct $k$-depth
+relations. Given the partition $\pi_i$ on level $i$ we want to construct
+$\pi_{i{+}1}$ such that it stable w.r.t. the following signatures.
+
+\[
+  \mathit{sig}(s, \pi_i) := \{(B, a, B') \mid s \pijl{\tau^*} s' \pijl{a} s''
+  , \textrm{where } s'\in B\in \pi_i, s''\in B'\in \pi_i\textrm{ and } (B \neq B' \vee a \neq \tau) \}  
+\]
+
+Performing this partitioning step efficiently is not obvious. We implemented the
+following algorithm. This algorithm only works since we removed strongly
+connected $\tau$ components in the preprocessing, hence there are no $\tau$
+cycles.
+
+\begin{algorithmic}[1]
+  \State $\textit{frontier} := \{s \mid s\notpijl{\tau}\}$\;
+  \State $\textit{done} := \emptyset$\;
+  \While{$\textit{frontier} \neq \emptyset$}
+  \State $s := \textit{frontier.pop\_front}()$\;
+  \State $\textit{signature} := \{(B, a, B') \mid s\pijl{a} s' \textrm{ s.t. } s\in B, s'\in B',\textrm{ and }  B, B'\in \pi_i \textrm{ and } (a \neq \tau \vee B \neq B')\}$\;
+  \ForAll{$s\pijl{\tau} s'$}
+    \State $\textit{signature} := \textit{signature} \cup sigs[s']$\;
+  \EndFor 
+  \State $\textit{sigs}[s] := signature$\;
+  \State $\textit{done} := \textit{done} \cup \{s\}$\:
+  \ForAll{$s_p \pijl{\tau} s$} 
+    \If{$\{s' \mid s_p \pijl{\tau} s'\} \setminus \textit{done} = \emptyset$}
+      \State $\textit{frontier.push\_back}(s_p)$\;
+    \EndIf
+  \EndFor
+  
+
+  \EndWhile
+\end{algorithmic}  
+
+
 
 \begin{thebibliography}{10}
 \bibitem{C90}
 R.~Cleaveland. On automatically explaining bisimulation inequivalence.
-In E.M.~Clarke and R.P.~Kurshan, editiors, {\it Computer Aided Verification (CAV'90)}, volume
+In E.M.~Clarke and R.P.~Kurshan, editors, {\it Computer Aided Verification (CAV'90)}, volume
 531 of {\it Lecture Notes in Computer Science}, Springer-Verlag, pages 364--372, 1990.
 
 \bibitem{GV90}
@@ -90,6 +156,15 @@ pages 626-638. Springer-Verlag, 1990.
 H.~Korver. Computing distinguishing formulas for branching bisimulation.
 In K.G.~Larsen and A.~Skou, editors, {\it Computer Aided Verification (CAV'91)}, volume 575 of
 {\it Lecture Notes in Computer Science}, Springer-Verlag, pages 13--23, 1991.
+
+\bibitem{M23}
+J.J.M.~Martens and J.F.~Groote. Computing Minimal Distinguishing Hennessy-Milner Formulas is NP-Hard, but Variants are Tractable.
+In G.-A.~P'erez and J.-F. Raskin, editors, {\it CONCUR '23}, Volume 279 of
+{\it LIPIcs}, Schloss Dagstuhl –- Leibniz-Zentrum für Informatik, pages 32:1--32:17, 2023.
+
+\bibitem {M24}
+J.J.M.~Martens and J.F.~Groote. Minimal Depth Distinguishing Formulas without Until for Branching Bisimulation. 
+to appear in LNCS 2024
 
 \end{thebibliography}
 \end{document}

--- a/doc/sphinx/home/publications.rst
+++ b/doc/sphinx/home/publications.rst
@@ -30,6 +30,7 @@ Research
 --------
 
 .. [SKN23] A\. Stramaglia, J.J.A. Keiren, T. Neele. Simplifying Process Parameters by Unfolding Algebraic Data Types. ICTAC 2023. LNCS vol. 14446, pp. 399-416. `(DOI) <https://doi.org/10.1007/978-3-031-47963-2_24>`__
+.. [MG23] J.J.M. Martens and J.F. Groote. Computing Minimal Distinguishing Hennessy-Milner Formulas is NP-Hard, but Variants are Tractable. CONCUR 2023, LIPIcs vol. 279. `(DOI) <https://doi.org/10.4230/LIPIcs.CONCUR.2023.32>`__
 .. [JGKW20] D.N. Jansen, J.F. Groote, J.J.A. Keiren, A. Wijs. An O(m log n) algorithm for branching bisimilarity on labelled transition systems. TACAS 2020, LNCS vol. 12079, pp. 3-20. `(DOI) <https://doi.org/10.1007/978-3-030-45237-7_1>`__
 .. [NWW20] T\. Neele, W. Wesselink, T.A.C. Willemse. Partial-Order Reduction for Parity Games with an Application on Parameterised Boolean Equation Systems. TACAS 2020, LNCS vol. 12079, pp. 307-324. `(DOI) <https://doi.org/10.1007/978-3-030-45237-7_19>`__
 .. [NWG20] T\. Neele, T.A.C. Willemse and J.F. Groote. Finding compact proofs for infinite-data parameterised Boolean equation systems. Science of Computer Programming (FACS 2018 special issue), vol. 188, pp. 102389. `(DOI) <https://doi.org/10.1016/j.scico.2019.102389>`__

--- a/doc/sphinx/user_manual/tools/release/ltscompare.rst
+++ b/doc/sphinx/user_manual/tools/release/ltscompare.rst
@@ -21,4 +21,5 @@ equivalence options.
 
 The second useful option is to hide some actions while doing the comparisons
 (option ``--tau=`` followed by a comma separated list of actions). Counter examples
-are provided without applying hiding.
+will only be distinguishing for the input transition systems with the hiding operation
+applied.

--- a/doc/sphinx/user_manual/tools/release/ltscompare.rst
+++ b/doc/sphinx/user_manual/tools/release/ltscompare.rst
@@ -13,11 +13,11 @@ The transition systems can either be compared using an equivalence relation
 (option ``--equivalence``) or a preorder (option ``--preorder``). The list of
 available equivalences is provided below.
 
-There are two useful options. One allows to generate counter examples in the form
-of a trace (option ``--counter-example``). These counter examples are useful for
-trace based equivalences. They can also be generated for some variants of bisimulation,
-but in this case they can also point to states where the two transition systems are
-nondeterministic.
+There are two useful options. One allows to generate counter examples (option
+``--counter-example``). The counter example consist of a Hennessy-Milner formula
+which is true in the first input LTS and false in the second. Counter-examples
+are implemented and tested for the `bisim`, `branching-bisim` and `trace`
+equivalence options. 
 
 The second useful option is to hide some actions while doing the comparisons
 (option ``--tau=`` followed by a comma separated list of actions). Counter examples

--- a/libraries/lts/include/mcrl2/lts/detail/liblts_bisim_minimal_depth.h
+++ b/libraries/lts/include/mcrl2/lts/detail/liblts_bisim_minimal_depth.h
@@ -629,8 +629,7 @@ template < class LTS_TYPE>
 bool destructive_bisimulation_compare_minimal_depth(
     LTS_TYPE & l1,
     LTS_TYPE & l2,
-    const std::string & counter_example_file /*= ""*/,
-    const bool /*structured_output = false */)
+    const std::string & counter_example_file)
 {
     std::size_t init_l2 = l2.initial_state() + l1.num_states();
     mcrl2::lts::detail::merge(l1, l2);
@@ -640,6 +639,7 @@ bool destructive_bisimulation_compare_minimal_depth(
     {
         return true; 
     }
+    
     // LTSs are not bisimilar, we can create a counter example. 
     std::string filename = "Counterexample.mcf";
     if (!counter_example_file.empty()) {

--- a/libraries/lts/include/mcrl2/lts/detail/liblts_bisim_minimal_depth.h
+++ b/libraries/lts/include/mcrl2/lts/detail/liblts_bisim_minimal_depth.h
@@ -624,6 +624,38 @@ private:
     return regular_formulas::regular_formula(action_formulas::multi_action(a.actions()));
   }
 };
+
+template < class LTS_TYPE>
+bool destructive_bisimulation_compare_minimal_depth(
+    LTS_TYPE & l1,
+    LTS_TYPE & l2,
+    const std::string & counter_example_file /*= ""*/,
+    const bool /*structured_output = false */)
+{
+    std::size_t init_l2 = l2.initial_state() + l1.num_states();
+    mcrl2::lts::detail::merge(l1, l2);
+    l2.clear(); // No use for l2 anymore.
+    detail::bisim_partitioner_minimal_depth<LTS_TYPE> bisim_partitioner_minimal_depth(l1, init_l2);
+    if (bisim_partitioner_minimal_depth.in_same_class(l1.initial_state(), init_l2))
+    {
+        return true; 
+    }
+    // LTSs are not bisimilar, we can create a counter example. 
+    std::string filename = "Counterexample.mcf";
+    if (!counter_example_file.empty()) {
+        filename = counter_example_file;
+    }
+
+    mcrl2::state_formulas::state_formula counter_example_formula = bisim_partitioner_minimal_depth.dist_formula_mindepth(l1.initial_state(), init_l2);
+    
+    std::ofstream counter_file(filename);
+    counter_file << mcrl2::state_formulas::pp(counter_example_formula);
+    counter_file.close();
+    mCRL2log(mcrl2::log::info) << "Saved counterexample to: \"" << filename << "\"" << std::endl;
+    return false;
+}
+
+
 } // namespace detail
 } // namespace lts
 } // namespace mcrl2

--- a/libraries/lts/include/mcrl2/lts/detail/liblts_branching_bisim_minimal_depth.h
+++ b/libraries/lts/include/mcrl2/lts/detail/liblts_branching_bisim_minimal_depth.h
@@ -81,7 +81,7 @@ public:
     std::size_t num_blocks_created = 1;
     std::size_t level = 0;
 
-    while (num_blocks_created > num_old_blocks && in_same_class(m_lts.initial_state(), initial_l2))
+    while (num_blocks_created > num_old_blocks && in_same_class(m_lts.initial_state(), initial_l2)) 
     {
       level += 1;
       num_old_blocks = num_blocks_created;
@@ -625,25 +625,19 @@ bool destructive_branching_bisimulation_compare_minimal_depth(LTS_TYPE& l1,
   scc_part.replace_transition_system(preserve_divergences);
 
   // Run a faster branching bisimulation algorithm as preprocessing, no preversing of loops.
-  if (false)
-  {
-    detail::bisim_partitioner_dnj branching_bisim_part(l1, true, preserve_divergences);
-    init_l2 = branching_bisim_part.get_eq_class(init_l2);
-    branching_bisim_part.finalize_minimized_LTS();
-    if (branching_bisim_part.in_same_class(l1.initial_state(), init_l2))
-    {
-      return true;
-    }
-  }
-
-  // Log that we continue to the slower partition refinement.
-
-  branching_bisim_partitioner_minimal_depth<LTS_TYPE> branching_bisim_min(l1, init_l2);
-
-  if (branching_bisim_min.in_same_class(l1.initial_state(), init_l2))
+  detail::bisim_partitioner_dnj branching_bisim_part(l1, true, preserve_divergences);
+  init_l2 = branching_bisim_part.get_eq_class(init_l2);
+  branching_bisim_part.finalize_minimized_LTS();
+  if (branching_bisim_part.in_same_class(l1.initial_state(), init_l2))
   {
     return true;
   }
+
+  //Start the new debugging to get minimal depth splitting information.  
+  branching_bisim_partitioner_minimal_depth<LTS_TYPE> branching_bisim_min(l1, init_l2);
+
+  //Min-depth partitioner should agree with dnj.  
+  assert(!branching_bisim_min.in_same_class(l1.initial_state(), init_l2));
 
   // LTSs are not bisimilar, we can create a counter example.
   std::string filename = "Counterexample.mcf";

--- a/libraries/lts/include/mcrl2/lts/detail/liblts_branching_bisim_minimal_depth.h
+++ b/libraries/lts/include/mcrl2/lts/detail/liblts_branching_bisim_minimal_depth.h
@@ -42,8 +42,8 @@ public:
    *  \param init_l2 reference to the initial state of lts2.
    */
   branching_bisim_partitioner_minimal_depth(LTS_TYPE& l, const std::size_t init_l2)
-      : initial_l2(init_l2),
-        m_lts(l)
+      : m_lts(l),
+        initial_l2(init_l2)
   {
     // Initialize data structures
     std::map<state_type, std::size_t> state2num_silent_in;
@@ -200,6 +200,20 @@ private:
       std::swap(b.parent_block_index, parent_block_index);
       std::swap(b.level, level);
     }
+
+    bool operator==(const block& other) 
+    {
+      return state_index == other.state_index 
+        && block_index == other.block_index 
+        && parent_block_index == other.parent_block_index 
+        && level == other.level 
+        && sig == other.sig;
+    }
+
+    bool operator!=(const block& other)
+    {
+      return !(*this == other);
+    }
   };
   std::vector<block> blocks;
 
@@ -241,6 +255,8 @@ private:
     // Compute signatures in order of bottom states and reachability order.
     // Debug info for frontier
     int num_added_to_frontier = 0;
+
+    mcrl2::utilities::mcrl2_unused(num_added_to_frontier);
     while (!frontier.empty())
     {
       state_type state = frontier.front();

--- a/libraries/lts/include/mcrl2/lts/detail/liblts_branching_bisim_minimal_depth.h
+++ b/libraries/lts/include/mcrl2/lts/detail/liblts_branching_bisim_minimal_depth.h
@@ -37,15 +37,79 @@ public:
   /** \brief Creates a branching bisimulation partitioner for an LTS.
    *  \details This partitioner is specifically for creating minimal depth counter-examples for branching bisimulation.
    *           It guarantees stability w.r.t. the old partition before considering new splitter blocks. This might cause
-   *           this implementation to be less efficient than other partitioners. 
-   *  \param l Reference to the LTS. 
-   *  \param init_l2 reference to the initial state of lts2. 
+   *           this implementation to be less efficient than other partitioners.
+   *  \param l Reference to the LTS.
+   *  \param init_l2 reference to the initial state of lts2.
    */
-  branching_bisim_partitioner_minimal_depth(LTS_TYPE &l, const std::size_t init_l2)
+  branching_bisim_partitioner_minimal_depth(LTS_TYPE& l, const std::size_t init_l2)
       : initial_l2(init_l2),
-	      m_lts(l)
-  {}
-  
+        m_lts(l)
+  {
+    // Initialize data structures
+    std::map<state_type, std::size_t> state2num_silent_in;
+    std::map<state_type, std::size_t> state2num_silent_out;
+    std::map<state_type, std::size_t> state2num_trans_out;
+
+    for (state_type s = 0; s < m_lts.num_states(); s++)
+    {
+      state2block[s] = 0;
+      state2num_touched[s] = 0;
+      state2num_silent_in[s] = 0;
+      state2num_silent_out[s] = 0;
+      state2num_trans_out[s] = 0;
+    }
+
+    for (transition trans : m_lts.get_transitions())
+    {
+      state2num_trans_out[trans.from()] += 1;
+      if (m_lts.is_tau(m_lts.apply_hidden_label_map(trans.label())))
+      {
+        state2num_silent_in[trans.to()] += 1;
+        state2num_silent_out[trans.from()] += 1;
+      }
+    }
+    for (state_type s = 0; s < m_lts.num_states(); s++)
+    {
+      if (state2num_silent_out[s] == 0)
+      {
+        bottom_states.push_back(s);
+      }
+      trans_out[s] = std::vector<observation>(state2num_trans_out[s]);
+      silent_out[s] = std::set<state_type>();
+      silent_in[s] = std::set<state_type>();
+    }
+
+    for (transition trans : m_lts.get_transitions())
+    {
+      trans_out[trans.from()].push_back(std::make_pair(trans.label(), trans.to()));
+      if (m_lts.is_tau(m_lts.apply_hidden_label_map(trans.label())))
+      {
+        silent_out[trans.from()].insert(trans.to());
+        silent_in[trans.to()].insert(trans.from());
+      }
+    }
+
+    // Initialize the partition with a single block.
+    blocks.push_back(block());
+    blocks[0].state_index = 0;
+    blocks[0].block_index = 0;
+    blocks[0].parent_block_index = 0;
+    blocks[0].level = 0;
+
+    // Now we can start refining the partition.
+    std::size_t num_old_blocks = 0;
+    std::size_t num_blocks_created = 1;
+    std::size_t level = 0;
+    while (num_blocks_created > num_old_blocks)
+    {
+      level += 1;
+      num_old_blocks = num_blocks_created;
+      num_blocks_created = refine_partition();
+      mCRL2log(mcrl2::log::info) << "Refined partition to " << num_blocks_created << " blocks on level " << level
+                                 << "." << std::endl;
+    }
+  }
+
   /** \brief Creates a state formula that distinguishes state s from state t.
    *  \details The states s and t are non branching bisimilar states. A distinguishign state formula phi is
    *           returned, which has the property that s \in \sem{phi} and  t \not\in\sem{phi}.
@@ -59,54 +123,174 @@ public:
   {
     mCRL2log(mcrl2::log::info) << "done with formula \n";
     return mcrl2::state_formulas::state_formula();
-  };
+  }
+
+  bool in_same_class(const std::size_t s, const std::size_t t)
+  {
+	return state2block[s] == state2block[t];
+  }
 
 
-private:  
+private:
   LTS_TYPE& m_lts;
   state_type initial_l2;
   state_type max_state_index = 0;
+  typedef std::size_t block_index_type;
+  typedef std::size_t level_type;
+  // This tuple is meant for an observation (s', a, s'') such that s -(silent)-> s' -a-> s''.
+  typedef std::tuple<block_index_type, label_type, block_index_type> branching_observation_type;
+  typedef std::set<branching_observation_type> signature_type;
+  typedef std::pair<label_type, state_type> observation;
+
+  std::map<state_type, std::set<state_type>> silent_in;
+  std::map<state_type, std::set<state_type>> silent_out;
+  std::map<state_type, std::vector<observation>> trans_out;
+  std::map<state_type, std::size_t> state2num_touched;
+  std::map<state_type, block_index_type> state2block;
+  std::map<state_type, signature_type> state2sig;
+  std::vector<state_type> bottom_states;
+  struct block
+  {
+    state_type state_index;       // The state number that represent the states in this block
+    block_index_type block_index; // The sequence number of this block.
+    block_index_type
+        parent_block_index; // Index of the parent block. If there is no parent block, this refers to the block itself.
+    level_type level;       // The level of the block in the partition.
+
+    void swap(block& b)
+    {
+      std::swap(b.state_index, state_index);
+      std::swap(b.block_index, block_index);
+      std::swap(b.parent_block_index, parent_block_index);
+      std::swap(b.level, level);
+    }
+  };
+  std::vector<block> blocks;
+  
+  signature_type get_signature(state_type s)
+  {
+	signature_type sig;
+    // Add the block index of the state to the signature.
+    sig.insert(std::make_tuple(state2block[s], m_lts.tau_label_index(), state2block[s]));
+
+    for (state_type target : silent_out[s])
+	{
+      sig.insert(state2sig[target].begin(), state2sig[target].end());
+	}
+    for (observation t : trans_out[s])
+	{
+      if (t.first != m_lts.tau_label_index() || state2block[s] != state2block[t.second])
+      {
+        sig.insert(std::make_tuple(state2block[s], t.first, state2block[t.second]));
+      }
+	}
+	state2sig[s] = sig;
+	return sig;
+  }
+
+  // Refine the partition exactly one level.
+  std::size_t refine_partition()
+  {
+    std::queue<state_type> frontier;
+    // start with bottom states.  
+    for (auto s : bottom_states)
+    {
+	  frontier.push(s);
+    }
+    std::map<signature_type, block_index_type> sig2block;
+    std::map<state_type, block_index_type> state2block_new;
+    std::size_t num_blocks_created = 0;
+    //Compute signatures in order of bottom states and reachability order.
+    //Debug info for frontier
+    int num_added_to_frontier = 0;
+    while (!frontier.empty())
+    {
+      state_type state = frontier.front();
+      frontier.pop();
+      signature_type sig = get_signature(state);
+      if (sig2block.find(sig) == sig2block.end())
+	  {
+        // Create the new block
+        blocks.push_back(block());
+        num_blocks_created += 1;
+        block_index_type new_block_id = blocks.size() -1;    
+        sig2block[sig] = new_block_id;
+        blocks[new_block_id].state_index = state;
+        blocks[new_block_id].block_index = new_block_id;
+        blocks[new_block_id].parent_block_index = state2block[state];
+        blocks[new_block_id].level = blocks[state2block[state]].level + 1;
+	  }
+      state2block_new[state] = sig2block[sig];
+      state2num_touched[state] = 0;
+
+      for (state_type backward : silent_in[state])
+      {
+        size_t max_out = silent_out[backward].size(); 
+        state2num_touched[backward] += 1;
+        if (state2num_touched[backward] == max_out) {
+          num_added_to_frontier += 1;
+          frontier.push(backward);
+        }
+      }
+    }
+    mCRL2log(mcrl2::log::info) << "Added " << num_added_to_frontier << " states to the frontier." << std::endl;
+    // Now we have computed the new blocks, we can redefine the partition.
+    state2block = state2block_new;
+    return num_blocks_created; 
+  }
 };
 
-template < class LTS_TYPE>
-bool destructive_branching_bisimulation_compare_minimal_depth(
-    LTS_TYPE & l1,
-    LTS_TYPE & l2,
-    const std::string & counter_example_file /*= ""*/,
+template <class LTS_TYPE>
+bool destructive_branching_bisimulation_compare_minimal_depth(LTS_TYPE& l1,
+    LTS_TYPE& l2,
+    const std::string& counter_example_file /*= ""*/,
     const bool /*structured_output = false */)
 {
   std::size_t init_l2 = l2.initial_state() + l1.num_states();
   mcrl2::lts::detail::merge(l1, l2);
   l2.clear(); // No use for l2 anymore.
-      
+
   // First remove tau loops in case of branching bisimulation
   bool preserve_divergences = false;
   detail::scc_partitioner<LTS_TYPE> scc_part(l1);
   scc_part.replace_transition_system(preserve_divergences);
   init_l2 = scc_part.get_eq_class(init_l2);
-  
+
   // Run a faster branching bisimulation algorithm as preprocessing, no preversing of loops.
-  detail::bisim_partitioner_dnj<LTS_TYPE> branching_bisim_part(l1, true, preserve_divergences, false);
-  if (branching_bisim_part.in_same_class(l1.initial_state(), init_l2))
+  if (false)
   {
-      return true; 
+    detail::bisim_partitioner_dnj branching_bisim_part(l1, true, preserve_divergences);
+    init_l2 = branching_bisim_part.get_eq_class(init_l2);
+    branching_bisim_part.finalize_minimized_LTS();
+    if (branching_bisim_part.in_same_class(l1.initial_state(), init_l2))
+    {
+      return true;
+    }
+    init_l2 = branching_bisim_part.get_eq_class(init_l2);
   }
-  
-  
+
+  // Log that we continue to the slower partition refinement.
+  mCRL2log(mcrl2::log::info) << "Starting minimal depth partition refinement." << std::endl;
+
   branching_bisim_partitioner_minimal_depth<LTS_TYPE> branching_bisim_min(l1, init_l2);
+
   if (branching_bisim_min.in_same_class(l1.initial_state(), init_l2))
   {
-      return true; 
+    assert(false);
+    // This should should not have happened.
+    return true;
   }
 
-  // LTSs are not bisimilar, we can create a counter example. 
+  // LTSs are not bisimilar, we can create a counter example.
   std::string filename = "Counterexample.mcf";
-  if (!counter_example_file.empty()) {
-      filename = counter_example_file;
+  if (!counter_example_file.empty())
+  {
+    filename = counter_example_file;
   }
 
-  mcrl2::state_formulas::state_formula counter_example_formula = branching_bisim_min.dist_formula_mindepth(l1.initial_state(), init_l2);
-    
+  mcrl2::state_formulas::state_formula counter_example_formula
+      = branching_bisim_min.dist_formula_mindepth(l1.initial_state(), init_l2);
+
   std::ofstream counter_file(filename);
   counter_file << mcrl2::state_formulas::pp(counter_example_formula);
   mCRL2log(mcrl2::log::info) << "Saved counterexample to: \"" << filename << "\"" << std::endl;
@@ -114,5 +298,4 @@ bool destructive_branching_bisimulation_compare_minimal_depth(
 }
 
 } // namespace mcrl2::lts::detail
-
 #endif // MCRl2_LTS_LIBLTS_BRANCHING_BISIM_MINIMAL_DEPTH

--- a/libraries/lts/include/mcrl2/lts/detail/liblts_branching_bisim_minimal_depth.h
+++ b/libraries/lts/include/mcrl2/lts/detail/liblts_branching_bisim_minimal_depth.h
@@ -176,11 +176,7 @@ private:
 
     bool operator==(const block& other) 
     {
-      return state_index == other.state_index 
-        && block_index == other.block_index 
-        && parent_block_index == other.parent_block_index 
-        && level == other.level 
-        && sig == other.sig;
+      return block_index == other.block_index;
     }
 
     bool operator!=(const block& other)

--- a/libraries/lts/include/mcrl2/lts/detail/liblts_branching_bisim_minimal_depth.h
+++ b/libraries/lts/include/mcrl2/lts/detail/liblts_branching_bisim_minimal_depth.h
@@ -1,0 +1,118 @@
+// Author(s): Jan Martens and Maurice Laveaux
+//
+// Copyright: see the accompanying file COPYING or copy at
+// https://github.com/mCRL2org/mCRL2/blob/master/COPYING
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+/// \file lts/detail/liblts_bisim_m.h
+///
+/// \brief Partition refinement algorithm for guaruanteed minimal depth
+/// counter-examples.
+///
+/// \details
+#ifndef MCRl2_LTS_LIBLTS_BRANCHING_BISIM_MINIMAL_DEPTH
+#define MCRl2_LTS_LIBLTS_BRANCHING_BISIM_MINIMAL_DEPTH
+
+
+#include "mcrl2/lts/detail/liblts_merge.h"
+#include "mcrl2/lts/detail/liblts_scc.h"
+#include "mcrl2/lts/detail/liblts_bisim_dnj.h"
+#include "mcrl2/lts/lts_aut.h"
+#include "mcrl2/lts/lts_dot.h"
+#include "mcrl2/lts/lts_fsm.h"
+#include "mcrl2/lts/lts_utilities.h"
+#include "mcrl2/modal_formula/state_formula.h"
+
+#include <fstream>
+
+namespace mcrl2::lts::detail
+{
+
+template <class LTS_TYPE>
+class branching_bisim_partitioner_minimal_depth
+{
+public:
+  /** \brief Creates a branching bisimulation partitioner for an LTS.
+   *  \details This partitioner is specifically for creating minimal depth counter-examples for branching bisimulation.
+   *           It guarantees stability w.r.t. the old partition before considering new splitter blocks. This might cause
+   *           this implementation to be less efficient than other partitioners. 
+   *  \param l Reference to the LTS. 
+   *  \param init_l2 reference to the initial state of lts2. 
+   */
+  branching_bisim_partitioner_minimal_depth(LTS_TYPE &l, const std::size_t init_l2)
+      : initial_l2(init_l2),
+	      m_lts(l)
+  {}
+  
+  /** \brief Creates a state formula that distinguishes state s from state t.
+   *  \details The states s and t are non branching bisimilar states. A distinguishign state formula phi is
+   *           returned, which has the property that s \in \sem{phi} and  t \not\in\sem{phi}.
+   *           Based on the preprint "Computing minimal distinguishing Hennessey-Milner formulas is NP-hard
+   *           But variants are tractable", 2023 by Jan Martens and Jan Friso Groote.
+   *  \param[in] s The state number for which the resulting formula should be true
+   *  \param[in] t The state number for which the resulting formula should be false
+   *  \return A minimal observation depth distinguishing state formula, that is often also minimum negation-depth and
+   * irreducible. */
+  mcrl2::state_formulas::state_formula dist_formula_mindepth(const std::size_t s, const std::size_t t)
+  {
+    mCRL2log(mcrl2::log::info) << "done with formula \n";
+    return mcrl2::state_formulas::state_formula();
+  };
+
+
+private:  
+  LTS_TYPE& m_lts;
+  state_type initial_l2;
+  state_type max_state_index = 0;
+};
+
+template < class LTS_TYPE>
+bool destructive_branching_bisimulation_compare_minimal_depth(
+    LTS_TYPE & l1,
+    LTS_TYPE & l2,
+    const std::string & counter_example_file /*= ""*/,
+    const bool /*structured_output = false */)
+{
+  std::size_t init_l2 = l2.initial_state() + l1.num_states();
+  mcrl2::lts::detail::merge(l1, l2);
+  l2.clear(); // No use for l2 anymore.
+      
+  // First remove tau loops in case of branching bisimulation
+  bool preserve_divergences = false;
+  detail::scc_partitioner<LTS_TYPE> scc_part(l1);
+  scc_part.replace_transition_system(preserve_divergences);
+  init_l2 = scc_part.get_eq_class(init_l2);
+  
+  // Run a faster branching bisimulation algorithm as preprocessing, no preversing of loops.
+  detail::bisim_partitioner_dnj<LTS_TYPE> branching_bisim_part(l1, true, preserve_divergences, false);
+  if (branching_bisim_part.in_same_class(l1.initial_state(), init_l2))
+  {
+      return true; 
+  }
+  
+  
+  branching_bisim_partitioner_minimal_depth<LTS_TYPE> branching_bisim_min(l1, init_l2);
+  if (branching_bisim_min.in_same_class(l1.initial_state(), init_l2))
+  {
+      return true; 
+  }
+
+  // LTSs are not bisimilar, we can create a counter example. 
+  std::string filename = "Counterexample.mcf";
+  if (!counter_example_file.empty()) {
+      filename = counter_example_file;
+  }
+
+  mcrl2::state_formulas::state_formula counter_example_formula = branching_bisim_min.dist_formula_mindepth(l1.initial_state(), init_l2);
+    
+  std::ofstream counter_file(filename);
+  counter_file << mcrl2::state_formulas::pp(counter_example_formula);
+  mCRL2log(mcrl2::log::info) << "Saved counterexample to: \"" << filename << "\"" << std::endl;
+  return false;
+}
+
+} // namespace mcrl2::lts::detail
+
+#endif // MCRl2_LTS_LIBLTS_BRANCHING_BISIM_MINIMAL_DEPTH

--- a/libraries/lts/include/mcrl2/lts/detail/liblts_branching_bisim_minimal_depth.h
+++ b/libraries/lts/include/mcrl2/lts/detail/liblts_branching_bisim_minimal_depth.h
@@ -508,8 +508,7 @@ private:
 template <class LTS_TYPE>
 bool destructive_branching_bisimulation_compare_minimal_depth(LTS_TYPE& l1,
     LTS_TYPE& l2,
-    const std::string& counter_example_file /*= ""*/,
-    const bool /*structured_output = false */)
+    const std::string& counter_example_file)
 {
   std::size_t init_l2 = l2.initial_state() + l1.num_states();
   mcrl2::lts::detail::merge(l1, l2);

--- a/libraries/lts/include/mcrl2/lts/detail/liblts_branching_bisim_minimal_depth.h
+++ b/libraries/lts/include/mcrl2/lts/detail/liblts_branching_bisim_minimal_depth.h
@@ -642,8 +642,6 @@ bool destructive_branching_bisimulation_compare_minimal_depth(LTS_TYPE& l1,
 
   if (branching_bisim_min.in_same_class(l1.initial_state(), init_l2))
   {
-    assert(false);
-    // This should should not have happened.
     return true;
   }
 

--- a/libraries/lts/include/mcrl2/lts/lts_algorithm.h
+++ b/libraries/lts/include/mcrl2/lts/lts_algorithm.h
@@ -98,7 +98,7 @@ bool destructive_compare(LTS_TYPE& l1,
     {
       if (generate_counter_examples)
       {
-        mCRL2log(mcrl2::log::warning) << "The default branching bisimulation comparison algorithm cannot generate counter examples. Therefore the slower gv algorithm is used instead.\n";
+        mCRL2log(mcrl2::log::warning) << "The default branching bisimulation comparison algorithm cannot generate counter examples. A slower partition refinement algorithm (Martens/Groote 2024) is used instead.\n";
         return detail::destructive_branching_bisimulation_compare_minimal_depth(l1, l2, counter_example_file);
       }
       return detail::destructive_bisimulation_compare_dnj(l1,l2, true,false,generate_counter_examples,counter_example_file,structured_output);

--- a/libraries/lts/include/mcrl2/lts/lts_algorithm.h
+++ b/libraries/lts/include/mcrl2/lts/lts_algorithm.h
@@ -82,7 +82,7 @@ bool destructive_compare(LTS_TYPE& l1,
       if (generate_counter_examples)
       {
         mCRL2log(mcrl2::log::warning) << "A slower partition refinement algorithm is used to generate minimal-depth counter examples.\n";
-        return detail::destructive_bisimulation_compare_minimal_depth(l1, l2, counter_example_file, structured_output);
+        return detail::destructive_bisimulation_compare_minimal_depth(l1, l2, counter_example_file);
       }
       return detail::destructive_bisimulation_compare_dnj(l1,l2, false,false,generate_counter_examples,counter_example_file,structured_output);
     }
@@ -99,7 +99,7 @@ bool destructive_compare(LTS_TYPE& l1,
       if (generate_counter_examples)
       {
         mCRL2log(mcrl2::log::warning) << "The default branching bisimulation comparison algorithm cannot generate counter examples. Therefore the slower gv algorithm is used instead.\n";
-        return detail::destructive_branching_bisimulation_compare_minimal_depth(l1, l2, counter_example_file, structured_output);
+        return detail::destructive_branching_bisimulation_compare_minimal_depth(l1, l2, counter_example_file);
       }
       return detail::destructive_bisimulation_compare_dnj(l1,l2, true,false,generate_counter_examples,counter_example_file,structured_output);
     }
@@ -177,19 +177,19 @@ bool destructive_compare(LTS_TYPE& l1,
     case lts_eq_trace:
     {
       // Determinise first LTS
-      detail::bisimulation_reduce_dnj(l1,false);
+      detail::bisimulation_reduce_dnj(l1, false);
       determinise(l1);
 
       // Determinise second LTS
-      detail::bisimulation_reduce_dnj(l2,false);
+      detail::bisimulation_reduce_dnj(l2, false);
       determinise(l2);
 
       // Trace equivalence now corresponds to bisimilarity
       if (generate_counter_examples) 
       {
-        return detail::destructive_bisimulation_compare_minimal_depth(l1, l2, counter_example_file, structured_output);
+        return detail::destructive_bisimulation_compare_minimal_depth(l1, l2, counter_example_file);
       }
-      return detail::destructive_bisimulation_compare(l1,l2,false,false,generate_counter_examples,counter_example_file,structured_output);
+      return detail::destructive_bisimulation_compare(l1, l2, false, false, generate_counter_examples, counter_example_file, structured_output);
     }
     case lts_eq_weak_trace:
     {

--- a/libraries/lts/include/mcrl2/lts/lts_algorithm.h
+++ b/libraries/lts/include/mcrl2/lts/lts_algorithm.h
@@ -20,7 +20,9 @@
 #define MCRL2_LTS_LTS_ALGORITHM_H
 
 #include "mcrl2/lts/detail/liblts_bisim.h"
+#include "mcrl2/lts/detail/liblts_bisim_minimal_depth.h"
 #include "mcrl2/lts/detail/liblts_bisim_gjkw.h"
+#include "mcrl2/lts/detail/liblts_branching_bisim_minimal_depth.h"
 #include "mcrl2/lts/detail/liblts_weak_bisim.h"
 #include "mcrl2/lts/detail/liblts_add_an_action_loop.h"
 #include "mcrl2/lts/detail/liblts_ready_sim.h"
@@ -80,7 +82,7 @@ bool destructive_compare(LTS_TYPE& l1,
       if (generate_counter_examples)
       {
         mCRL2log(mcrl2::log::warning) << "A slower partition refinement algorithm is used to generate minimal-depth counter examples.\n";
-        return detail::destructive_bisimulation_compare_minimal_depth(l1,l2, false,false,true,counter_example_file,structured_output);
+        return detail::destructive_bisimulation_compare_minimal_depth(l1, l2, counter_example_file, structured_output);
       }
       return detail::destructive_bisimulation_compare_dnj(l1,l2, false,false,generate_counter_examples,counter_example_file,structured_output);
     }
@@ -97,7 +99,7 @@ bool destructive_compare(LTS_TYPE& l1,
       if (generate_counter_examples)
       {
         mCRL2log(mcrl2::log::warning) << "The default branching bisimulation comparison algorithm cannot generate counter examples. Therefore the slower gv algorithm is used instead.\n";
-        return detail::destructive_bisimulation_compare(l1,l2, true,false,generate_counter_examples,counter_example_file,structured_output);
+        return detail::destructive_branching_bisimulation_compare_minimal_depth(l1, l2, counter_example_file, structured_output);
       }
       return detail::destructive_bisimulation_compare_dnj(l1,l2, true,false,generate_counter_examples,counter_example_file,structured_output);
     }
@@ -185,7 +187,7 @@ bool destructive_compare(LTS_TYPE& l1,
       // Trace equivalence now corresponds to bisimilarity
       if (generate_counter_examples) 
       {
-        return detail::destructive_bisimulation_compare_minimal_depth(l1, l2, false, false, generate_counter_examples, counter_example_file, structured_output);
+        return detail::destructive_bisimulation_compare_minimal_depth(l1, l2, counter_example_file, structured_output);
       }
       return detail::destructive_bisimulation_compare(l1,l2,false,false,generate_counter_examples,counter_example_file,structured_output);
     }

--- a/libraries/pbes/test/ltscompare_counter_example_test.cpp
+++ b/libraries/pbes/test/ltscompare_counter_example_test.cpp
@@ -1,0 +1,132 @@
+// Author(s): Maurice Laveaux, Jan Martens
+// Copyright: see the accompanying file COPYING or copy at
+// https://github.com/mCRL2org/mCRL2/blob/master/COPYING
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+
+#include "mcrl2/data/data_specification.h"
+#include "mcrl2/lps/stochastic_specification.h"
+#include "mcrl2/process/action_label.h"
+#include "mcrl2/process/process_expression.h"
+#define BOOST_TEST_MODULE ltscompare_counter_example_test
+#include <boost/test/included/unit_test.hpp>
+
+#include "mcrl2/data/parse.h"
+#include "mcrl2/lts/detail/lts_convert.h"
+#include "mcrl2/lts/lts_algorithm.h"
+#include "mcrl2/lts/lts_equivalence.h"
+#include "mcrl2/lts/lts_io.h"
+#include "mcrl2/lts/lts_lts.h"
+#include "mcrl2/pbes/lts2pbes.h"
+#include "mcrl2/pbes/pbesinst_structure_graph.h"
+#include "mcrl2/pbes/solve_structure_graph.h"
+
+using namespace mcrl2::lps;
+using namespace mcrl2::lts;
+using namespace mcrl2::pbes_system;
+using namespace mcrl2::state_formulas;
+
+static lts_aut_t parse_aut(const std::string& s)
+{
+  std::stringstream is(s);
+  lts_aut_t l;
+  l.load(is);
+  return l;
+}
+
+inline
+void compare(const char* s1, const char* s2, const char* counterexample_name)
+{    
+  mcrl2::lts::lts_aut_t t1 = parse_aut(s1);
+  mcrl2::lts::lts_aut_t t2 = parse_aut(s2);
+
+  compare(t1, t2, lts_equivalence::lts_eq_branching_bisim, true, counterexample_name);
+
+  // Read the counter example file and verify that it is distinguishing
+  std::ifstream counter_example(counterexample_name);
+
+  mcrl2::process::action_label_list labels;
+  labels.push_front(mcrl2::process::action_label("a", {}));
+  labels.push_front(mcrl2::process::action_label("b", {}));
+  labels.push_front(mcrl2::process::action_label("tau", {}));
+
+  // Convert aut to lts format for lts2pbes
+  lts_lts_t t1_lts;
+  lts_lts_t t2_lts;
+
+  lts_convert(t1, t1_lts, {}, labels, {}, true);
+  lts_convert(t2, t2_lts, {}, labels, {}, true);
+
+  // Parse a formula and make up some action declaration since that is necessary.  
+  stochastic_specification spec({}, t1_lts.action_label_declarations(), {}, {}, {});
+  mcrl2::state_formulas::state_formula formula = mcrl2::state_formulas::algorithms::parse_state_formula(counter_example, spec, false);
+
+  lts2pbes_algorithm algorithm1(t1_lts);
+  auto t1_pbes = algorithm1.run(formula);
+
+  lts2pbes_algorithm algorithm2(t2_lts);
+  auto t2_pbes = algorithm2.run(formula);
+
+  pbessolve_options options;
+  structure_graph G1;
+  pbesinst_structure_graph_algorithm algorithm_inst1(options, t1_pbes, G1);
+  algorithm_inst1.run();
+
+  structure_graph G2;
+  pbesinst_structure_graph_algorithm algorithm_inst2(options, t2_pbes, G2);
+  algorithm_inst2.run();
+
+  solve_structure_graph_algorithm algorithm_solve(true, false);   
+  BOOST_CHECK_NE(algorithm_solve.solve(G1), algorithm_solve.solve(G2));  
+}
+
+BOOST_AUTO_TEST_CASE(ltscompare_br_hard_test)
+{
+    auto br_hard1 = R"""(des (0,9,7)
+        (0,"tau",1)
+        (6, "tau", 1)
+        (1, "tau", 2)
+        (2, "tau", 3)
+        (1, "tau", 4)
+        (2, "tau", 5)
+        (0, "tau", 3)
+        (4, a, 4)
+        (5, b, 5)
+        )""";
+
+    
+    auto br_hard2 = R"""(des (6,9,7)
+        (0,"tau",1)
+        (6, "tau", 1)
+        (1, "tau", 2)
+        (2, "tau", 3)
+        (1, "tau", 4)
+        (2, "tau", 5)
+        (0, "tau", 3)
+        (4, a, 4)
+        (5, b, 5)
+        )""";
+
+    compare(br_hard1, br_hard2, "br_hard_counterexample.mcf");
+}
+
+BOOST_AUTO_TEST_CASE(ltscompare_tau_dist_test)
+{
+    auto tau_dist1 = R"""(des (0,3,2)
+        (0,"tau",1)
+        (0,"a",1)
+        (0,"b",1))""";
+
+    
+    auto tau_dist2 = R"""(des (0,4,3)
+        (0,"a",2)
+        (0,"b",2)
+        (0, "tau",1)
+        (1,"b",2)
+        )""";
+
+    compare(tau_dist1, tau_dist2, "tau_dist_counterexample.mcf");
+}

--- a/tests/random/random_testing.py
+++ b/tests/random/random_testing.py
@@ -222,6 +222,11 @@ class Lts2pbesTest(ProcessTest):
     def __init__(self, name, settings):
         super(Lts2pbesTest, self).__init__(name, ymlfile('lts2pbes'), settings)
 
+    def create_inputfiles(self, runpath = '.'):
+        super(Lts2pbesTest, self).create_inputfiles(runpath)
+        # Use the nodeadlock property to generate the PBES.
+        self.inputfiles.append(mcrl2file('examples/modal-formulas/nodeadlock.mcf'))
+
 class LtsconvertsymbolicTest(ProcessTest):
     def __init__(self, name, settings):
         super(LtsconvertsymbolicTest, self).__init__(name, ymlfile('ltsconvertsymbolic'), settings)

--- a/tests/random/random_testing.py
+++ b/tests/random/random_testing.py
@@ -147,6 +147,13 @@ class LtscompareTest(ProcessTauTest):
         self.add_command_line_options('t3', ['-e' + equivalence_type])
         self.add_command_line_options('t4', ['-e' + equivalence_type])
 
+class LtscompareCounterexampleTest(ProcessTauTest):
+    def __init__(self, name, equivalence_type, settings):
+        assert equivalence_type in ['bisim', 'branching-bisim', 'trace']
+        super(LtscompareCounterexampleTest, self).__init__(name, ymlfile('ltscompare-counter-example'), settings)
+        self.add_command_line_options('t4', ['-e' + equivalence_type])
+
+
 class StochasticLtscompareTest(StochasticProcessTest):
     def __init__(self, name, settings):
         super(StochasticLtscompareTest, self).__init__(name, ymlfile('stochastic-ltscompare'), settings)
@@ -373,15 +380,17 @@ available_tests = {
     'lpsconfcheck-trivial'                        : lambda name, settings: LpsConfcheckTest(name, 'trivial', settings)                                 ,
     'lpsconstelm'                                 : lambda name, settings: LpsConstelmTest(name, settings)                                             ,
     'lpsbinary'                                   : lambda name, settings: LpsBinaryTest(name, settings)                                               ,
-    'lps2lts-algorithms'                          : lambda name, settings: Lps2ltsAlgorithmsTest(name, settings)                                      ,
-    'lps2lts-parallel'                            : lambda name, settings: Lps2ltsParallelTest(name, settings)                                       ,
+    'lps2lts-algorithms'                          : lambda name, settings: Lps2ltsAlgorithmsTest(name, settings)                                       ,
+    'lps2lts-parallel'                            : lambda name, settings: Lps2ltsParallelTest(name, settings)                                         ,
     'lps2pbes'                                    : lambda name, settings: Lps2pbesTest(name, settings)                                                ,
     'lpsstategraph'                               : lambda name, settings: LpsstategraphTest(name, settings)                                           ,
     'lts2pbes'                                    : lambda name, settings: Lts2pbesTest(name, settings)                                                ,
     'ltscompare-bisim'                            : lambda name, settings: LtscompareTest(name, 'bisim', settings)                                     ,
+    'ltscompare-bisim-counter-example'            : lambda name, settings: LtscompareCounterexampleTest(name, 'bisim', settings)                       ,
     'ltscompare-bisim-gv'                         : lambda name, settings: LtscompareTest(name, 'bisim-gv', settings)                                  ,
     'ltscompare-bisim-gjkw'                       : lambda name, settings: LtscompareTest(name, 'bisim-gjkw', settings)                                ,
     'ltscompare-branching-bisim'                  : lambda name, settings: LtscompareTest(name, 'branching-bisim', settings)                           ,
+    'ltscompare-branching-bisim-counter-example'  : lambda name, settings: LtscompareCounterexampleTest(name, 'branching-bisim', settings)             ,
     'ltscompare-branching-bisim-gv'               : lambda name, settings: LtscompareTest(name, 'branching-bisim-gv', settings)                        ,
     'ltscompare-branching-bisim-gjkw'             : lambda name, settings: LtscompareTest(name, 'branching-bisim-gjkw', settings)                      ,
     'ltscompare-dpbranching-bisim'                : lambda name, settings: LtscompareTest(name, 'dpbranching-bisim', settings)                         ,
@@ -392,6 +401,7 @@ available_tests = {
     'ltscompare-sim'                              : lambda name, settings: LtscompareTest(name, 'sim', settings)                                       ,
     'ltscompare-ready-sim'                        : lambda name, settings: LtscompareTest(name, 'ready-sim', settings)                                 ,
     'ltscompare-trace'                            : lambda name, settings: LtscompareTest(name, 'trace', settings)                                     ,
+    'ltscompare-trace-counter-example'            : lambda name, settings: LtscompareCounterexampleTest(name, 'trace', settings)                       ,
     'ltscompare-weak-trace'                       : lambda name, settings: LtscompareTest(name, 'weak-trace', settings)                                ,
     'bisimulation-bisim'                          : lambda name, settings: BisimulationTest(name, 'bisim', settings)                                   ,
     'bisimulation-bisim-gv'                       : lambda name, settings: BisimulationTest(name, 'bisim-gv', settings)                                ,

--- a/tests/random/random_testing.py
+++ b/tests/random/random_testing.py
@@ -153,6 +153,11 @@ class LtscompareCounterexampleTest(ProcessTauTest):
         super(LtscompareCounterexampleTest, self).__init__(name, ymlfile('ltscompare-counter-example'), settings)
         self.add_command_line_options('t4', ['-e' + equivalence_type])
 
+    def create_inputfiles(self, runpath = '.'):
+        super(LtscompareCounterexampleTest, self).create_inputfiles(runpath)
+        # This is a hack to ensure that the counter example formula always exists for the further steps.
+        filename = runpath + '/l5.mcf'
+        write_text(filename, "true")
 
 class StochasticLtscompareTest(StochasticProcessTest):
     def __init__(self, name, settings):
@@ -217,13 +222,13 @@ class Lts2pbesTest(ProcessTest):
     def __init__(self, name, settings):
         super(Lts2pbesTest, self).__init__(name, ymlfile('lts2pbes'), settings)
 
-    def create_inputfiles(self, runpath = '.'):
-        super(Lts2pbesTest, self).create_inputfiles(runpath)
-        self.inputfiles.append(mcrl2file('examples/modal-formulas/nodeadlock.mcf'))
-
 class LtsconvertsymbolicTest(ProcessTest):
     def __init__(self, name, settings):
         super(LtsconvertsymbolicTest, self).__init__(name, ymlfile('ltsconvertsymbolic'), settings)
+
+    def LtsconvertsymbolicTest(self, runpath = '.'):
+        super(Lts2pbesTest, self).create_outputfiles(runpath)
+        self.inputfiles.append(mcrl2file('examples/modal-formulas/nodeadlock.mcf'))
 
 class PbesTest(RandomTest):
     def __init__(self, name, ymlfile, settings):

--- a/tests/specifications/ltscompare-counter-example.yml
+++ b/tests/specifications/ltscompare-counter-example.yml
@@ -36,12 +36,12 @@ tools:
     args: [-c]
     name: ltscompare
   t5:
-    input: [l5, l3]
+    input: [l3, l5]
     output: [l6]
     args: []
     name: lts2pbes
   t6:
-    input: [l5, l4]
+    input: [l4, l5]
     output: [l7]
     args: []
     name: lts2pbes
@@ -57,4 +57,4 @@ tools:
     name: pbessolve
 
 result: |
-  t7.value['result'] != t8.value['result']
+  result = t7.value['solution'] != t8.value['solution']

--- a/tests/specifications/ltscompare-counter-example.yml
+++ b/tests/specifications/ltscompare-counter-example.yml
@@ -1,0 +1,60 @@
+nodes:
+  l1:
+    type: mcrl2
+  l2:
+    type: lps
+  l3:
+    type: lts
+  l4:
+    type: lts
+  l5:
+    type: mcf
+  l6:
+    type: pbes
+  l7:
+    type: pbes
+
+tools:
+  t1:
+    input: [l1]
+    output: [l2]
+    args: [-n]
+    name: mcrl22lps
+  t2:
+    input: [l2]
+    output: [l3]
+    args: []
+    name: lps2lts
+  t3:
+    input: [l3]
+    output: [l4]
+    args: [-etrace]
+    name: ltsconvert
+  t4:
+    input: [l3, l4]
+    output: [l5]
+    args: [-c]
+    name: ltscompare
+  t5:
+    input: [l5, l3]
+    output: [l6]
+    args: []
+    name: lts2pbes
+  t6:
+    input: [l5, l4]
+    output: [l7]
+    args: []
+    name: lts2pbes
+  t7:
+    input: [l6]
+    output: []
+    args: []
+    name: pbessolve
+  t8:
+    input: [l7]
+    output: []
+    args: []
+    name: pbessolve
+
+result: |
+  t7.value['result'] != t8.value['result']

--- a/tests/specifications/ltscompare-counter-example.yml
+++ b/tests/specifications/ltscompare-counter-example.yml
@@ -57,4 +57,4 @@ tools:
     name: pbessolve
 
 result: |
-  result = t7.value['solution'] != t8.value['solution']
+  result = t4.value['result'] or t7.value['solution'] != t8.value['solution']

--- a/tests/utility/tools.py
+++ b/tests/utility/tools.py
@@ -281,7 +281,7 @@ class LtscompareTool(Tool):
 
         # counter example generation
         if len(self.output_nodes) > 0:
-            args[2] = '--evidence-file={}'.format(args[2])
+            args[2] = '--counter-example-file={}'.format(args[2])
         return args
 
 class ToolFactory(object):

--- a/tests/utility/tools.py
+++ b/tests/utility/tools.py
@@ -271,6 +271,18 @@ class PbesSolveTool(Tool):
         # mark the evidence file as executed
         if len(self.output_nodes) == 1:
             self.output_nodes[0].value = 'executed'
+            
+class LtscompareTool(Tool):
+    def __init__(self, label, name, toolpath, input_nodes, output_nodes, args):
+        super(LtscompareTool, self).__init__(label, name, toolpath, input_nodes, output_nodes, args)
+
+    def arguments(self, working_directory = None, no_paths = False):
+        args = super(LtscompareTool, self).arguments(working_directory, no_paths)
+
+        # counter example generation
+        if len(self.output_nodes) > 0:
+            args[2] = '--evidence-file={}'.format(args[2])
+        return args
 
 class ToolFactory(object):
     def create_tool(self, label, name, toolpath, input_nodes, output_nodes, args):
@@ -286,4 +298,6 @@ class ToolFactory(object):
             return SolveTool(label, name, toolpath, input_nodes, output_nodes, args)
         elif name in ['pbes2bool', 'pbessolve', 'pbessolvesymbolic', 'pbessymbolicbisim']:
             return PbesSolveTool(label, name, toolpath, input_nodes, output_nodes, args)
+        elif name == 'ltscompare':
+            return LtscompareTool(label, name, toolpath, input_nodes, output_nodes, args)
         return Tool(label, name, toolpath, input_nodes, output_nodes, args)

--- a/tests/utility/tools.py
+++ b/tests/utility/tools.py
@@ -43,6 +43,7 @@ class Tool(object):
         self.input_nodes = input_nodes
         self.output_nodes = output_nodes
         self.args = args
+        self.stderr = ""
         self.executed = False
         self.value = {}
 


### PR DESCRIPTION
Currently implements a partitioner that maintains minimal-depth splitting information. 

TODO:
- [x] generate distinguishing formula.
- [x]  some tests.
- [x] maybe postprocess formula(*).
- [x] pre-process correctly with dnj.
- [x] Modify documentation of ltscompare, it should probably point to the correct publications.
- [x] Test hidden-label-map, I'm not sure what happens if you use the --tau parameter in the command.
- [x]  ~~Add static tests `hard{-2}.aut` where the formula necessarily contains a \hat{tau} and `simple-{2}.aut` where postprocessing is used.~~