### PR TITLE
Use compiled tools for example tests

### DIFF
--- a/tests/scripts/run_examples.py
+++ b/tests/scripts/run_examples.py
@@ -29,7 +29,7 @@ def main():
 
     args = parser.parse_args()
 
-    os.environ["PATH"] += os.pathsep + args.toolpath
+    os.environ["PATH"] = args.toolpath + os.pathsep + os.environ["PATH"]
 
     def run_example(path, index):
         print(f"[{index}] Running {path}", flush=True)


### PR DESCRIPTION
The example tests run with the tools first found in the configured PATH. Currently, if e.g. a system-wide mCRL2 install is present, the tests are run against this installation instead of the compiled version.

Prepend the tool path to PATH instead of appending it to make sure that the compiled tools are found before the system-wide install.