### PR TITLE
Balance term structure for parallel composition operator.

### DIFF
--- a/libraries/lps/include/mcrl2/lps/linearise.h
+++ b/libraries/lps/include/mcrl2/lps/linearise.h
@@ -41,6 +41,8 @@ struct t_lin_options
   bool apply_alphabet_axioms;
   bool balance_summands;      // Used to balance long expressions of the shape p1 + p2 + ... + pn. By default the parser delivers
                               // such expressions in a skewed form, causing stack overflow. 
+  bool balance_merge;      // Used to balance long expressions of the shape p1 || p2 || ... || pn. By default the parser
+                         // delivers such expressions in a skewed form, causing stack overflow. 
   mcrl2::data::rewriter::strategy rewrite_strategy;
 
   t_lin_options()

--- a/libraries/lps/source/linearise.cpp
+++ b/libraries/lps/source/linearise.cpp
@@ -8211,7 +8211,7 @@ class specification_basic_type
       deadlock_summand_vector resultingDeltaSummands;
       deadlock_summands.swap(resultingDeltaSummands);
 
-      bool inline_allow = is_allow || is_block;
+      const bool inline_allow = is_allow || is_block;
       if (inline_allow)
       {
         // Inline allow is only supported for ignore_time,
@@ -11273,6 +11273,7 @@ mcrl2::lps::stochastic_specification mcrl2::lps::linearise(
   {
     balance_summands(input_process);
   }
+  balance_merge(input_process);
 
   if (lin_options.apply_alphabet_axioms) // Apply alphabet reduction if requested. 
   {

--- a/libraries/lps/source/linearise.cpp
+++ b/libraries/lps/source/linearise.cpp
@@ -11267,13 +11267,18 @@ mcrl2::lps::stochastic_specification mcrl2::lps::linearise(
   mcrl2::process::process_specification input_process=type_checked_spec;
   data_specification data_spec=input_process.data();
 
-  if (lin_options.balance_summands) // Make a balanced tree of long expressions of the shape p1 + p2 + p3 + ... + p4. 
+  if (lin_options.balance_summands) // Make a balanced tree of long expressions of the shape p1 + p2 + p3 + ... + pn. 
                                     // By default the parser provides a skewed tree, and for very long sequences of summands this overflows the
                                     // stack.
   {
     balance_summands(input_process);
   }
-  balance_merge(input_process);
+  if (lin_options.balance_merge) // Make a balanced tree of long expressions of the shape p1 || p2 || p3 || ... || pn. 
+                                 // By default the parser provides a skewed tree, and for very long sequences of summands this overflows the
+                                 // stack.
+  {
+    balance_merge(input_process);
+  }  
 
   if (lin_options.apply_alphabet_axioms) // Apply alphabet reduction if requested. 
   {

--- a/libraries/process/include/mcrl2/process/alphabet_operations.h
+++ b/libraries/process/include/mcrl2/process/alphabet_operations.h
@@ -72,10 +72,9 @@ inline
 multi_action_name_set make_name_set(const action_name_multiset_list& v)
 {
   multi_action_name_set result;
-  core::identifier_string_list& names;
   for (const action_name_multiset& i: v)
   {
-    names = i.names();
+    const core::identifier_string_list& names = i.names();
     result.insert(multi_action_name(names.begin(), names.end()));
   }
   return result;

--- a/libraries/process/include/mcrl2/process/alphabet_operations.h
+++ b/libraries/process/include/mcrl2/process/alphabet_operations.h
@@ -72,9 +72,10 @@ inline
 multi_action_name_set make_name_set(const action_name_multiset_list& v)
 {
   multi_action_name_set result;
+  core::identifier_string_list& names;
   for (const action_name_multiset& i: v)
   {
-    const core::identifier_string_list& names = i.names();
+    names = i.names();
     result.insert(multi_action_name(names.begin(), names.end()));
   }
   return result;
@@ -166,8 +167,7 @@ inline
 multi_action_name_set block(const core::identifier_string_list& B, const multi_action_name_set& A, bool A_includes_subsets = false)
 {
   multi_action_name_set result;
-  multi_action_name beta(B.begin(), B.end());
-
+  
   if (A_includes_subsets)
   {
     for (multi_action_name alpha: A)
@@ -184,6 +184,8 @@ multi_action_name_set block(const core::identifier_string_list& B, const multi_a
   }
   else
   {
+    multi_action_name beta(B.begin(), B.end());
+
     for (const multi_action_name& alpha: A)
     {
       if (utilities::detail::has_empty_intersection(beta.begin(), beta.end(), alpha.begin(), alpha.end()))
@@ -249,7 +251,6 @@ multi_action_name hide(const std::set<core::identifier_string>& I, const multi_a
 template <typename IdentifierContainer>
 multi_action_name_set hide(const IdentifierContainer& I, const multi_action_name_set& A, bool /* A_includes_subsets */ = false)
 {
-  multi_action_name m(I.begin(), I.end());
   multi_action_name_set result;
   for (multi_action_name alpha: A)
   {

--- a/libraries/process/include/mcrl2/process/balance_nesting_depth.h
+++ b/libraries/process/include/mcrl2/process/balance_nesting_depth.h
@@ -68,6 +68,50 @@ T balance_summands(const T& x, typename std::enable_if<std::is_base_of<atermpp::
   return result;
 }
 
+namespace detail
+{
+struct balance_merge_builder : public process_expression_builder<balance_merge_builder>
+{
+  typedef process_expression_builder<balance_merge_builder> super;
+  using super::apply;
+
+  template <class T>
+  void apply(T& result, const process::merge& x)
+  {
+    std::vector<process_expression> merges = split_merges(x);
+    process_expression new_merge;
+    for (process_expression& merge : merges)
+    {
+      super::apply(new_merge, merge);
+      merge = new_merge;
+    }
+
+    result = utilities::detail::join_balanced<process_expression>(merges.begin(),
+        merges.end(),
+        [](const process::process_expression& x, const process_expression& y) { return merge(x, y); });
+  }
+};
+
+} // namespace detail
+
+/// \brief Reduces the nesting depth of the merge operator
+template <typename T>
+void balance_merge(T& x, typename std::enable_if<!std::is_base_of<atermpp::aterm, T>::value>::type* = nullptr)
+{
+  detail::balance_merge_builder f;
+  f.update(x);
+}
+
+/// \brief Reduces the nesting depth of the choice operator
+template <typename T>
+T balance_merge(const T& x, typename std::enable_if<std::is_base_of<atermpp::aterm, T>::value>::type* = nullptr)
+{
+  T result;
+  detail::balance_merge_builder f;
+  f.apply(result, x);
+  return result;
+}
+
 } // namespace process
 
 } // namespace mcrl2

--- a/libraries/process/include/mcrl2/process/detail/alphabet_push_allow.h
+++ b/libraries/process/include/mcrl2/process/detail/alphabet_push_allow.h
@@ -276,7 +276,7 @@ std::ostream& operator<<(std::ostream& out, const push_allow_node& x)
   return out << "Node(" << pp(x.alphabet) << ", " << process::pp(x.expression) << ")";
 }
 
-push_allow_node push_allow(const process_expression& x, const allow_set& A, std::vector<process_equation>& equations, push_allow_cache& W, bool generate_missing_equations = false);
+push_allow_node push_allow(const process_expression& x, const allow_set& A, std::map<process_identifier, process_equation>& equations, push_allow_cache& W, bool generate_missing_equations = false);
 
 template <typename Derived, typename Node = push_allow_node>
 struct push_allow_traverser: public process_expression_traverser<Derived>
@@ -287,7 +287,7 @@ struct push_allow_traverser: public process_expression_traverser<Derived>
   using super::apply;
 
   // used for computing the alphabet
-  std::vector<process_equation>& equations;
+  std::map<process_identifier, process_equation>& equations;
   push_allow_cache& W;
 
   // the parameter A
@@ -295,7 +295,7 @@ struct push_allow_traverser: public process_expression_traverser<Derived>
 
   std::vector<Node> node_stack;
 
-  push_allow_traverser(std::vector<process_equation>& equations_, push_allow_cache& W_, const allow_set& A_)
+  push_allow_traverser(std::map<process_identifier, process_equation>& equations_, push_allow_cache& W_, const allow_set& A_)
     : equations(equations_), W(W_), A(A_)
   {}
 
@@ -430,7 +430,7 @@ struct push_allow_traverser: public process_expression_traverser<Derived>
         // create a new equation P(d) = p1
         const process_expression& p1 = node.expression;
         process_equation eqn1(P1, d, p1);
-        equations.push_back(eqn1);
+        equations.insert({P1, eqn1});
 
         alpha.alphabet = node.alphabet;
         alpha.status = push_allow_cache::finished;
@@ -697,13 +697,13 @@ struct apply_push_allow_traverser: public Traverser<apply_push_allow_traverser<T
   using super::leave;
   using super::apply;
 
-  apply_push_allow_traverser(std::vector<process_equation>& equations, push_allow_cache& W, const allow_set& A)
+  apply_push_allow_traverser(std::map<process_identifier, process_equation>& equations, push_allow_cache& W, const allow_set& A)
     : super(equations, W, A)
   {}
 };
 
 inline
-push_allow_node push_allow(const process_expression& x, const allow_set& A, std::vector<process_equation>& equations, push_allow_cache& W, bool generate_missing_equations)
+push_allow_node push_allow(const process_expression& x, const allow_set& A, std::map<process_identifier, process_equation>& equations, push_allow_cache& W, bool generate_missing_equations)
 {
   apply_push_allow_traverser<push_allow_traverser> f(equations, W, A);
   f.apply(x);
@@ -734,7 +734,7 @@ push_allow_node push_allow(const process_expression& x, const allow_set& A, std:
 inline
 process_expression push_allow(const process_expression& x,
                               const action_name_multiset_list& V,
-                              std::vector<process_equation>& equations,
+                              std::map<process_identifier, process_equation>& equations,
                               data::set_identifier_generator& id_generator,
                               std::map<process_identifier, multi_action_name_set>& pcrl_equation_cache
                             )

--- a/libraries/process/include/mcrl2/process/detail/alphabet_push_block.h
+++ b/libraries/process/include/mcrl2/process/detail/alphabet_push_block.h
@@ -154,7 +154,7 @@ std::string print_B(const std::set<core::identifier_string>& B)
   return out.str();
 }
 
-process_expression push_block(const std::set<core::identifier_string>& B, const process_expression& x, std::vector<process_equation>& equations, push_block_cache& W, data::set_identifier_generator& id_generator);
+process_expression push_block(const std::set<core::identifier_string>& B, const process_expression& x, std::map<process_identifier, process_equation>& equations, push_block_cache& W, data::set_identifier_generator& id_generator);
 
 template <typename Derived>
 struct push_block_builder: public process_expression_builder<Derived>
@@ -166,7 +166,7 @@ struct push_block_builder: public process_expression_builder<Derived>
   using super::update;
 
   // used for computing the alphabet
-  std::vector<process_equation>& equations;
+  std::map<process_identifier, process_equation>& equations;
   push_block_cache& W;
 
   // the parameter B
@@ -175,7 +175,7 @@ struct push_block_builder: public process_expression_builder<Derived>
   // used for generating process identifiers
   data::set_identifier_generator& id_generator;
 
-  push_block_builder(std::vector<process_equation>& equations_, push_block_cache& W_, const std::set<core::identifier_string>& B_, data::set_identifier_generator& id_generator_)
+  push_block_builder(std::map<process_identifier, process_equation>& equations_, push_block_cache& W_, const std::set<core::identifier_string>& B_, data::set_identifier_generator& id_generator_)
     : equations(equations_), W(W_), B(B_), id_generator(id_generator_)
   {}
 
@@ -230,7 +230,7 @@ struct push_block_builder: public process_expression_builder<Derived>
 
     // create a new equation P1(d) = p1
     process_equation eqn1(P1, d, p1);
-    equations.push_back(eqn1);
+    equations.insert({P1, eqn1});
 
     result = process_instance(P1, x.actual_parameters());
   }
@@ -338,13 +338,13 @@ struct apply_push_block_builder: public Traverser<apply_push_block_builder<Trave
   using super::apply;
   using super::update;
 
-  apply_push_block_builder(std::vector<process_equation>& equations, push_block_cache& W, const std::set<core::identifier_string>& B, data::set_identifier_generator& id_generator)
+  apply_push_block_builder(std::map<process_identifier, process_equation>& equations, push_block_cache& W, const std::set<core::identifier_string>& B, data::set_identifier_generator& id_generator)
     : super(equations, W, B, id_generator)
   {}
 };
 
 inline
-process_expression push_block(const std::set<core::identifier_string>& B, const process_expression& x, std::vector<process_equation>& equations, push_block_cache& W, data::set_identifier_generator& id_generator)
+process_expression push_block(const std::set<core::identifier_string>& B, const process_expression& x, std::map<process_identifier, process_equation>& equations, push_block_cache& W, data::set_identifier_generator& id_generator)
 {
   apply_push_block_builder<push_block_builder> f(equations, W, B, id_generator);
   process_expression result;
@@ -357,7 +357,7 @@ process_expression push_block(const std::set<core::identifier_string>& B, const 
 inline
 process_expression push_block(const core::identifier_string_list& B,
                               const process_expression& x,
-                              std::vector<process_equation>& equations,
+                              std::map<process_identifier, process_equation>& equations,
                               data::set_identifier_generator& id_generator,
                               std::map<process_identifier, multi_action_name_set>& pcrl_equation_cache
                              )

--- a/libraries/process/include/mcrl2/process/detail/alphabet_push_block.h
+++ b/libraries/process/include/mcrl2/process/detail/alphabet_push_block.h
@@ -312,7 +312,8 @@ struct push_block_builder: public process_expression_builder<Derived>
     core::identifier_string_list B1(B.begin(), B.end());
     allow_set A1(alphabet_operations::block(B1, A.A));
     detail::push_allow_cache W_allow(id_generator, W.pcrl_equation_cache);
-    detail::push_allow_node node = detail::push_allow(x.operand(), A1, equations, W_allow, true);
+    detail::push_allow_node node;
+    detail::push_allow(node, x.operand(), A1, equations, W_allow, true);
     mCRL2log(log::debug) << push_block_printer(B).print(x, A1);
     result = node.expression;
   }

--- a/libraries/process/include/mcrl2/process/expand_process_instance_assignments.h
+++ b/libraries/process/include/mcrl2/process/expand_process_instance_assignments.h
@@ -28,9 +28,9 @@ struct expand_process_instance_assignments_builder: public process_expression_bu
   using super::apply;
   using super::update;
 
-  const std::vector<process_equation>& equations;
+  const std::map<process_identifier, process_equation>& equations;
 
-  explicit expand_process_instance_assignments_builder(const std::vector<process_equation>& equations_)
+  explicit expand_process_instance_assignments_builder(const std::map<process_identifier, process_equation>& equations_)
     : equations(equations_)
   {}
 
@@ -73,7 +73,7 @@ struct expand_process_instance_assignments_builder: public process_expression_bu
 
 /// \brief Replaces embedded process instances by the right hand sides of the corresponding equations
 inline
-process_expression expand_process_instance_assignments(const process_expression& x, const std::vector<process_equation>& equations)
+process_expression expand_process_instance_assignments(const process_expression& x, const std::map<process_identifier, process_equation>& equations)
 {
   detail::expand_process_instance_assignments_builder f(equations);
   process_expression result;
@@ -83,7 +83,7 @@ process_expression expand_process_instance_assignments(const process_expression&
 
 // Converts a process_instance_assignment into a process_instance, by expanding assignments
 inline
-process_instance expand_assignments(const process::process_instance_assignment& x, const std::vector<process_equation>& equations)
+process_instance expand_assignments(const process::process_instance_assignment& x, const std::map<process_identifier, process_equation>& equations)
 {
   const process_equation& eqn = find_equation(equations, x.identifier());
   data::assignment_sequence_substitution sigma(x.assignments());

--- a/libraries/process/include/mcrl2/process/find.h
+++ b/libraries/process/include/mcrl2/process/find.h
@@ -286,15 +286,31 @@ std::set<core::identifier_string> find_action_names(const T& x)
 /// \param[in] equations a sequence of process equations
 /// \param[in] id The identifier of the equation that is searched for.
 /// \return The equation with the given process identifier. Throws an exception if no such equation was found.
+/// \note Complexity of this function is O(equations.size()).
 inline
 const process_equation& find_equation(const std::vector<process_equation>& equations, const process_identifier& id)
 {
-  for (const process_equation& equation: equations)
+  const auto it = std::find_if(equations.begin(), equations.end(),
+      [&id](auto equation) { return equation.identifier() == id; });
+  if (it != equations.end())
   {
-    if (equation.identifier() == id)
-    {
-      return equation;
-    }
+    return *it;
+  }
+  throw mcrl2::runtime_error("unknown process identifier " + process::pp(id));
+}
+
+/// \brief Finds an equation that corresponds to a process identifier
+/// \param[in] equations a mapping of identifiers to process equations
+/// \param[in] id The identifier of the equation that is searched for.
+/// \return The equation with the given process identifier. Throws an exception if no such equation was found.
+/// \note Complexity of this function is the complexity of std::map's find()
+inline
+const process_equation& find_equation(const std::map<process_identifier, process_equation>& equations, const process_identifier& id)
+{
+  const auto it = equations.find(id);
+  if (it != equations.end())
+  {
+    return it->second;
   }
   throw mcrl2::runtime_error("unknown process identifier " + process::pp(id));
 }

--- a/libraries/process/include/mcrl2/process/join.h
+++ b/libraries/process/include/mcrl2/process/join.h
@@ -50,6 +50,39 @@ process_expression join_summands(FwdIt first, FwdIt last)
   }, delta_);
 }
 
+/// \brief Splits a merge into a set of operands
+/// Given a process expression of the form p1 || p2 || .... || pn, this will yield a
+/// set of the form { p1, p2, ..., pn }, assuming that pi does not have a || as main
+/// function symbol.
+/// \param x A process expression.
+/// \return A set of process expressions.
+inline std::vector<process_expression> split_merges(const process_expression& x)
+{
+  std::vector<process_expression> result;
+  utilities::detail::split(
+      x,
+      std::back_inserter(result),
+      is_merge,
+      [](const process_expression& x) { return atermpp::down_cast<merge>(x).left(); },
+      [](const process_expression& x) { return atermpp::down_cast<merge>(x).right(); });
+  return result;
+}
+
+/// \brief Returns || applied to the sequence of process expressions [first, last).
+/// \param first Start of a sequence of process expressions.
+/// \param last End of a sequence of of process expressions.
+/// \return The choice operator applied to the sequence of process expressions [first, last).
+template <typename FwdIt>
+process_expression join_merge(FwdIt first, FwdIt last)
+{
+  const process_expression delta_ = delta();
+  return utilities::detail::join(
+      first,
+      last,
+      [](const process_expression& x, const process_expression& y) { return merge(x, y); },
+      delta_);
+}
+
 } // namespace process
 
 } // namespace mcrl2

--- a/libraries/process/include/mcrl2/process/multi_action_name.h
+++ b/libraries/process/include/mcrl2/process/multi_action_name.h
@@ -20,17 +20,7 @@ namespace mcrl2 {
 namespace process {
 
 /// \brief Represents the name of a multi action
-struct multi_action_name: public std::multiset<core::identifier_string>
-{
-  typedef std::multiset<core::identifier_string> super;
-
-  multi_action_name() = default;
-
-  template <typename InputIterator>
-  multi_action_name(InputIterator first, InputIterator last)
-    : super(first, last)
-  {}
-};
+typedef std::multiset<core::identifier_string> multi_action_name;
 
 /// \brief Represents a set of multi action names
 typedef std::set<multi_action_name> multi_action_name_set;

--- a/tools/release/mcrl22lps/mcrl22lps.cpp
+++ b/tools/release/mcrl22lps/mcrl22lps.cpp
@@ -124,6 +124,9 @@ class mcrl22lps_tool : public rewriter_tool< input_output_tool >
       desc.add_option("balance-summands",
                       "transform inputs expressions p1 + ... + pn into a balanced tree before "
                       "linearising. Sometimes helpful in preventing stack overflow.");
+      desc.add_option("balance-merge",
+          "transform inputs expressions p1 || ... || pn into a balanced tree before "
+          "linearising. Sometimes helpful in preventing stack overflow.");
     }
 
     void parse_options(const mcrl2::utilities::command_line_parser& parser)
@@ -145,6 +148,7 @@ class mcrl22lps_tool : public rewriter_tool< input_output_tool >
       m_linearisation_options.do_not_apply_constelm   = 0 < parser.options.count("no-constelm") ||
                                                         0 < parser.options.count("no-rewrite");
       m_linearisation_options.balance_summands        = 0 < parser.options.count("balance-summands");
+      m_linearisation_options.balance_merge           = 0 < parser.options.count("balance-merge");
 
       m_linearisation_options.lin_method = parser.option_argument_as< mcrl2::lps::t_lin_method >("lin-method");
 


### PR DESCRIPTION
Before applying alphabet reductions, in this commit we balance the term structure for parallel composition. When having p1 || ... || pn, this results in a term structure of depth log_2(n), instead of n.

I have observed 10% speed increases in mcrl22lps on some examples due to this change.

If desired, we could make this an option of mcrl22lps, similar to --balance-summands.