### PR TITLE
Fix run script for MLV example.

### DIFF
--- a/examples/industrial/MLV/run.py
+++ b/examples/industrial/MLV/run.py
@@ -9,7 +9,7 @@ from shutil import which
 os.chdir(os.path.dirname(os.path.abspath(__file__)))
 
 model = 'MLV'
-run = subprocess.run(['mcrl22lps', f'{model}.mcrl2'], stdout=subprocess.PIPE, check=True)
+run = subprocess.run(['mcrl22lps', '-n', f'{model}.mcrl2'], stdout=subprocess.PIPE, check=True)
 run = subprocess.run(['lpsconstelm'], input=run.stdout, stdout=subprocess.PIPE, check=True)
 run = subprocess.run(['lpsparelm', '-', f'{model}.lps'], input=run.stdout, check=True)
 
@@ -27,7 +27,7 @@ if lpsreach is not None and pbessolvesymbolic is not None:
             print(f' REQUIREMENT {prop}')
             print('=================')
 
-            subprocess.run(['lps2pbes', '-v', '-f', mcfpath, f'{model}.lps', f'{model}.{prop}.pbes'], check=True)
-            subprocess.run([pbessolvesymbolic, '-v', '-c', '--saturation', '--cached', '--chaining', '--groups=simple', f'{model}.{property}.pbes'], check=True)
+            subprocess.run(['lps2pbes', '-v', '-f', f'properties/{mcfpath}', f'{model}.lps', f'{model}.{prop}.pbes'], check=True)
+            subprocess.run([pbessolvesymbolic, '-v', '-c', '--saturation', '--cached', '--chaining', '--groups=simple', f'{model}.{prop}.pbes'], check=True)
 
             print('\n\n')


### PR DESCRIPTION
- To facilitate symbolic model checking, do not cluster during linearization
- Fix file paths for verification of the requirements.