### PR TITLE
Implemented impossible-futures preorder checking in ltscompare

### DIFF
--- a/libraries/atermpp/include/mcrl2/atermpp/detail/aterm_container.h
+++ b/libraries/atermpp/include/mcrl2/atermpp/detail/aterm_container.h
@@ -440,7 +440,7 @@ class generic_aterm_container
 public:
   /// \brief Constructor
   generic_aterm_container(const Container& container)
-   : m_container(std::bind([&container](term_mark_stack& todo) {   
+   : m_container([&container](term_mark_stack& todo) {   
       // Marking contained terms.       
       for (const typename Container::value_type& element: container) 
       {
@@ -455,12 +455,12 @@ public:
           static_assert(!is_reference_aterm<typename Container::value_type >::value);
           reference_aterm<typename Container::value_type>(element).mark(todo);
         }
-      }        
-     }, std::placeholders::_1),
-     std::bind([&container]() -> std::size_t {  
+      }
+    },
+    [&container]() -> std::size_t {  
       // Return the number of elements in the container.
       return container.size();
-     }))
+     })
   {}
 
   // Container is a reference so unclear what to do in these cases.

--- a/libraries/lts/include/mcrl2/lts/detail/liblts_failures_refinement.h
+++ b/libraries/lts/include/mcrl2/lts/detail/liblts_failures_refinement.h
@@ -496,6 +496,27 @@ inline bool antichain_include(anti_chain_type& anti_chain,
   return false;
 }
 
+inline bool antichain_include_inverse(anti_chain_type& anti_chain,
+  const detail::state_type& impl,
+  const detail::set_of_states& spec)
+{
+  // First check whether there is a set in the antichain for impl_spec.state() which is smaller than impl_spec.states().
+  // If so, impl_spec.states() is included in the antichain.
+  for (anti_chain_type::const_iterator i = anti_chain.lower_bound(impl);
+       i != anti_chain.upper_bound(impl);
+       ++i)
+  {
+    const set_of_states s = i->second;
+    // If s is included in impl_spec.states()
+    if (std::includes(s.begin(), s.end(), spec.begin(), spec.end()))
+    {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 /* This function implements the insertion of <p,state(), p.states()> in the anti_chain.
    Concretely, this means that p.states() is inserted among the sets s1,...,sn associated to p.state().
    It is important that an anti_chain contains for each state a set of states of which

--- a/libraries/lts/include/mcrl2/lts/detail/liblts_failures_refinement.h
+++ b/libraries/lts/include/mcrl2/lts/detail/liblts_failures_refinement.h
@@ -12,208 +12,189 @@
 // M. Laveaux, J.F. Groote and T.A.C. Willemse
 // Correct and Efficient Antichain Algorithms for Refinement Checking. Logical Methods in Computer Science 17(1) 2021
 //
-// There are six algorithms. One for trace inclusion, one for failures inclusion and one for failures-divergence inclusion.
-// All algorithms come in a variant with and without internal steps.
-// It is possible to generate a counter transition system in case the inclusion is answered by no.
+// There are six algorithms. One for trace inclusion, one for failures inclusion and one for failures-divergence
+// inclusion. All algorithms come in a variant with and without internal steps. It is possible to generate a counter
+// transition system in case the inclusion is answered by no.
 
 #ifndef LIBLTS_FAILURES_REFINEMENT_H
 #define LIBLTS_FAILURES_REFINEMENT_H
 
-#include "mcrl2/lts/detail/counter_example.h"
 #include "mcrl2/lps/exploration_strategy.h"
+#include "mcrl2/lts/detail/counter_example.h"
 #include "mcrl2/lts/detail/liblts_bisim_dnj.h"
 
-namespace mcrl2
+namespace mcrl2::lts 
 {
-namespace lts
-{
+  
 namespace detail
 {
-  typedef std::size_t state_type;
-  typedef std::size_t label_type;
-  typedef std::set<state_type> set_of_states;
-  typedef std::multimap <detail::state_type,detail::set_of_states> anti_chain_type;
-  typedef std::set < label_type > action_label_set;
 
-  template < class COUNTER_EXAMPLE_CONSTRUCTOR >
-  class state_states_counter_example_index_triple
+typedef std::size_t state_type;
+typedef std::size_t label_type;
+typedef std::set<state_type> set_of_states;
+typedef std::multimap<detail::state_type, detail::set_of_states> anti_chain_type;
+typedef std::set<label_type> action_label_set;
+
+template <class COUNTER_EXAMPLE_CONSTRUCTOR>
+class state_states_counter_example_index_triple
+{
+protected:
+  detail::state_type m_state;
+  detail::set_of_states m_states;
+  typename COUNTER_EXAMPLE_CONSTRUCTOR::index_type m_counter_example_index;
+
+public:
+  state_states_counter_example_index_triple() {}
+
+  /// \brief Constructor.
+  state_states_counter_example_index_triple(const state_type state,
+      const set_of_states& states,
+      const typename COUNTER_EXAMPLE_CONSTRUCTOR::index_type& counter_example_index)
+      : m_state(state),
+        m_states(states),
+        m_counter_example_index(counter_example_index)
+  {}
+
+  /// \brief Get the state.
+  state_type state() const { return m_state; }
+
+  void swap(state_states_counter_example_index_triple& other)
   {
-    protected:
-      detail::state_type m_state;
-      detail::set_of_states m_states;
-      typename COUNTER_EXAMPLE_CONSTRUCTOR::index_type m_counter_example_index;
+    std::swap(m_state, other.m_state);
+    std::swap(m_states, other.m_states);
+    std::swap(m_counter_example_index, other.m_counter_example_index);
+  }
 
-    public:
-      state_states_counter_example_index_triple()
-      {}
+  /// \brief Get the set of states.
+  const set_of_states& states() const { return m_states; }
 
-      /// \brief Constructor.
-      state_states_counter_example_index_triple(
-              const state_type state,
-              const set_of_states& states,
-              const typename COUNTER_EXAMPLE_CONSTRUCTOR::index_type& counter_example_index)
-       : m_state(state),
-         m_states(states),
-         m_counter_example_index(counter_example_index)
-      {}
-
-      /// \brief Get the state.
-      state_type state() const
-      {
-        return m_state;
-      }
-
-      void swap(state_states_counter_example_index_triple& other)
-      {
-        std::swap(m_state,other.m_state);
-        std::swap(m_states,other.m_states);
-        std::swap(m_counter_example_index,other.m_counter_example_index);
-      }
-
-      /// \brief Get the set of states.
-      const set_of_states& states() const
-      {
-        return m_states;
-      }
-
-      /// \brief Get the counter example index.
-      const typename COUNTER_EXAMPLE_CONSTRUCTOR::index_type& counter_example_index() const
-      {
-        return m_counter_example_index;
-      }
-  };
-
-  template <  class COUNTER_EXAMPLE_CONSTRUCTOR >
-  inline bool antichain_insert(
-                  anti_chain_type& anti_chain,
-                  const state_states_counter_example_index_triple<COUNTER_EXAMPLE_CONSTRUCTOR>& impl_spec);
-
-  // The class below recalls what the stable states and the states with a divergent
-  // self loop of a transition system are, such that it does not have to be recalculated each time again.
-  template < class LTS_TYPE >
-  class lts_cache
+  /// \brief Get the counter example index.
+  const typename COUNTER_EXAMPLE_CONSTRUCTOR::index_type& counter_example_index() const
   {
-    protected:
-      LTS_TYPE& m_l;
-      std::vector<std::vector<state_type> > m_tau_reachable_states;
-      std::vector<std::vector<transition> > m_sorted_transitions;
-      std::vector<bool> m_divergent;
-      std::vector<action_label_set> m_enabled_actions;
+    return m_counter_example_index;
+  }
+};
 
-    private:
-      void calculate_weak_property_cache(const bool weak_reduction)
+template <class COUNTER_EXAMPLE_CONSTRUCTOR>
+inline bool antichain_insert(anti_chain_type& anti_chain,
+    const state_states_counter_example_index_triple<COUNTER_EXAMPLE_CONSTRUCTOR>& impl_spec);
+
+// The class below recalls what the stable states and the states with a divergent
+// self loop of a transition system are, such that it does not have to be recalculated each time again.
+template <class LTS_TYPE>
+class lts_cache
+{
+protected:
+  LTS_TYPE& m_l;
+  std::vector<std::vector<state_type>> m_tau_reachable_states;
+  std::vector<std::vector<transition>> m_sorted_transitions;
+  std::vector<bool> m_divergent;
+  std::vector<action_label_set> m_enabled_actions;
+
+private:
+  void calculate_weak_property_cache(const bool weak_reduction)
+  {
+    scc_partitioner<LTS_TYPE> strongly_connected_component_partitioner(m_l);
+    for (const transition& t : m_l.get_transitions())
+    {
+      assert(t.from() < m_l.num_states());
+      if (m_l.is_tau(m_l.apply_hidden_label_map(t.label())) && weak_reduction)
       {
-        scc_partitioner<LTS_TYPE> strongly_connected_component_partitioner(m_l);
-        for(const transition& t: m_l.get_transitions())
-        {
-          assert(t.from()<m_l.num_states());
-          if (m_l.is_tau(m_l.apply_hidden_label_map(t.label())) && weak_reduction)
-          {
-            m_tau_reachable_states[t.from()].push_back(t.to());  // There is an outgoing tau.
-          }
-          m_sorted_transitions[t.from()].push_back(t);
-
-          if (weak_reduction && m_l.is_tau(m_l.apply_hidden_label_map(t.label())) &&
-              strongly_connected_component_partitioner.in_same_class(t.from(),t.to()))
-          {
-            m_divergent[t.from()]=true;  // There is a self loop.
-          }
-          m_enabled_actions[t.from()].insert(m_l.apply_hidden_label_map(t.label()));
-        }
+        m_tau_reachable_states[t.from()].push_back(t.to()); // There is an outgoing tau.
       }
+      m_sorted_transitions[t.from()].push_back(t);
 
-    public:
-
-      lts_cache(/* const */ LTS_TYPE& l, const bool weak_reduction)    /* l is not changed, but the use of the scc partitioner requires l to be non const */
-        : m_l(l),
-          m_tau_reachable_states(l.num_states()),
-          m_sorted_transitions(l.num_states()),
-          m_divergent(l.num_states(),false),
-          m_enabled_actions(l.num_states())
+      if (weak_reduction && m_l.is_tau(m_l.apply_hidden_label_map(t.label()))
+          && strongly_connected_component_partitioner.in_same_class(t.from(), t.to()))
       {
-        calculate_weak_property_cache(weak_reduction);
+        m_divergent[t.from()] = true; // There is a self loop.
       }
+      m_enabled_actions[t.from()].insert(m_l.apply_hidden_label_map(t.label()));
+    }
+  }
 
-      bool stable(const state_type s) const
-      {
-        return m_tau_reachable_states[s].size()==0;
-      }
+public:
 
-      const std::vector<state_type>& tau_reachable_states(const state_type s) const
-      {
-        return m_tau_reachable_states[s];
-      }
+  lts_cache(/* const */ LTS_TYPE& l,
+      const bool weak_reduction) /* l is not changed, but the use of the scc partitioner requires l to be non const */
+      : m_l(l),
+        m_tau_reachable_states(l.num_states()),
+        m_sorted_transitions(l.num_states()),
+        m_divergent(l.num_states(), false),
+        m_enabled_actions(l.num_states())
+  {
+    calculate_weak_property_cache(weak_reduction);
+  }
 
-      const std::vector<transition>& transitions(const state_type s) const
-      {
-        assert(s<m_sorted_transitions.size());
-        return m_sorted_transitions[s];
-      }
+  bool stable(const state_type s) const { return m_tau_reachable_states[s].size() == 0; }
 
-      bool diverges(const state_type s) const
-      {
-        return m_divergent[s];
-      }
+  const std::vector<state_type>& tau_reachable_states(const state_type s) const { return m_tau_reachable_states[s]; }
 
-      const action_label_set& action_labels(const state_type s) const
-      {
-        return m_enabled_actions[s];
-      }
-  };
+  const std::vector<transition>& transitions(const state_type s) const
+  {
+    assert(s < m_sorted_transitions.size());
+    return m_sorted_transitions[s];
+  }
 
-  template < class LTS_TYPE >
-  set_of_states collect_reachable_states_via_taus(
-                 const state_type s,
-                 const lts_cache<LTS_TYPE>& weak_property_cache,
-                 const bool weak_reduction);
+  bool diverges(const state_type s) const { return m_divergent[s]; }
 
-  template < class LTS_TYPE >
-  set_of_states collect_reachable_states_via_an_action(
-                 const state_type s,
-                 const label_type e,
-                 const lts_cache<LTS_TYPE>& weak_property_cache,
-                 const bool weak_reduction,
-                 const LTS_TYPE& l);
+  const action_label_set& action_labels(const state_type s) const { return m_enabled_actions[s]; }
+};
 
-  template < class LTS_TYPE >
-  bool refusals_contained_in(
-              const state_type impl,
-              const set_of_states& spec,
-              const lts_cache<LTS_TYPE>& weak_property_cache,
-              label_type& culprit,
-              const LTS_TYPE& l,
-              const bool provide_a_counter_example,
-              const bool structured_output);
+template <class LTS_TYPE>
+set_of_states collect_reachable_states_via_taus(const state_type s,
+    const lts_cache<LTS_TYPE>& weak_property_cache,
+    const bool weak_reduction);
+
+template <class LTS_TYPE>
+set_of_states collect_reachable_states_via_an_action(const state_type s,
+    const label_type e,
+    const lts_cache<LTS_TYPE>& weak_property_cache,
+    const bool weak_reduction,
+    const LTS_TYPE& l);
+
+template <class LTS_TYPE>
+bool refusals_contained_in(const state_type impl,
+    const set_of_states& spec,
+    const lts_cache<LTS_TYPE>& weak_property_cache,
+    label_type& culprit,
+    const LTS_TYPE& l,
+    const bool provide_a_counter_example,
+    const bool structured_output);
 
 } // namespace detail
 
-enum class refinement_type { trace, failures, failures_divergence };
+enum class refinement_type
+{
+  trace,
+  failures,
+  failures_divergence
+};
 
-template<typename T>
+template <typename T>
 struct refinement_statistics
 {
-  refinement_statistics(detail::anti_chain_type& antichain, std::deque<T>& working) :
-    antichain(antichain),
-    working(working)
+  refinement_statistics(detail::anti_chain_type& antichain, std::deque<T>& working)
+      : antichain(antichain),
+        working(working)
   {}
 
   detail::anti_chain_type& antichain;
   std::deque<T>& working;
-  std::size_t max_working = 0; // The largest size of working.
-  std::size_t max_antichain = 0; // The largest size of the antichain.
-  std::size_t antichain_misses = 0; // Number of times a pair was inserted into the antichain.
+  std::size_t max_working = 0;       // The largest size of working.
+  std::size_t max_antichain = 0;     // The largest size of the antichain.
+  std::size_t antichain_misses = 0;  // Number of times a pair was inserted into the antichain.
   std::size_t antichain_inserts = 0; // Number of times antichain_insert was called.
 };
 
 /// \brief Print a message to debugging containing information about the given statistics.
-template<typename T>
+template <typename T>
 void report_statistics(refinement_statistics<T>& stats)
 {
   mCRL2log(log::debug) << "working (current: " << stats.working.size() << ", max: " << stats.max_working << ").\n";
   mCRL2log(log::debug) << "antichain (hits: " << stats.antichain_inserts - stats.antichain_misses
-      << ", misses: " << stats.antichain_misses
-      << ", size: " << stats.antichain.size()
-      << ", max: " << stats.max_antichain << ")\n";
+                       << ", misses: " << stats.antichain_misses << ", size: " << stats.antichain.size()
+                       << ", max: " << stats.max_antichain << ")\n";
 }
 
 /// \brief Preprocess the LTS for destructive refinement checking.
@@ -221,11 +202,9 @@ void report_statistics(refinement_statistics<T>& stats)
 /// \param init The initial state of the right LTS that was merged.
 /// \return A pair where the first element is the state number of init in the reduced
 ///         lts and the second value indicate whether this state in equal to lts.initial_state.
-template<typename LTS_TYPE>
-std::pair<std::size_t, bool> reduce(LTS_TYPE& lts,
-            const bool weak_reduction,
-            const bool preserve_divergence,
-            std::size_t l2_init)
+template <typename LTS_TYPE>
+std::pair<std::size_t, bool>
+reduce(LTS_TYPE& lts, const bool weak_reduction, const bool preserve_divergence, std::size_t l2_init)
 {
   lts.clear_state_labels();
   if (weak_reduction)
@@ -236,8 +215,7 @@ std::pair<std::size_t, bool> reduce(LTS_TYPE& lts,
     scc_part.replace_transition_system(preserve_divergence);
   }
 
-  detail::bisim_partitioner_dnj<LTS_TYPE> bisim_part(lts, weak_reduction,
-                                                          preserve_divergence);
+  detail::bisim_partitioner_dnj<LTS_TYPE> bisim_part(lts, weak_reduction, preserve_divergence);
   // Assign the reduced LTS, and set init_l2.
   l2_init = bisim_part.get_eq_class(l2_init);
   bisim_part.finalize_minimized_LTS();
@@ -251,21 +229,21 @@ std::pair<std::size_t, bool> reduce(LTS_TYPE& lts,
 /// inclusion.
 /// \param weak_reduction Remove inert tau loops.
 /// \param strategy Choose between breadth and depth first.
-/// \param preprocess Uses (divergence preserving) branching bisimulation and tau scc reduction to reduce the input LTSs.
-/// \param generate_counter_example If set, a labelled transition system is generated
+/// \param preprocess Uses (divergence preserving) branching bisimulation and tau scc reduction to reduce the input
+/// LTSs. \param generate_counter_example If set, a labelled transition system is generated
 ///        that can act as a counterexample. It consists of a trace, followed by
 ///        outgoing transitions representing a refusal set.
-template < class LTS_TYPE, class COUNTER_EXAMPLE_CONSTRUCTOR = detail::dummy_counter_example_constructor >
-bool destructive_refinement_checker(
-                        LTS_TYPE& l1,
-                        LTS_TYPE& l2,
-                        const refinement_type refinement,
-                        const bool weak_reduction,
-                        const lps::exploration_strategy strategy,
-                        const bool preprocess = true,
-                        COUNTER_EXAMPLE_CONSTRUCTOR generate_counter_example = detail::dummy_counter_example_constructor())
+template <class LTS_TYPE, class COUNTER_EXAMPLE_CONSTRUCTOR = detail::dummy_counter_example_constructor>
+bool destructive_refinement_checker(LTS_TYPE& l1,
+    LTS_TYPE& l2,
+    const refinement_type refinement,
+    const bool weak_reduction,
+    const lps::exploration_strategy strategy,
+    const bool preprocess = true,
+    COUNTER_EXAMPLE_CONSTRUCTOR generate_counter_example = detail::dummy_counter_example_constructor())
 {
-  assert(strategy == lps::exploration_strategy::es_breadth || strategy == lps::exploration_strategy::es_depth); // Need a valid strategy.
+  assert(strategy == lps::exploration_strategy::es_breadth
+         || strategy == lps::exploration_strategy::es_depth); // Need a valid strategy.
 
   // For weak-failures and failures-divergence, the existence of tau loops make a difference.
   // Therefore, we apply bisimulation reduction preserving divergences.
@@ -303,63 +281,63 @@ bool destructive_refinement_checker(
 
   std::deque<detail::state_states_counter_example_index_triple<COUNTER_EXAMPLE_CONSTRUCTOR>> working;
   detail::anti_chain_type anti_chain;
-  refinement_statistics<detail::state_states_counter_example_index_triple<COUNTER_EXAMPLE_CONSTRUCTOR>> stats(anti_chain, working);
+  refinement_statistics<detail::state_states_counter_example_index_triple<COUNTER_EXAMPLE_CONSTRUCTOR>> stats(
+      anti_chain,
+      working);
   const detail::lts_cache<LTS_TYPE> weak_property_cache(l1, weak_reduction);
 
-
-  bool result = check_refinement(l1, 
-    weak_property_cache,
-    working,
-    stats,
-    anti_chain,
-    generate_counter_example,
-    l1.initial_state(),
-    init_l2,
-    refinement,
-    weak_reduction,
-    strategy);
+  bool result = check_refinement(l1,
+      weak_property_cache,
+      working,
+      stats,
+      anti_chain,
+      generate_counter_example,
+      l1.initial_state(),
+      init_l2,
+      refinement,
+      weak_reduction,
+      strategy);
   report_statistics(stats);
   return result;
 }
 
-template<typename LTS_TYPE,
-  typename COUNTER_EXAMPLE_CONSTRUCTOR>
-bool check_refinement( 
-  LTS_TYPE& l1,
-  const detail::lts_cache<LTS_TYPE>& weak_property_cache,
-  std::deque<detail::state_states_counter_example_index_triple<COUNTER_EXAMPLE_CONSTRUCTOR>>& working,
-  refinement_statistics<detail::state_states_counter_example_index_triple<COUNTER_EXAMPLE_CONSTRUCTOR>>& stats,
-  detail::anti_chain_type& anti_chain,
-  COUNTER_EXAMPLE_CONSTRUCTOR& generate_counter_example,
-  detail::state_type init_l1,
-  detail::state_type init_l2,
-  const refinement_type refinement,
-  bool weak_reduction,
-  const lps::exploration_strategy strategy)
+template <typename LTS_TYPE, typename COUNTER_EXAMPLE_CONSTRUCTOR>
+bool check_refinement(LTS_TYPE& l1,
+    const detail::lts_cache<LTS_TYPE>& weak_property_cache,
+    std::deque<detail::state_states_counter_example_index_triple<COUNTER_EXAMPLE_CONSTRUCTOR>>& working,
+    refinement_statistics<detail::state_states_counter_example_index_triple<COUNTER_EXAMPLE_CONSTRUCTOR>>& stats,
+    detail::anti_chain_type& anti_chain,
+    COUNTER_EXAMPLE_CONSTRUCTOR& generate_counter_example,
+    detail::state_type init_l1,
+    detail::state_type init_l2,
+    const refinement_type refinement,
+    bool weak_reduction,
+    const lps::exploration_strategy strategy)
 {
   // let working be a stack containg the triple (init1,{s|init2-->s},root_index);
   working.clear();
-  working.push_back({
-    detail::state_states_counter_example_index_triple<COUNTER_EXAMPLE_CONSTRUCTOR>(
-      init_l1,
+  working.push_back({detail::state_states_counter_example_index_triple<COUNTER_EXAMPLE_CONSTRUCTOR>(init_l1,
       detail::collect_reachable_states_via_taus(init_l2, weak_property_cache, weak_reduction),
       generate_counter_example.root_index())});
-    
+
   // let antichain := emptyset;
   anti_chain.clear();
-  detail::antichain_insert(anti_chain, working.front());   // antichain := antichain united with (impl,spec);
-                                                           // This line occurs at another place in the code than in
-                                                           // the original algorithm, where insertion in the anti-chain
-                                                           // was too late, causing too many impl-spec pairs to be investigated.
+  detail::antichain_insert(anti_chain,
+      working.front()); // antichain := antichain united with (impl,spec);
+                        // This line occurs at another place in the code than in
+                        // the original algorithm, where insertion in the anti-chain
+                        // was too late, causing too many impl-spec pairs to be investigated.
 
-  while (!working.empty())                            // while working!=empty
+  while (!working.empty()) // while working!=empty
   {
-    detail::state_states_counter_example_index_triple < COUNTER_EXAMPLE_CONSTRUCTOR > impl_spec;   // pop (impl,spec) from working;
+    detail::state_states_counter_example_index_triple<COUNTER_EXAMPLE_CONSTRUCTOR>
+        impl_spec; // pop (impl,spec) from working;
     impl_spec.swap(working.front());
-    stats.max_working   = std::max(working.size(), stats.max_working);
+    stats.max_working = std::max(working.size(), stats.max_working);
     stats.max_antichain = std::max(anti_chain.size(), stats.max_antichain);
-    working.pop_front();     // At this point it could be checked whether impl_spec still exists in anti_chain.
-                             // Small scale experiments show that this is a little bit more expensive than doing the explicit check below.
+    working.pop_front(); // At this point it could be checked whether impl_spec still exists in anti_chain.
+                         // Small scale experiments show that this is a little bit more expensive than doing the
+                         // explicit check below.
 
     bool spec_diverges = false;
     if (refinement == refinement_type::failures_divergence)
@@ -378,219 +356,240 @@ bool check_refinement(
     // if not diverges(spec) or not CheckDiv (refinement == failures_divergence_preorder)
     if (!spec_diverges || refinement != refinement_type::failures_divergence)
     {
-      if (weak_property_cache.diverges(impl_spec.state()) && refinement == refinement_type::failures_divergence) // if impl diverges and CheckDiv
+      if (weak_property_cache.diverges(impl_spec.state())
+          && refinement == refinement_type::failures_divergence) // if impl diverges and CheckDiv
       {
-        generate_counter_example.save_counter_example(impl_spec.counter_example_index(),l1);
+        generate_counter_example.save_counter_example(impl_spec.counter_example_index(), l1);
         report_statistics(stats);
-        return false;  // return false;
+        return false; // return false;
       }
 
       if (refinement == refinement_type::failures || refinement == refinement_type::failures_divergence)
       {
-        detail::label_type offending_action=std::size_t(-1);
+        detail::label_type offending_action = std::size_t(-1);
         // if refusals(impl) not contained in refusals(spec) then
         if (!detail::refusals_contained_in(impl_spec.state(),
-                                           impl_spec.states(),
-                                           weak_property_cache,
-                                           offending_action,
-                                           l1,
-                                           !generate_counter_example.is_dummy(),
-                                           generate_counter_example.is_structured()))
+                impl_spec.states(),
+                weak_property_cache,
+                offending_action,
+                l1,
+                !generate_counter_example.is_dummy(),
+                generate_counter_example.is_structured()))
         {
           generate_counter_example.save_counter_example(impl_spec.counter_example_index(), l1);
           report_statistics(stats);
-          return false;                               // return false;
+          return false; // return false;
         }
       }
 
-      for(const transition& t: weak_property_cache.transitions(impl_spec.state()))
+      for (const transition& t : weak_property_cache.transitions(impl_spec.state()))
       {
-        const typename COUNTER_EXAMPLE_CONSTRUCTOR::index_type new_counterexample_index=
-               generate_counter_example.add_transition(t.label(),impl_spec.counter_example_index());
+        const typename COUNTER_EXAMPLE_CONSTRUCTOR::index_type new_counterexample_index
+            = generate_counter_example.add_transition(t.label(), impl_spec.counter_example_index());
         detail::set_of_states spec_prime;
-        if (l1.is_tau(l1.apply_hidden_label_map(t.label())) && weak_reduction)                   // if e=tau then
+        if (l1.is_tau(l1.apply_hidden_label_map(t.label())) && weak_reduction) // if e=tau then
         {
-          spec_prime=impl_spec.states();        // spec' := spec;
+          spec_prime = impl_spec.states(); // spec' := spec;
         }
         else
-        {                                           // spec' := {s' | exists s in spec. s-e->s'};
-          for(const detail::state_type s: impl_spec.states())
+        { // spec' := {s' | exists s in spec. s-e->s'};
+          for (const detail::state_type s : impl_spec.states())
           {
-            detail::set_of_states reachable_states_from_s_via_e=
-                    detail::collect_reachable_states_via_an_action(s,l1.apply_hidden_label_map(t.label()),weak_property_cache,weak_reduction,l1);
-            spec_prime.insert(reachable_states_from_s_via_e.begin(),reachable_states_from_s_via_e.end());
+            detail::set_of_states reachable_states_from_s_via_e = detail::collect_reachable_states_via_an_action(s,
+                l1.apply_hidden_label_map(t.label()),
+                weak_property_cache,
+                weak_reduction,
+                l1);
+            spec_prime.insert(reachable_states_from_s_via_e.begin(), reachable_states_from_s_via_e.end());
           }
         }
-        if (spec_prime.empty())                     // if spec'={} then
+        if (spec_prime.empty()) // if spec'={} then
         {
-          generate_counter_example.save_counter_example(new_counterexample_index,l1);
+          generate_counter_example.save_counter_example(new_counterexample_index, l1);
           report_statistics(stats);
-          return false;                             //    return false;
+          return false; //    return false;
         }
-                                                    // if (impl',spec') in antichain is not true then
+        // if (impl',spec') in antichain is not true then
         ++stats.antichain_inserts;
-        const detail::state_states_counter_example_index_triple < COUNTER_EXAMPLE_CONSTRUCTOR >
-                          impl_spec_counterex(t.to(),spec_prime,new_counterexample_index);
+        const detail::state_states_counter_example_index_triple<COUNTER_EXAMPLE_CONSTRUCTOR> impl_spec_counterex(t.to(),
+            spec_prime,
+            new_counterexample_index);
         if (detail::antichain_insert(anti_chain, impl_spec_counterex))
         {
           ++stats.antichain_misses;
           if (strategy == lps::exploration_strategy::es_breadth)
           {
-            working.push_back(impl_spec_counterex);   // add(impl,spec') at the bottom of the working;
+            working.push_back(impl_spec_counterex); // add(impl,spec') at the bottom of the working;
           }
           else if (strategy == lps::exploration_strategy::es_depth)
           {
-            working.push_front(impl_spec_counterex);   // push(impl,spec') into working;
+            working.push_front(impl_spec_counterex); // push(impl,spec') into working;
           }
         }
       }
     }
   }
 
-  return true;                                      // return true;
+  return true; // return true;
 }
-
 
 namespace detail
 {
-  /* This function generates the set of states reachable from s within labelled
-     transition system l1 by internal transitions, provided weak_reduction is true.
-     Otherwise it generates a set with only state s in it.
-  */
-  template < class LTS_TYPE >
-  set_of_states collect_reachable_states_via_taus(
-              const set_of_states& s,
-              const lts_cache<LTS_TYPE>& weak_property_cache,
-              const bool weak_reduction)
+/* This function generates the set of states reachable from s within labelled
+   transition system l1 by internal transitions, provided weak_reduction is true.
+   Otherwise it generates a set with only state s in it.
+*/
+template <class LTS_TYPE>
+set_of_states collect_reachable_states_via_taus(const set_of_states& s,
+    const lts_cache<LTS_TYPE>& weak_property_cache,
+    const bool weak_reduction)
+{
+  set_of_states result(s);
+  if (!weak_reduction)
   {
-    set_of_states result(s);
-    if (!weak_reduction)
-    {
-      return result;
-    }
-    set_of_states visited(s);
-    std::deque<state_type> todo_stack(s.begin(),s.end());
-    while (todo_stack.size()>0)
-    {
-      state_type current_state=todo_stack.front();
-      todo_stack.pop_front();
-      for(const state_type s: weak_property_cache.tau_reachable_states(current_state))
-      {
-        if (visited.insert(s).second)  // The element has been inserted.
-        {
-          todo_stack.push_back(s);
-          result.insert(s);
-        }
-      }
-    }
-
     return result;
   }
-
-  template < class LTS_TYPE >
-  set_of_states collect_reachable_states_via_taus(
-                  const state_type s,
-                  const lts_cache<LTS_TYPE>& weak_property_cache,
-                  const bool weak_reduction)
+  set_of_states visited(s);
+  std::deque<state_type> todo_stack(s.begin(), s.end());
+  while (todo_stack.size() > 0)
   {
-    set_of_states set_with_s({s});
-    return collect_reachable_states_via_taus(set_with_s, weak_property_cache, weak_reduction);
+    state_type current_state = todo_stack.front();
+    todo_stack.pop_front();
+    for (const state_type s : weak_property_cache.tau_reachable_states(current_state))
+    {
+      if (visited.insert(s).second) // The element has been inserted.
+      {
+        todo_stack.push_back(s);
+        result.insert(s);
+      }
+    }
   }
 
-  template < class LTS_TYPE >
-  set_of_states collect_reachable_states_via_an_action(
-                 const state_type s,
-                 const label_type e,  // This is already the hidden action.
-                 const lts_cache<LTS_TYPE>& weak_property_cache,
-                 const bool weak_reduction,
-                 const LTS_TYPE& l)
+  return result;
+}
+
+template <class LTS_TYPE>
+set_of_states collect_reachable_states_via_taus(const state_type s,
+    const lts_cache<LTS_TYPE>& weak_property_cache,
+    const bool weak_reduction)
+{
+  set_of_states set_with_s({s});
+  return collect_reachable_states_via_taus(set_with_s, weak_property_cache, weak_reduction);
+}
+
+template <class LTS_TYPE>
+set_of_states collect_reachable_states_via_an_action(const state_type s,
+    const label_type e, // This is already the hidden action.
+    const lts_cache<LTS_TYPE>& weak_property_cache,
+    const bool weak_reduction,
+    const LTS_TYPE& l)
+{
+  const set_of_states set_before_action_e = collect_reachable_states_via_taus(s, weak_property_cache, weak_reduction);
+  set_of_states states_reachable_via_e;
+  for (const state_type s : set_before_action_e)
   {
-    const set_of_states set_before_action_e=collect_reachable_states_via_taus(s,weak_property_cache,weak_reduction);
-    set_of_states states_reachable_via_e;
-    for(const state_type s: set_before_action_e)
+    for (const transition& t : weak_property_cache.transitions(s))
     {
-      for(const transition& t: weak_property_cache.transitions(s))
       {
+        if (l.apply_hidden_label_map(t.label()) == e)
         {
-          if (l.apply_hidden_label_map(t.label())==e)
-          {
-            assert(set_before_action_e.count(t.from())>0);
-            states_reachable_via_e.insert(t.to());
-          }
+          assert(set_before_action_e.count(t.from()) > 0);
+          states_reachable_via_e.insert(t.to());
         }
       }
     }
-    return collect_reachable_states_via_taus(states_reachable_via_e, weak_property_cache, weak_reduction);
+  }
+  return collect_reachable_states_via_taus(states_reachable_via_e, weak_property_cache, weak_reduction);
+}
+
+/* This function implements the insertion of <p,state(), p.states()> in the anti_chain.
+   Concretely, this means that p.states() is inserted among the sets s1,...,sn associated to p.state().
+   It is important that an anti_chain contains for each state a set of states of which
+   no set is a subset of another. The idea is that if such two sets occur, it is enough
+   to keep the smallest.
+   If p.states() is smaller than a set si associated to p.state(), this set is removed.
+   If p.states() is larger than a set si, there is no need to add p.states(), as a better candidate
+   is already there.
+   This function returns true if insertion was succesful, and false otherwise.
+ */
+template <class COUNTER_EXAMPLE_CONSTRUCTOR>
+inline bool antichain_insert(anti_chain_type& anti_chain,
+    const state_states_counter_example_index_triple<COUNTER_EXAMPLE_CONSTRUCTOR>& impl_spec)
+{
+  // First check whether there is a set in the antichain for impl_spec.state() which is smaller than impl_spec.states().
+  // If so, impl_spec.states() does not have to be inserted in the anti_chain.
+  for (anti_chain_type::const_iterator i = anti_chain.lower_bound(impl_spec.state());
+       i != anti_chain.upper_bound(impl_spec.state());
+       ++i)
+  {
+    const set_of_states s = i->second;
+    // If s is included in impl_spec.states()
+    if (std::includes(impl_spec.states().begin(), impl_spec.states().end(), s.begin(), s.end()))
+    {
+      return false;
+    }
   }
 
-  /* This function implements the insertion of <p,state(), p.states()> in the anti_chain.
-     Concretely, this means that p.states() is inserted among the sets s1,...,sn associated to p.state().
-     It is important that an anti_chain contains for each state a set of states of which
-     no set is a subset of another. The idea is that if such two sets occur, it is enough
-     to keep the smallest.
-     If p.states() is smaller than a set si associated to p.state(), this set is removed.
-     If p.states() is larger than a set si, there is no need to add p.states(), as a better candidate
-     is already there.
-     This function returns true if insertion was succesful, and false otherwise.
-   */
-  template <  class COUNTER_EXAMPLE_CONSTRUCTOR >
-  inline bool antichain_insert(
-                  anti_chain_type& anti_chain,
-                  const state_states_counter_example_index_triple<COUNTER_EXAMPLE_CONSTRUCTOR>& impl_spec)
+  // Here impl_spec.states() must be inserted in the antichain. Moreover, all sets in the antichain that
+  // are a superset of impl_spec.states() must be removed.
+  for (anti_chain_type::iterator i = anti_chain.lower_bound(impl_spec.state());
+       i != anti_chain.upper_bound(impl_spec.state());)
   {
-    // First check whether there is a set in the antichain for impl_spec.state() which is smaller than impl_spec.states().
-    // If so, impl_spec.states() does not have to be inserted in the anti_chain.
-    for(anti_chain_type::const_iterator i=anti_chain.lower_bound(impl_spec.state()); i!=anti_chain.upper_bound(impl_spec.state()); ++i)
+    const set_of_states s = i->second;
+    // if s is a superset of impl_spec.states()
+    // if (std::includes(impl_spec.states().begin(),impl_spec.states().end(),s.begin(),s.end()))
+    if (std::includes(s.begin(), s.end(), impl_spec.states().begin(), impl_spec.states().end()))
     {
-      const set_of_states s=i->second;
-      // If s is included in impl_spec.states()
-      if (std::includes(impl_spec.states().begin(), impl_spec.states().end(), s.begin(),s.end()))
-      {
-        return false;
-      }
+      // set s must be removed.
+      i = anti_chain.erase(i);
     }
+    else
+    {
+      ++i;
+    }
+  }
+  anti_chain.insert(std::pair<detail::state_type, detail::set_of_states>(impl_spec.state(), impl_spec.states()));
+  return true;
+}
 
-    // Here impl_spec.states() must be inserted in the antichain. Moreover, all sets in the antichain that
-    // are a superset of impl_spec.states() must be removed.
-    for(anti_chain_type::iterator i=anti_chain.lower_bound(impl_spec.state()); i!=anti_chain.upper_bound(impl_spec.state()); )
-    {
-      const set_of_states s=i->second;
-      // if s is a superset of impl_spec.states()
-      // if (std::includes(impl_spec.states().begin(),impl_spec.states().end(),s.begin(),s.end()))
-      if (std::includes(s.begin(), s.end(), impl_spec.states().begin(),impl_spec.states().end()))
-      {
-        // set s must be removed.
-        i=anti_chain.erase(i);
-      }
-      else
-      {
-        ++i;
-      }
-    }
-    anti_chain.insert(std::pair<detail::state_type,detail::set_of_states>(impl_spec.state(),impl_spec.states()));
-    return true;
+/* Calculate the states that are stable and reachable through tau-steps */
+template <class LTS_TYPE>
+const set_of_states& calculate_tau_reachable_states(const set_of_states& states,
+    const lts_cache<LTS_TYPE>& weak_property_cache)
+{
+  static std::map<set_of_states, set_of_states> cache;
+  const std::map<set_of_states, set_of_states>::const_iterator i = cache.find(states);
+  if (i != cache.end())
+  {
+    return i->second;
   }
 
-  /* Calculate the states that are stable and reachable through tau-steps */
-  template < class LTS_TYPE >
-  const set_of_states& calculate_tau_reachable_states(
-        const set_of_states& states,
-        const lts_cache<LTS_TYPE>& weak_property_cache)
+  static set_of_states visited;
+  assert(visited.empty());
+  static std::stack<state_type> todo_stack;
+  assert(todo_stack.empty());
+  set_of_states result;
+
+  for (const state_type s : states)
   {
-    static std::map<set_of_states, set_of_states> cache;
-    const std::map<set_of_states, set_of_states>::const_iterator i=cache.find(states);
-    if (i!=cache.end())
+    if (weak_property_cache.stable(s))
     {
-      return i->second;
+      // Put the outgoing action labels in a set and put these in the result.
+      result.insert(s);
     }
+    else
+    {
+      visited.insert(s);
+      todo_stack.push(s);
+    }
+  }
 
-    static set_of_states visited;
-    assert(visited.empty());
-    static std::stack < state_type > todo_stack;
-    assert(todo_stack.empty());
-    set_of_states result;
-
-    for(const state_type s: states)
+  while (todo_stack.size() > 0)
+  {
+    const state_type current_state = todo_stack.top();
+    todo_stack.pop();
+    // Consider the states reachable in one tau step.
+    for (const state_type s : weak_property_cache.tau_reachable_states(current_state))
     {
       if (weak_property_cache.stable(s))
       {
@@ -599,116 +598,162 @@ namespace detail
       }
       else
       {
-        visited.insert(s);
-        todo_stack.push(s);
+        if (visited.insert(s).second) // t.to() is a new state.
+        {
+          todo_stack.push(s);
+        }
       }
+    }
+  }
+  cache[states] = result;
+  visited.clear();
+  return cache[states];
+}
+
+/// \brief This function checks that the refusals(impl) are contained in the refusals of spec, where
+///        the refusals of spec are defined by { r | exists s in spec. r in refusals(s) and stable(r) }.
+/// \details This is equivalent to saying that for all enabled actions of impl it must be contained in the enabled
+/// actions
+///          of every stable state in spec.
+///          If enable(t') is not included in enable(s'), their is a problematic action a. This action is returned as
+///          "culprit". It can be used to construct an extended counterexample.
+template <class LTS_TYPE>
+bool refusals_contained_in(const state_type impl,
+    const set_of_states& spec,
+    const lts_cache<LTS_TYPE>& weak_property_cache,
+    label_type& culprit,
+    const LTS_TYPE& l,
+    const bool provide_a_counter_example,
+    const bool structured_output)
+{
+  if (!weak_property_cache.stable(impl))
+    return true; // Checking in case of instability is not necessary, but rather time consuming.
+
+  const action_label_set& impl_action_labels = weak_property_cache.action_labels(impl);
+  bool success = false;
+
+  // Compare the obtained enable set of s' with all those of the specification.
+  for (const state_type s : spec)
+  {
+    // Only stable states in this set should be checked.
+    if (!weak_property_cache.stable(s))
+    {
+      continue;
     }
 
-    while (todo_stack.size()>0)
+    // Check whether the enabled actions of spec are included in the enabled actions of impl.
+    // This is equivalent to checking that all spec_action_labels are in the impl_enabled_action_set.
+    const action_label_set& spec_action_labels = weak_property_cache.action_labels(s);
+
+    // Warning: std::includes checks whether the second range is included in the first.
+    bool inclusion_success = std::includes(impl_action_labels.begin(),
+        impl_action_labels.end(),
+        spec_action_labels.begin(),
+        spec_action_labels.end());
+    if (inclusion_success)
     {
-      const state_type current_state=todo_stack.top();
-      todo_stack.pop();
-      // Consider the states reachable in one tau step.
-      for(const state_type s: weak_property_cache.tau_reachable_states(current_state))
+      success = true;
+      break;
+    }
+    else
+    {
+      // Find the offending action.
+      for (const label_type a : spec_action_labels)
       {
-        if (weak_property_cache.stable(s))
+        if (impl_action_labels.count(a) == 0) // We want to know which action caused the problem.
         {
-          // Put the outgoing action labels in a set and put these in the result.
-          result.insert(s);
-        }
-        else
-        {
-          if (visited.insert(s).second) // t.to() is a new state.
-          {
-            todo_stack.push(s);
-          }
+          culprit = a;
+          break;
         }
       }
     }
-    cache[states]=result;
-    visited.clear();
-    return cache[states];
   }
 
-  /// \brief This function checks that the refusals(impl) are contained in the refusals of spec, where
-  ///        the refusals of spec are defined by { r | exists s in spec. r in refusals(s) and stable(r) }.
-  /// \details This is equivalent to saying that for all enabled actions of impl it must be contained in the enabled actions
-  ///          of every stable state in spec.
-  ///          If enable(t') is not included in enable(s'), their is a problematic action a. This action is returned as "culprit".
-  ///          It can be used to construct an extended counterexample.
-  template < class LTS_TYPE >
-  bool refusals_contained_in(
-              const state_type impl,
-              const set_of_states& spec,
-              const lts_cache<LTS_TYPE>& weak_property_cache,
-              label_type& culprit,
-              const LTS_TYPE& l,
-              const bool provide_a_counter_example,
-              const bool structured_output)
+  if (!success && provide_a_counter_example)
   {
-    if (!weak_property_cache.stable(impl)) return true; // Checking in case of instability is not necessary, but rather time consuming.
-
-    const action_label_set& impl_action_labels = weak_property_cache.action_labels(impl);
-    bool success = false;
-
-    // Compare the obtained enable set of s' with all those of the specification.
-    for(const state_type s : spec)
+    // Print the acceptance set of the implementation
+    if (impl_action_labels.empty())
     {
-      // Only stable states in this set should be checked.
-      if (!weak_property_cache.stable(s)) { continue; }
-
-      // Check whether the enabled actions of spec are included in the enabled actions of impl.
-      // This is equivalent to checking that all spec_action_labels are in the impl_enabled_action_set.
-      const action_label_set& spec_action_labels = weak_property_cache.action_labels(s);
-
-      // Warning: std::includes checks whether the second range is included in the first.
-      bool inclusion_success = std::includes(impl_action_labels.begin(), impl_action_labels.end(),
-                                             spec_action_labels.begin(), spec_action_labels.end());
-      if (inclusion_success)
+      if (structured_output)
       {
-        success = true;
-        break;
+        std::cout << "left-acceptance:\n";
       }
       else
       {
-        // Find the offending action.
-        for(const label_type a : spec_action_labels)
+        mCRL2log(log::verbose) << "The acceptance of the left process is empty.\n";
+      }
+    }
+    else
+    {
+      if (structured_output)
+      {
+        std::cout << "left-acceptance: ";
+      }
+      else
+      {
+        mCRL2log(log::verbose) << "A stable acceptance set of the left process is:\n";
+      }
+      std::string sep = "";
+      for (const label_type a : impl_action_labels)
+      {
+        if (structured_output)
         {
-          if (impl_action_labels.count(a) == 0) // We want to know which action caused the problem.
-          {
-            culprit = a;
-            break;
-          }
+          std::cout << sep << l.action_label(a);
+          sep = ";";
         }
+        else
+        {
+          mCRL2log(log::verbose) << l.action_label(a) << "\n";
+        }
+      }
+      if (structured_output)
+      {
+        std::cout << "\n";
       }
     }
 
-    if (!success && provide_a_counter_example)
+    // Print the acceptance sets of the specification.
+    if (spec.empty())
     {
-      // Print the acceptance set of the implementation
-      if (impl_action_labels.empty())
+      if (structured_output)
       {
-        if (structured_output)
-        {
-          std::cout << "left-acceptance:\n";
-        }
-        else
-        {
-          mCRL2log(log::verbose) << "The acceptance of the left process is empty.\n";
-        }
+        std::cout << "right-acceptance-sets: 0\n";
       }
       else
       {
+        mCRL2log(log::verbose) << "The process at the right has no acceptance sets.\n";
+      }
+    }
+    else
+    {
+      set_of_states stable;
+      // Only the stable specification states contributed to this counter example.
+      std::copy_if(spec.begin(),
+          spec.end(),
+          std::inserter(stable, stable.end()),
+          [=](const state_type s) { return weak_property_cache.stable(s); });
+
+      if (structured_output)
+      {
+        std::cout << "right-acceptance-sets: " << stable.size() << "\n";
+      }
+      else
+      {
+        mCRL2log(log::verbose) << "Below all corresponding stable acceptance sets of the right process are provided:\n";
+      }
+      for (const state_type s : stable)
+      {
+        const action_label_set& spec_action_labels = weak_property_cache.action_labels(s);
         if (structured_output)
         {
-          std::cout << "left-acceptance: ";
+          std::cout << "right-acceptance: ";
         }
         else
         {
-          mCRL2log(log::verbose) << "A stable acceptance set of the left process is:\n";
+          mCRL2log(log::verbose) << "An acceptance set of the right process is:\n";
         }
         std::string sep = "";
-        for (const label_type a: impl_action_labels)
+        for (const label_type a : spec_action_labels)
         {
           if (structured_output)
           {
@@ -725,73 +770,16 @@ namespace detail
           std::cout << "\n";
         }
       }
-
-      // Print the acceptance sets of the specification.
-      if (spec.empty())
-      {
-        if (structured_output)
-        {
-          std::cout << "right-acceptance-sets: 0\n";
-        }
-        else
-        {
-          mCRL2log(log::verbose) << "The process at the right has no acceptance sets.\n";
-        }
-      }
-      else
-      {
-        set_of_states stable;
-        // Only the stable specification states contributed to this counter example.
-        std::copy_if(spec.begin(), spec.end(), std::inserter(stable,stable.end()), [=](const state_type s){return weak_property_cache.stable(s);});
-
-        if (structured_output)
-        {
-          std::cout << "right-acceptance-sets: " << stable.size () << "\n";
-        }
-        else
-        {
-          mCRL2log(log::verbose) << "Below all corresponding stable acceptance sets of the right process are provided:\n";
-        }
-        for (const state_type s: stable)
-        {
-          const action_label_set& spec_action_labels = weak_property_cache.action_labels(s);
-          if (structured_output)
-          {
-            std::cout << "right-acceptance: ";
-          }
-          else
-          {
-            mCRL2log(log::verbose) << "An acceptance set of the right process is:\n";
-          }
-          std::string sep = "";
-          for (const label_type a: spec_action_labels)
-          {
-            if (structured_output)
-            {
-              std::cout << sep << l.action_label(a);
-              sep = ";";
-            }
-            else
-            {
-              mCRL2log(log::verbose) << l.action_label(a) << "\n";
-            }
-          }
-          if (structured_output)
-          {
-            std::cout << "\n";
-          }
-        }
-      }
-      if (!structured_output)
-      {
-        mCRL2log(log::verbose) << "Finished printing acceptance sets.\n";
-      }
-      // Done printing acceptance sets.
     }
-
-    return success;
+    if (!structured_output)
+    {
+      mCRL2log(log::verbose) << "Finished printing acceptance sets.\n";
+    }
+    // Done printing acceptance sets.
   }
 
+  return success;
+}
 
 } // namespace detail
 } // namespace lts

--- a/libraries/lts/include/mcrl2/lts/detail/liblts_failures_refinement.h
+++ b/libraries/lts/include/mcrl2/lts/detail/liblts_failures_refinement.h
@@ -50,23 +50,15 @@ public:
 
   /// \brief Constructor.
   state_states_counter_example_index_triple(const state_type state,
-      const set_of_states& states,
+      set_of_states states,
       const typename COUNTER_EXAMPLE_CONSTRUCTOR::index_type& counter_example_index)
       : m_state(state),
-        m_states(states),
+        m_states(std::move(states)),
         m_counter_example_index(counter_example_index)
   {}
 
   /// \brief Get the state.
   state_type state() const { return m_state; }
-
-  void swap(state_states_counter_example_index_triple& other)
-  {
-    std::swap(m_state, other.m_state);
-    std::swap(m_states, other.m_states);
-    std::swap(m_counter_example_index, other.m_counter_example_index);
-  }
-
   /// \brief Get the set of states.
   const set_of_states& states() const { return m_states; }
 
@@ -101,8 +93,10 @@ private:
   void calculate_weak_property_cache(const bool weak_reduction)
   {
     scc_partitioner<LTS_TYPE> strongly_connected_component_partitioner(m_l);
+    
     for (const transition& t : m_l.get_transitions())
     {
+
       assert(t.from() < m_l.num_states());
       if (m_l.is_tau(m_l.apply_hidden_label_map(t.label())) && weak_reduction)
       {
@@ -307,9 +301,9 @@ bool destructive_refinement_checker(LTS_TYPE& l1,
 
   while (!working.empty()) // while working!=empty
   {
+    // pop (impl,spec) from working;
     detail::state_states_counter_example_index_triple<COUNTER_EXAMPLE_CONSTRUCTOR>
-        impl_spec; // pop (impl,spec) from working;
-    impl_spec.swap(working.front());
+        impl_spec = working.front();
     stats.max_working = std::max(working.size(), stats.max_working);
     stats.max_antichain = std::max(anti_chain.size(), stats.max_antichain);
     working.pop_front(); // At this point it could be checked whether impl_spec still exists in anti_chain.

--- a/libraries/lts/include/mcrl2/lts/detail/liblts_failures_refinement.h
+++ b/libraries/lts/include/mcrl2/lts/detail/liblts_failures_refinement.h
@@ -9,9 +9,8 @@
 /// \file lts/detail/liblts_failures_refinement.h
 
 // This file contains an implementation of
-// T. Wang, S. Song, J. Sun, Y. Liu, J.S. Dong, X. Wang and S. Li.
-// More Anti-Chain Based Refinement Checking. In proceedings ICFEM 2012, editors T. Aoki and K. Tagushi,
-// Lecture Notes in Computer Science no 7635, pages 364-380, 2012.
+// M. Laveaux, J.F. Groote and T.A.C. Willemse
+// Correct and Efficient Antichain Algorithms for Refinement Checking. Logical Methods in Computer Science 17(1) 2021
 //
 // There are six algorithms. One for trace inclusion, one for failures inclusion and one for failures-divergence inclusion.
 // All algorithms come in a variant with and without internal steps.

--- a/libraries/lts/include/mcrl2/lts/detail/liblts_failures_refinement.h
+++ b/libraries/lts/include/mcrl2/lts/detail/liblts_failures_refinement.h
@@ -23,6 +23,8 @@
 #include "mcrl2/lts/detail/counter_example.h"
 #include "mcrl2/lts/detail/liblts_bisim_dnj.h"
 
+#include <boost/container/flat_set.hpp>
+
 namespace mcrl2::lts 
 {
   
@@ -31,9 +33,9 @@ namespace detail
 
 typedef std::size_t state_type;
 typedef std::size_t label_type;
-typedef std::set<state_type> set_of_states;
+typedef boost::container::flat_set<state_type> set_of_states;
+typedef boost::container::flat_set<label_type> action_label_set;
 typedef std::multimap<detail::state_type, detail::set_of_states> anti_chain_type;
-typedef std::set<label_type> action_label_set;
 
 template <class COUNTER_EXAMPLE_CONSTRUCTOR>
 class state_states_counter_example_index_triple

--- a/libraries/lts/include/mcrl2/lts/detail/liblts_failures_refinement.h
+++ b/libraries/lts/include/mcrl2/lts/detail/liblts_failures_refinement.h
@@ -346,6 +346,7 @@ bool check_refinement(
       generate_counter_example.root_index())});
     
   // let antichain := emptyset;
+  anti_chain.clear();
   detail::antichain_insert(anti_chain, working.front());   // antichain := antichain united with (impl,spec);
                                                            // This line occurs at another place in the code than in
                                                            // the original algorithm, where insertion in the anti-chain

--- a/libraries/lts/include/mcrl2/lts/detail/liblts_failures_refinement.h
+++ b/libraries/lts/include/mcrl2/lts/detail/liblts_failures_refinement.h
@@ -782,7 +782,7 @@ bool refusals_contained_in(const state_type impl,
 }
 
 } // namespace detail
-} // namespace lts
-} // namespace mcrl2
+
+} // namespace mcrl2::lts
 
 #endif //  LIBLTS_FAILURES_REFINEMENT_H

--- a/libraries/lts/include/mcrl2/lts/detail/liblts_impossible_futures.h
+++ b/libraries/lts/include/mcrl2/lts/detail/liblts_impossible_futures.h
@@ -50,9 +50,9 @@ bool check_trace_inclusion(LTS_TYPE& l1,
 
   while (!working.empty()) // while working!=empty
   {
+    // pop (impl,spec) from working;
     detail::state_states_counter_example_index_triple<COUNTER_EXAMPLE_CONSTRUCTOR>
-        impl_spec; // pop (impl,spec) from working;
-    impl_spec.swap(working.front());
+        impl_spec = working.front();
     stats.max_working = std::max(working.size(), stats.max_working);
     stats.max_antichain = std::max(anti_chain.size(), stats.max_antichain);
     working.pop_front(); // At this point it could be checked whether impl_spec still exists in anti_chain.

--- a/libraries/lts/include/mcrl2/lts/detail/liblts_impossible_futures.h
+++ b/libraries/lts/include/mcrl2/lts/detail/liblts_impossible_futures.h
@@ -27,6 +27,7 @@ bool check_trace_inclusion(LTS_TYPE& l1,
     refinement_statistics<detail::state_states_counter_example_index_triple<COUNTER_EXAMPLE_CONSTRUCTOR>>& stats,
     detail::anti_chain_type& anti_chain,
     detail::anti_chain_type& anti_chain_positive,
+    detail::anti_chain_type& anti_chain_negative,
     COUNTER_EXAMPLE_CONSTRUCTOR& generate_counter_example,
     detail::state_type init_l1,
     detail::state_type init_l2,
@@ -59,6 +60,10 @@ bool check_trace_inclusion(LTS_TYPE& l1,
                          // Small scale experiments show that this is a little bit more expensive than doing the
                          // explicit check below.
 
+    if (detail::antichain_include_inverse(anti_chain_negative, impl_spec.state(), impl_spec.states())) {
+      return false;
+    }
+
     for (const transition& t : weak_property_cache.transitions(impl_spec.state()))
     {
       const typename COUNTER_EXAMPLE_CONSTRUCTOR::index_type new_counterexample_index
@@ -86,6 +91,7 @@ bool check_trace_inclusion(LTS_TYPE& l1,
       {
         generate_counter_example.save_counter_example(new_counterexample_index, l1);
         report_statistics(stats);
+        detail::antichain_insert(anti_chain_negative, init_l1, detail::collect_reachable_states_via_taus(init_l2, weak_property_cache, weak_reduction));
         return false; //    return false;
       }
       
@@ -146,6 +152,7 @@ bool destructive_impossible_futures(LTS& l1, LTS& l2, const lps::exploration_str
 
   // Used for the weak trace refinement checks
   detail::anti_chain_type positive_anti_chain;
+  detail::anti_chain_type negative_anti_chain;
   detail::anti_chain_type inner_anti_chain;
   std::deque<state_states_counter_example_index_triple<COUNTER_EXAMPLE_CONSTRUCTOR>> inner_working;
   refinement_statistics<detail::state_states_counter_example_index_triple<COUNTER_EXAMPLE_CONSTRUCTOR>> inner_stats(inner_anti_chain, inner_working);
@@ -174,6 +181,7 @@ bool destructive_impossible_futures(LTS& l1, LTS& l2, const lps::exploration_str
                   inner_stats,
                   inner_anti_chain,
                   positive_anti_chain,
+                  negative_anti_chain,
                   inner_generate_counterexample,
                   t,
                   impl,

--- a/libraries/lts/include/mcrl2/lts/detail/liblts_impossible_futures.h
+++ b/libraries/lts/include/mcrl2/lts/detail/liblts_impossible_futures.h
@@ -40,8 +40,9 @@ bool destructive_impossible_futures(LTS& l1, LTS& l2, const lps::exploration_str
   detail::anti_chain_type anti_chain;
   detail::antichain_insert(anti_chain, working.front()); // antichain := antichain united with (impl,spec);
 
-  // Used for the weak trace refinement
+  // Used for the weak trace refinement checks
   detail::anti_chain_type inner_anti_chain;
+  detail::anti_chain_type inner_anti_chain_updated;
   std::deque<state_states_counter_example_index_triple<COUNTER_EXAMPLE_CONSTRUCTOR>> inner_working;
   refinement_statistics<detail::state_states_counter_example_index_triple<COUNTER_EXAMPLE_CONSTRUCTOR>> stats(inner_anti_chain, inner_working);
   
@@ -63,17 +64,25 @@ bool destructive_impossible_futures(LTS& l1, LTS& l2, const lps::exploration_str
               // Print the current (impl,spec) pair being inspected
               std::cout << "Checking (" << impl << ", " << t << ")" << std::endl;
 
-              return check_refinement(l1,
+              inner_anti_chain = inner_anti_chain_updated;
+              if (!check_refinement(l1,
                   weak_property_cache,
                   inner_working,
                   stats,
-                  inner_anti_chain,
+                  inner_anti_chain_updated,
                   inner_generate_counterexample,
                   t,
                   impl,
                   refinement_type::trace,
                   true,
-                  strategy);
+                  strategy))
+                {
+                  // Reset for failing inclusion checks.
+                  std::swap(inner_anti_chain_updated, inner_anti_chain);
+                  return false;
+                }
+
+                return true;
             }))
     {
       return false;

--- a/libraries/lts/include/mcrl2/lts/detail/liblts_impossible_futures.h
+++ b/libraries/lts/include/mcrl2/lts/detail/liblts_impossible_futures.h
@@ -1,0 +1,131 @@
+// Author(s): Maurice Laveaux
+// Copyright: see the accompanying file COPYING or copy at
+// https://github.com/mCRL2org/mCRL2/blob/master/COPYING
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+/// \file lts/detail/liblts_failures_refinement.h
+
+#ifndef LIBLTS_IMPOSSIBLE_FUTURES_H
+#define LIBLTS_IMPOSSIBLE_FUTURES_H
+
+#include <boost/container/vector.hpp>
+#include <deque>
+
+#include "mcrl2/lts/detail/counter_example.h"
+#include "mcrl2/lts/detail/liblts_failures_refinement.h"
+
+namespace mcrl2::lts::detail
+{
+
+/// \brief This function checks using algorithms in the paper mentioned above
+/// whether transition system l1 is included in transition system l2, in the
+/// sense of trace inclusions, failures inclusion and divergence failures
+/// inclusion.
+template <typename LTS,
+  typename COUNTER_EXAMPLE_CONSTRUCTOR = detail::dummy_counter_example_constructor>
+bool destructive_impossible_futures(LTS& l1, LTS& l2, const lps::exploration_strategy strategy)
+{
+  std::size_t init_l2 = l2.initial_state() + l1.num_states();
+  mcrl2::lts::detail::merge(l1, l2);
+
+  const detail::lts_cache<LTS> weak_property_cache(l1, true);
+
+  std::deque<state_states_counter_example_index_triple<COUNTER_EXAMPLE_CONSTRUCTOR>> working = std::deque(
+      {state_states_counter_example_index_triple<COUNTER_EXAMPLE_CONSTRUCTOR>(l1.initial_state(),
+          detail::collect_reachable_states_via_taus(init_l2, weak_property_cache, true),
+          COUNTER_EXAMPLE_CONSTRUCTOR())});
+  detail::anti_chain_type anti_chain;
+  detail::antichain_insert(anti_chain, working.front()); // antichain := antichain united with (impl,spec);
+
+  // Used for the weak trace refinement
+  detail::anti_chain_type inner_anti_chain;
+  std::deque<state_states_counter_example_index_triple<COUNTER_EXAMPLE_CONSTRUCTOR>> inner_working;
+  refinement_statistics<detail::state_states_counter_example_index_triple<COUNTER_EXAMPLE_CONSTRUCTOR>> stats(inner_anti_chain, inner_working);
+  
+  COUNTER_EXAMPLE_CONSTRUCTOR inner_generate_counterexample = COUNTER_EXAMPLE_CONSTRUCTOR();
+
+  while (!working.empty())
+  {
+    // pop(impl,spec) from working;
+    const auto front = working.front();
+    working.pop_front();
+
+    const detail::state_type impl = front.state();
+    const detail::set_of_states& spec = front.states();
+
+    if (!std::any_of(spec.begin(),
+            spec.end(),
+            [&](const auto& t)
+            {
+              // Print the current (impl,spec) pair being inspected
+              std::cout << "Checking (" << impl << ", " << t << ")" << std::endl;
+
+              return check_refinement(l1,
+                  weak_property_cache,
+                  inner_working,
+                  stats,
+                  inner_anti_chain,
+                  inner_generate_counterexample,
+                  t,
+                  impl,
+                  refinement_type::trace,
+                  true,
+                  strategy);
+            }))
+    {
+      return false;
+    }
+
+    for (const transition& t : weak_property_cache.transitions(impl))
+    {
+      detail::set_of_states spec_prime;
+      if (l1.is_tau(l1.apply_hidden_label_map(t.label())))
+      {
+        spec_prime = spec;
+      }
+      else
+      {
+        for (const detail::state_type s : spec)
+        {
+          detail::set_of_states reachable_states_from_s_via_e = detail::collect_reachable_states_via_an_action(s,
+              l1.apply_hidden_label_map(t.label()),
+              weak_property_cache,
+              true,
+              l1);
+          spec_prime.insert(reachable_states_from_s_via_e.begin(), reachable_states_from_s_via_e.end());
+        }
+      }
+
+      if (spec_prime.empty())
+      {
+        return false;
+      }
+
+      auto impl_spec_counterex
+          = state_states_counter_example_index_triple<detail::dummy_counter_example_constructor>(t.to(),
+              spec_prime,
+              detail::dummy_counter_example_constructor());
+
+      if (detail::antichain_insert(anti_chain, impl_spec_counterex))
+      {
+        if (strategy == lps::exploration_strategy::es_breadth)
+        {
+          working.push_back(impl_spec_counterex);
+        }
+        else if (strategy == lps::exploration_strategy::es_depth)
+        {
+          working.push_front(impl_spec_counterex);
+        }
+      }
+    }
+  }
+
+  return true;
+}
+
+} // namespace mcrl2::lts::detail
+
+#endif // LIBLTS_IMPOSSIBLE_FUTURES_H

--- a/libraries/lts/include/mcrl2/lts/detail/liblts_impossible_futures.h
+++ b/libraries/lts/include/mcrl2/lts/detail/liblts_impossible_futures.h
@@ -132,6 +132,10 @@ template <typename LTS,
   typename COUNTER_EXAMPLE_CONSTRUCTOR = detail::dummy_counter_example_constructor>
 bool destructive_impossible_futures(LTS& l1, LTS& l2, const lps::exploration_strategy strategy)
 {
+  // Remove tau-loops from l1 to allow the (impl, spec) => (impl', spec) optimisation.
+  scc_partitioner<LTS> scc_partitioner(l1);
+  scc_partitioner.replace_transition_system(false);
+
   std::size_t init_l2 = l2.initial_state() + l1.num_states();
   mcrl2::lts::detail::merge(l1, l2);
 
@@ -163,7 +167,7 @@ bool destructive_impossible_futures(LTS& l1, LTS& l2, const lps::exploration_str
     const detail::state_type impl = front.state();
     const detail::set_of_states& spec = front.states();
 
-    if (!std::any_of(spec.begin(),
+    if (weak_property_cache.stable(impl) && !std::any_of(spec.begin(),
             spec.end(),
             [&](const auto& t)
             {

--- a/libraries/lts/include/mcrl2/lts/detail/liblts_impossible_futures.h
+++ b/libraries/lts/include/mcrl2/lts/detail/liblts_impossible_futures.h
@@ -90,7 +90,6 @@ bool check_trace_inclusion(LTS_TYPE& l1,
       if (spec_prime.empty()) // if spec'={} then
       {
         generate_counter_example.save_counter_example(new_counterexample_index, l1);
-        report_statistics(stats);
         detail::antichain_insert(anti_chain_negative, init_l1, detail::collect_reachable_states_via_taus(init_l2, weak_property_cache, weak_reduction));
         return false; //    return false;
       }
@@ -133,10 +132,6 @@ template <typename LTS,
   typename COUNTER_EXAMPLE_CONSTRUCTOR = detail::dummy_counter_example_constructor>
 bool destructive_impossible_futures(LTS& l1, LTS& l2, const lps::exploration_strategy strategy)
 {
-  // Remove tau-loops from l1 to allow the (impl, spec) => (impl', spec) optimisation.
-  scc_partitioner<LTS> scc_partitioner(l1);
-  scc_partitioner.replace_transition_system(false);
-
   std::size_t init_l2 = l2.initial_state() + l1.num_states();
   mcrl2::lts::detail::merge(l1, l2);
 
@@ -168,13 +163,10 @@ bool destructive_impossible_futures(LTS& l1, LTS& l2, const lps::exploration_str
     const detail::state_type impl = front.state();
     const detail::set_of_states& spec = front.states();
 
-    if (weak_property_cache.stable(impl) && !std::any_of(spec.begin(),
+    if (!std::any_of(spec.begin(),
             spec.end(),
             [&](const auto& t)
             {
-              // Print the current (impl,spec) pair being inspected
-              std::cout << "Checking (" << impl << ", " << t << ")" << std::endl;
-
               return check_trace_inclusion(l1,
                   weak_property_cache,
                   inner_working,

--- a/libraries/lts/include/mcrl2/lts/detail/liblts_impossible_futures.h
+++ b/libraries/lts/include/mcrl2/lts/detail/liblts_impossible_futures.h
@@ -124,10 +124,9 @@ bool check_trace_inclusion(LTS_TYPE& l1,
 
 namespace detail {
 
-/// \brief This function checks using algorithms in the paper mentioned above
-/// whether transition system l1 is included in transition system l2, in the
-/// sense of trace inclusions, failures inclusion and divergence failures
-/// inclusion.
+/// \brief Checks impossible futures refinement for the given LTSs. Impossible futures are defined in the article:
+/// 
+/// Marc Voorhoeve, Sjouke Mauw. Impossible futures and determinism, Inf. Process. Lett. 80, 2001. 
 template <typename LTS,
   typename COUNTER_EXAMPLE_CONSTRUCTOR = detail::dummy_counter_example_constructor>
 bool destructive_impossible_futures(LTS& l1, LTS& l2, const lps::exploration_strategy strategy)

--- a/libraries/lts/include/mcrl2/lts/lts_algorithm.h
+++ b/libraries/lts/include/mcrl2/lts/lts_algorithm.h
@@ -874,7 +874,7 @@ bool destructive_compare(LTS_TYPE& l1, LTS_TYPE& l2, const lts_preorder pre, con
 {
   switch (pre)
   {
-    case lts_pre_sim:
+    case lts_preorder::lts_pre_sim:
     {
       // Merge this LTS and l and store the result in this LTS.
       // In the resulting LTS, the initial state i of l will have the
@@ -892,7 +892,7 @@ bool destructive_compare(LTS_TYPE& l1, LTS_TYPE& l2, const lts_preorder pre, con
 
       return sp.in_preorder(l1.initial_state(),init_l2);
     }
-    case lts_pre_ready_sim:
+    case lts_preorder::lts_pre_ready_sim:
     {
       // Merge this LTS and l and store the result in this LTS.
       // In the resulting LTS, the initial state i of l will have the
@@ -910,7 +910,7 @@ bool destructive_compare(LTS_TYPE& l1, LTS_TYPE& l2, const lts_preorder pre, con
 
       return rsp.in_preorder(l1.initial_state(),init_l2);
     }
-    case lts_pre_trace:
+    case lts_preorder::lts_pre_trace:
     {
       // Preprocessing: reduce modulo strong bisimulation equivalence.
       // This is not strictly necessary, but may reduce time/memory
@@ -929,9 +929,9 @@ bool destructive_compare(LTS_TYPE& l1, LTS_TYPE& l2, const lts_preorder pre, con
       detail::bisimulation_reduce_dnj(l2,false);
 
       // Trace preorder now corresponds to simulation preorder
-      return destructive_compare(l1, l2, lts_pre_sim, generate_counter_example, counter_example_file, structured_output, strategy);
+      return destructive_compare(l1, l2, lts_preorder::lts_pre_sim, generate_counter_example, counter_example_file, structured_output, strategy);
     }
-    case lts_pre_weak_trace:
+    case lts_preorder::lts_pre_weak_trace:
     {
       // Eliminate silent steps of first LTS
       detail::bisimulation_reduce_dnj(l1,true,false);
@@ -942,9 +942,9 @@ bool destructive_compare(LTS_TYPE& l1, LTS_TYPE& l2, const lts_preorder pre, con
       detail::tau_star_reduce(l2);
 
       // Weak trace preorder now corresponds to strong trace preorder
-      return destructive_compare(l1, l2, lts_pre_trace, generate_counter_example, counter_example_file, structured_output, strategy);
+      return destructive_compare(l1, l2, lts_preorder::lts_pre_trace, generate_counter_example, counter_example_file, structured_output, strategy);
     }
-    case lts_pre_trace_anti_chain:
+    case lts_preorder::lts_pre_trace_anti_chain:
     {
       if (generate_counter_example)
       {
@@ -953,7 +953,7 @@ bool destructive_compare(LTS_TYPE& l1, LTS_TYPE& l2, const lts_preorder pre, con
       }
       return destructive_refinement_checker(l1, l2, refinement_type::trace, false, strategy, preprocess);
     }
-    case lts_pre_weak_trace_anti_chain:
+    case lts_preorder::lts_pre_weak_trace_anti_chain:
     {
       if (generate_counter_example)
       {
@@ -962,7 +962,7 @@ bool destructive_compare(LTS_TYPE& l1, LTS_TYPE& l2, const lts_preorder pre, con
       }
       return destructive_refinement_checker(l1, l2, refinement_type::trace, true, strategy, preprocess);
     }
-    case lts_pre_failures_refinement:
+    case lts_preorder::lts_pre_failures_refinement:
     {
       if (generate_counter_example)
       {
@@ -971,7 +971,7 @@ bool destructive_compare(LTS_TYPE& l1, LTS_TYPE& l2, const lts_preorder pre, con
       }
       return destructive_refinement_checker(l1, l2, refinement_type::failures, false, strategy, preprocess);
     }
-    case lts_pre_weak_failures_refinement:
+    case lts_preorder::lts_pre_weak_failures_refinement:
     {
       if (generate_counter_example)
       {
@@ -980,7 +980,7 @@ bool destructive_compare(LTS_TYPE& l1, LTS_TYPE& l2, const lts_preorder pre, con
       }
       return destructive_refinement_checker(l1, l2, refinement_type::failures, true, strategy, preprocess);
     }
-    case lts_pre_failures_divergence_refinement:
+    case lts_preorder::lts_pre_failures_divergence_refinement:
     {
       if (generate_counter_example)
       {

--- a/libraries/lts/include/mcrl2/lts/lts_algorithm.h
+++ b/libraries/lts/include/mcrl2/lts/lts_algorithm.h
@@ -993,7 +993,7 @@ bool destructive_compare(LTS_TYPE& l1, LTS_TYPE& l2, const lts_preorder pre, con
     }
     case lts_preorder::lts_pre_impossible_futures:
     {
-      return detail::destructive_impossible_futures(l1, l2);
+      return detail::destructive_impossible_futures(l1, l2, strategy);
     }
     case lts_preorder::lts_pre_none:
     {

--- a/libraries/lts/include/mcrl2/lts/lts_algorithm.h
+++ b/libraries/lts/include/mcrl2/lts/lts_algorithm.h
@@ -33,10 +33,12 @@
 #include "mcrl2/lts/detail/liblts_ready_sim.h"
 #include "mcrl2/lts/detail/liblts_failures_refinement.h"
 #include "mcrl2/lts/detail/liblts_coupledsim.h"
+#include "mcrl2/lts/detail/liblts_impossible_futures.h"
 #include "mcrl2/lts/detail/tree_set.h"
 #include "mcrl2/lts/lts_equivalence.h"
 #include "mcrl2/lts/lts_preorder.h"
 #include "mcrl2/lts/sigref.h"
+#include "mcrl2/utilities/exception.h"
 
 namespace mcrl2
 {
@@ -988,6 +990,14 @@ bool destructive_compare(LTS_TYPE& l1, LTS_TYPE& l2, const lts_preorder pre, con
         return destructive_refinement_checker(l1, l2, refinement_type::failures_divergence, true, strategy, preprocess, cec);
       }
       return destructive_refinement_checker(l1, l2, refinement_type::failures_divergence, true, strategy, preprocess);
+    }
+    case lts_preorder::lts_pre_impossible_futures:
+    {
+      return detail::destructive_impossible_futures(l1, l2);
+    }
+    case lts_preorder::lts_pre_none:
+    {
+      throw new mcrl2::runtime_error("Expected a valid preorder");
     }
     default:
       mCRL2log(log::error) << "Comparison for this preorder is not available\n";

--- a/libraries/lts/include/mcrl2/lts/lts_preorder.h
+++ b/libraries/lts/include/mcrl2/lts/lts_preorder.h
@@ -40,8 +40,9 @@ enum class lts_preorder
   lts_pre_failures_refinement,    /**< Failures refinement based on anti chains */
   lts_pre_weak_failures_refinement, /**< Weak failures refinement based on anti chains */
   lts_pre_failures_divergence_refinement, /**< Failures divergence refinement based on anti chains, which is automatically weak */
-  lts_preorder_min = lts_pre_none,
-  lts_preorder_max = lts_pre_failures_divergence_refinement
+  lts_pre_impossible_futures, /**< Impossible futures */
+  lts_preorder_min = lts_preorder::lts_pre_none,
+  lts_preorder_max = lts_preorder::lts_pre_impossible_futures
 };
 
 /** \brief Determines the preorder from a string.
@@ -96,6 +97,10 @@ lts_preorder parse_preorder(std::string const& s)
   {
     return lts_preorder::lts_pre_failures_divergence_refinement;
   }
+  else if (s == "impossible-futures")
+  {
+    return lts_preorder::lts_pre_impossible_futures;
+  }
   else
   {
     throw mcrl2::runtime_error("unknown preorder " + s);
@@ -149,8 +154,10 @@ std::string print_preorder(const lts_preorder pre)
       return "weak-failures";
     case lts_preorder::lts_pre_failures_divergence_refinement:
       return "failures-divergence";
+    case lts_preorder::lts_pre_impossible_futures:
+      return "impossible-futures";
     default:
-      throw mcrl2::runtime_error("unknown preorder");
+      throw new mcrl2::runtime_error("unknown preorder");
   }
 }
 
@@ -190,6 +197,8 @@ std::string description(const lts_preorder pre)
       return "weak failures refinement";
     case lts_preorder::lts_pre_failures_divergence_refinement:
       return "failures divergence refinement (automatically weak)";
+    case lts_preorder::lts_pre_impossible_futures:
+      return "impossible futures";
     default:
       throw mcrl2::runtime_error("unknown preorder");
   }

--- a/libraries/lts/include/mcrl2/lts/lts_preorder.h
+++ b/libraries/lts/include/mcrl2/lts/lts_preorder.h
@@ -28,7 +28,7 @@ namespace lts
  * \details This enumerated type defines preorder relations on LTSs.
  * They can be used to decide whether one LTS is behaviourally
  * contained in another LTS. */
-enum lts_preorder
+enum class lts_preorder
 {
   lts_pre_none,   /**< Unknown or no preorder */
   lts_pre_sim,    /**< Strong simulation preorder */
@@ -58,43 +58,43 @@ lts_preorder parse_preorder(std::string const& s)
 {
   if (s == "unknown")
   {
-    return lts_pre_none;
+    return lts_preorder::lts_pre_none;
   }
   else if (s == "sim")
   {
-    return lts_pre_sim;
+    return lts_preorder::lts_pre_sim;
   }
   else if (s == "ready-sim")
   {
-    return lts_pre_ready_sim;
+    return lts_preorder::lts_pre_ready_sim;
   }  
   else if (s == "trace")
   {
-    return lts_pre_trace;
+    return lts_preorder::lts_pre_trace;
   }
   else if (s == "weak-trace")
   {
-    return lts_pre_weak_trace;
+    return lts_preorder::lts_pre_weak_trace;
   }
   else if (s == "trace-ac")
   {
-    return lts_pre_trace_anti_chain;
+    return lts_preorder::lts_pre_trace_anti_chain;
   }
   else if (s == "weak-trace-ac")
   {
-    return lts_pre_weak_trace_anti_chain;
+    return lts_preorder::lts_pre_weak_trace_anti_chain;
   }
   else if (s == "failures")
   {
-    return lts_pre_failures_refinement;
+    return lts_preorder::lts_pre_failures_refinement;
   }
   else if (s == "weak-failures")
   {
-    return lts_pre_weak_failures_refinement;
+    return lts_preorder::lts_pre_weak_failures_refinement;
   }
   else if (s == "failures-divergence")
   {
-    return lts_pre_failures_divergence_refinement;
+    return lts_preorder::lts_pre_failures_divergence_refinement;
   }
   else
   {
@@ -129,25 +129,25 @@ std::string print_preorder(const lts_preorder pre)
 {
   switch(pre)
   {
-    case lts_pre_none:
+    case lts_preorder::lts_pre_none:
       return "unknown";
-    case lts_pre_sim:
+    case lts_preorder::lts_pre_sim:
       return "sim";
-    case lts_pre_ready_sim:
+    case lts_preorder::lts_pre_ready_sim:
       return "ready-sim";      
-    case lts_pre_trace:
+    case lts_preorder::lts_pre_trace:
       return "trace";
-    case lts_pre_weak_trace:
+    case lts_preorder::lts_pre_weak_trace:
       return "weak-trace";
-    case lts_pre_trace_anti_chain:
+    case lts_preorder::lts_pre_trace_anti_chain:
       return "trace-ac";
-    case lts_pre_weak_trace_anti_chain:
+    case lts_preorder::lts_pre_weak_trace_anti_chain:
       return "weak-trace-ac";
-    case lts_pre_failures_refinement:
+    case lts_preorder::lts_pre_failures_refinement:
       return "failures";
-    case lts_pre_weak_failures_refinement:
+    case lts_preorder::lts_pre_weak_failures_refinement:
       return "weak-failures";
-    case lts_pre_failures_divergence_refinement:
+    case lts_preorder::lts_pre_failures_divergence_refinement:
       return "failures-divergence";
     default:
       throw mcrl2::runtime_error("unknown preorder");
@@ -170,25 +170,25 @@ std::string description(const lts_preorder pre)
 {
   switch(pre)
   {
-    case lts_pre_none:
+    case lts_preorder::lts_pre_none:
       return "default void preorder";
-    case lts_pre_sim:
+    case lts_preorder::lts_pre_sim:
       return "strong simulation preorder";
-    case lts_pre_ready_sim:
+    case lts_preorder::lts_pre_ready_sim:
       return "strong ready simulation preorder";      
-    case lts_pre_trace:
+    case lts_preorder::lts_pre_trace:
       return "strong trace preorder";
-    case lts_pre_weak_trace:
+    case lts_preorder::lts_pre_weak_trace:
       return "weak trace preorder";
-    case lts_pre_trace_anti_chain:
+    case lts_preorder::lts_pre_trace_anti_chain:
       return "trace preorder based on an anti chain algorithm";
-    case lts_pre_weak_trace_anti_chain:
+    case lts_preorder::lts_pre_weak_trace_anti_chain:
       return "weak trace preorder based on an anti chain algorithm";
-    case lts_pre_failures_refinement:
+    case lts_preorder::lts_pre_failures_refinement:
       return "failures refinement";
-    case lts_pre_weak_failures_refinement:
+    case lts_preorder::lts_pre_weak_failures_refinement:
       return "weak failures refinement";
-    case lts_pre_failures_divergence_refinement:
+    case lts_preorder::lts_pre_failures_divergence_refinement:
       return "failures divergence refinement (automatically weak)";
     default:
       throw mcrl2::runtime_error("unknown preorder");

--- a/libraries/lts/test/compare.cpp
+++ b/libraries/lts/test/compare.cpp
@@ -90,35 +90,35 @@ bool compare(const std::string& s1, const std::string& s2, lts_equivalence eq, b
 
 BOOST_AUTO_TEST_CASE(test_reflexive)
 {
-  BOOST_CHECK(preorder_compare(l2a,l2a,lts_pre_sim));
-  BOOST_CHECK(preorder_compare(l2a,l2a,lts_pre_trace));
+  BOOST_CHECK(preorder_compare(l2a,l2a,lts_preorder::lts_pre_sim));
+  BOOST_CHECK(preorder_compare(l2a,l2a,lts_preorder::lts_pre_trace));
   BOOST_CHECK(compare(l2a,l2a,lts_eq_sim));
   BOOST_CHECK(compare(l2a,l2a,lts_eq_trace));
-  BOOST_CHECK(preorder_compare(l2a,l2a,lts_pre_ready_sim));
+  BOOST_CHECK(preorder_compare(l2a,l2a,lts_preorder::lts_pre_ready_sim));
   BOOST_CHECK(compare(l2a,l2a,lts_eq_ready_sim));    
 }
 
 
 BOOST_AUTO_TEST_CASE(test_sim_1_2)
 {
-  BOOST_CHECK(!preorder_compare(l1,l2,lts_pre_sim));  
-  BOOST_CHECK(preorder_compare(l2,l1,lts_pre_sim));
+  BOOST_CHECK(!preorder_compare(l1,l2,lts_preorder::lts_pre_sim));  
+  BOOST_CHECK(preorder_compare(l2,l1,lts_preorder::lts_pre_sim));
   BOOST_CHECK(!compare(l2,l1,lts_eq_sim));
   BOOST_CHECK(!compare(l1,l2,lts_eq_sim));    
 }
 
 BOOST_AUTO_TEST_CASE(test_sim_2_2a)
 {
-  BOOST_CHECK(preorder_compare(l2,l2a,lts_pre_sim));
-  BOOST_CHECK(!preorder_compare(l2a,l2,lts_pre_sim));
+  BOOST_CHECK(preorder_compare(l2,l2a,lts_preorder::lts_pre_sim));
+  BOOST_CHECK(!preorder_compare(l2a,l2,lts_preorder::lts_pre_sim));
   BOOST_CHECK(!compare(l2a,l2,lts_eq_sim));
   BOOST_CHECK(!compare(l2,l2a,lts_eq_sim));    
 }
 
 BOOST_AUTO_TEST_CASE(test_sim_1_3)
 {
-  BOOST_CHECK(!preorder_compare(l1,l3,lts_pre_sim));
-  BOOST_CHECK(!preorder_compare(l3,l1,lts_pre_sim));
+  BOOST_CHECK(!preorder_compare(l1,l3,lts_preorder::lts_pre_sim));
+  BOOST_CHECK(!preorder_compare(l3,l1,lts_preorder::lts_pre_sim));
   BOOST_CHECK(!compare(l3,l1,lts_eq_sim));
   BOOST_CHECK(!compare(l1,l3,lts_eq_sim));    
 }
@@ -126,8 +126,8 @@ BOOST_AUTO_TEST_CASE(test_sim_1_3)
 
 BOOST_AUTO_TEST_CASE(test_sim_1_4)
 {
-  BOOST_CHECK(!preorder_compare(l1,l4,lts_pre_sim));
-  BOOST_CHECK(preorder_compare(l4,l1,lts_pre_sim));
+  BOOST_CHECK(!preorder_compare(l1,l4,lts_preorder::lts_pre_sim));
+  BOOST_CHECK(preorder_compare(l4,l1,lts_preorder::lts_pre_sim));
   BOOST_CHECK(!compare(l1,l4,lts_eq_sim));
   BOOST_CHECK(!compare(l4,l1,lts_eq_sim));
 }
@@ -135,31 +135,31 @@ BOOST_AUTO_TEST_CASE(test_sim_1_4)
 
 BOOST_AUTO_TEST_CASE(test_ready_sim_1_2)
 {
-  BOOST_CHECK(!preorder_compare(l1,l2,lts_pre_ready_sim));
-  BOOST_CHECK(!preorder_compare(l2,l1,lts_pre_ready_sim));
+  BOOST_CHECK(!preorder_compare(l1,l2,lts_preorder::lts_pre_ready_sim));
+  BOOST_CHECK(!preorder_compare(l2,l1,lts_preorder::lts_pre_ready_sim));
   BOOST_CHECK(!compare(l2,l1,lts_eq_ready_sim));
   BOOST_CHECK(!compare(l1,l2,lts_eq_ready_sim));  
 }
 
 BOOST_AUTO_TEST_CASE(test_ready_sim_2_2a)
 {
-  BOOST_CHECK(preorder_compare(l2,l2a,lts_pre_ready_sim));      
-  BOOST_CHECK(!preorder_compare(l2a,l2,lts_pre_ready_sim));
+  BOOST_CHECK(preorder_compare(l2,l2a,lts_preorder::lts_pre_ready_sim));      
+  BOOST_CHECK(!preorder_compare(l2a,l2,lts_preorder::lts_pre_ready_sim));
   BOOST_CHECK(!compare(l2,l2a,lts_eq_ready_sim));      
   BOOST_CHECK(!compare(l2a,l2,lts_eq_ready_sim));  
 }
 
 BOOST_AUTO_TEST_CASE(test_ready_sim_1_3)
 {
-  BOOST_CHECK(!preorder_compare(l1,l3,lts_pre_ready_sim));
-  BOOST_CHECK(!preorder_compare(l3,l1,lts_pre_ready_sim));
+  BOOST_CHECK(!preorder_compare(l1,l3,lts_preorder::lts_pre_ready_sim));
+  BOOST_CHECK(!preorder_compare(l3,l1,lts_preorder::lts_pre_ready_sim));
   BOOST_CHECK(!compare(l3,l1,lts_eq_ready_sim));  
 }
 
 BOOST_AUTO_TEST_CASE(test_ready_sim_1_4)
 {
-  BOOST_CHECK(!preorder_compare(l1,l4,lts_pre_ready_sim));
-  BOOST_CHECK(!preorder_compare(l4,l1,lts_pre_ready_sim));
+  BOOST_CHECK(!preorder_compare(l1,l4,lts_preorder::lts_pre_ready_sim));
+  BOOST_CHECK(!preorder_compare(l4,l1,lts_preorder::lts_pre_ready_sim));
   BOOST_CHECK(!compare(l1,l4,lts_eq_ready_sim));  
 }
 
@@ -170,14 +170,14 @@ BOOST_AUTO_TEST_CASE(test_symmetric_trace_1_2)
   BOOST_CHECK(!compare(l2,l1,lts_eq_bisim));
   BOOST_CHECK(!compare(l2,l1,lts_eq_bisim_gv));
   BOOST_CHECK(!compare(l2,l1,lts_eq_bisim_gjkw));
-  BOOST_CHECK(preorder_compare(l1,l2,lts_pre_trace));
-  BOOST_CHECK(preorder_compare(l2,l1,lts_pre_trace));
-  BOOST_CHECK(preorder_compare(l1,l2,lts_pre_trace_anti_chain));
-  BOOST_CHECK(preorder_compare(l2,l1,lts_pre_trace_anti_chain));
-  BOOST_CHECK(preorder_compare(l1,l2,lts_pre_failures_refinement));
-  BOOST_CHECK(!preorder_compare(l2,l1,lts_pre_failures_refinement));
-  BOOST_CHECK(preorder_compare(l1,l2,lts_pre_failures_divergence_refinement));
-  BOOST_CHECK(!preorder_compare(l2,l1,lts_pre_failures_divergence_refinement));
+  BOOST_CHECK(preorder_compare(l1,l2,lts_preorder::lts_pre_trace));
+  BOOST_CHECK(preorder_compare(l2,l1,lts_preorder::lts_pre_trace));
+  BOOST_CHECK(preorder_compare(l1,l2,lts_preorder::lts_pre_trace_anti_chain));
+  BOOST_CHECK(preorder_compare(l2,l1,lts_preorder::lts_pre_trace_anti_chain));
+  BOOST_CHECK(preorder_compare(l1,l2,lts_preorder::lts_pre_failures_refinement));
+  BOOST_CHECK(!preorder_compare(l2,l1,lts_preorder::lts_pre_failures_refinement));
+  BOOST_CHECK(preorder_compare(l1,l2,lts_preorder::lts_pre_failures_divergence_refinement));
+  BOOST_CHECK(!preorder_compare(l2,l1,lts_preorder::lts_pre_failures_divergence_refinement));
 }
 
 BOOST_AUTO_TEST_CASE(test_symmetric_trace_1_2a)
@@ -187,14 +187,14 @@ BOOST_AUTO_TEST_CASE(test_symmetric_trace_1_2a)
   BOOST_CHECK(!compare(l2a,l2,lts_eq_bisim));
   BOOST_CHECK(!compare(l2a,l2,lts_eq_bisim_gv));
   BOOST_CHECK(!compare(l2a,l2,lts_eq_bisim_gjkw));
-  BOOST_CHECK(preorder_compare(l2,l2a,lts_pre_trace));
-  BOOST_CHECK(preorder_compare(l2a,l2,lts_pre_trace));
-  BOOST_CHECK(preorder_compare(l2,l2a,lts_pre_trace_anti_chain));
-  BOOST_CHECK(preorder_compare(l2a,l2,lts_pre_trace_anti_chain));
-  BOOST_CHECK(preorder_compare(l2,l2a,lts_pre_failures_refinement));
-  BOOST_CHECK(preorder_compare(l2a,l2,lts_pre_failures_refinement));
-  BOOST_CHECK(preorder_compare(l2,l2a,lts_pre_failures_divergence_refinement));
-  BOOST_CHECK(preorder_compare(l2a,l2,lts_pre_failures_divergence_refinement));
+  BOOST_CHECK(preorder_compare(l2,l2a,lts_preorder::lts_pre_trace));
+  BOOST_CHECK(preorder_compare(l2a,l2,lts_preorder::lts_pre_trace));
+  BOOST_CHECK(preorder_compare(l2,l2a,lts_preorder::lts_pre_trace_anti_chain));
+  BOOST_CHECK(preorder_compare(l2a,l2,lts_preorder::lts_pre_trace_anti_chain));
+  BOOST_CHECK(preorder_compare(l2,l2a,lts_preorder::lts_pre_failures_refinement));
+  BOOST_CHECK(preorder_compare(l2a,l2,lts_preorder::lts_pre_failures_refinement));
+  BOOST_CHECK(preorder_compare(l2,l2a,lts_preorder::lts_pre_failures_divergence_refinement));
+  BOOST_CHECK(preorder_compare(l2a,l2,lts_preorder::lts_pre_failures_divergence_refinement));
 }
 
 BOOST_AUTO_TEST_CASE(test_symmetric_trace_1_3)
@@ -203,16 +203,16 @@ BOOST_AUTO_TEST_CASE(test_symmetric_trace_1_3)
   BOOST_CHECK(!compare(l3,l1,lts_eq_trace));
   BOOST_CHECK(compare(l1,l3,lts_eq_weak_trace));
   BOOST_CHECK(compare(l3,l1,lts_eq_weak_trace));
-  BOOST_CHECK(!preorder_compare(l1,l3,lts_pre_trace_anti_chain));
-  BOOST_CHECK(!preorder_compare(l3,l1,lts_pre_trace_anti_chain));
-  BOOST_CHECK(preorder_compare(l1,l3,lts_pre_weak_trace_anti_chain));
-  BOOST_CHECK(preorder_compare(l3,l1,lts_pre_weak_trace_anti_chain));
-  BOOST_CHECK(!preorder_compare(l1,l3,lts_pre_failures_refinement));
-  BOOST_CHECK(!preorder_compare(l3,l1,lts_pre_failures_refinement));
-  BOOST_CHECK(preorder_compare(l1,l3,lts_pre_weak_failures_refinement));
-  BOOST_CHECK(preorder_compare(l3,l1,lts_pre_weak_failures_refinement));
-  BOOST_CHECK(preorder_compare(l1,l3,lts_pre_failures_divergence_refinement));
-  BOOST_CHECK(preorder_compare(l3,l1,lts_pre_failures_divergence_refinement));
+  BOOST_CHECK(!preorder_compare(l1,l3,lts_preorder::lts_pre_trace_anti_chain));
+  BOOST_CHECK(!preorder_compare(l3,l1,lts_preorder::lts_pre_trace_anti_chain));
+  BOOST_CHECK(preorder_compare(l1,l3,lts_preorder::lts_pre_weak_trace_anti_chain));
+  BOOST_CHECK(preorder_compare(l3,l1,lts_preorder::lts_pre_weak_trace_anti_chain));
+  BOOST_CHECK(!preorder_compare(l1,l3,lts_preorder::lts_pre_failures_refinement));
+  BOOST_CHECK(!preorder_compare(l3,l1,lts_preorder::lts_pre_failures_refinement));
+  BOOST_CHECK(preorder_compare(l1,l3,lts_preorder::lts_pre_weak_failures_refinement));
+  BOOST_CHECK(preorder_compare(l3,l1,lts_preorder::lts_pre_weak_failures_refinement));
+  BOOST_CHECK(preorder_compare(l1,l3,lts_preorder::lts_pre_failures_divergence_refinement));
+  BOOST_CHECK(preorder_compare(l3,l1,lts_preorder::lts_pre_failures_divergence_refinement));
 }
 
 BOOST_AUTO_TEST_CASE(test_symmetric_trace_1_4)
@@ -271,14 +271,14 @@ BOOST_AUTO_TEST_CASE(test_bisim_a_b)
 // variables have been replaced by single actions.
 BOOST_AUTO_TEST_CASE(laws_for_failures_equivalence)
 {
-  BOOST_CHECK(preorder_compare(failures_law_left_hand_side,failures_law_right_hand_side,lts_pre_failures_refinement));
-  BOOST_CHECK(preorder_compare(failures_law_right_hand_side,failures_law_left_hand_side,lts_pre_failures_refinement));
-  BOOST_CHECK(preorder_compare(failures_law_left_hand_side,failures_law_right_hand_side,lts_pre_trace));
-  BOOST_CHECK(preorder_compare(failures_law_right_hand_side,failures_law_left_hand_side,lts_pre_trace));
-  BOOST_CHECK(preorder_compare(failures_law_left_hand_side,failures_law_right_hand_side,lts_pre_trace_anti_chain));
-  BOOST_CHECK(preorder_compare(failures_law_right_hand_side,failures_law_left_hand_side,lts_pre_trace_anti_chain));
-  BOOST_CHECK(preorder_compare(failures_law_left_hand_side,failures_law_right_hand_side,lts_pre_failures_divergence_refinement));
-  BOOST_CHECK(preorder_compare(failures_law_right_hand_side,failures_law_left_hand_side,lts_pre_failures_divergence_refinement));
+  BOOST_CHECK(preorder_compare(failures_law_left_hand_side,failures_law_right_hand_side,lts_preorder::lts_pre_failures_refinement));
+  BOOST_CHECK(preorder_compare(failures_law_right_hand_side,failures_law_left_hand_side,lts_preorder::lts_pre_failures_refinement));
+  BOOST_CHECK(preorder_compare(failures_law_left_hand_side,failures_law_right_hand_side,lts_preorder::lts_pre_trace));
+  BOOST_CHECK(preorder_compare(failures_law_right_hand_side,failures_law_left_hand_side,lts_preorder::lts_pre_trace));
+  BOOST_CHECK(preorder_compare(failures_law_left_hand_side,failures_law_right_hand_side,lts_preorder::lts_pre_trace_anti_chain));
+  BOOST_CHECK(preorder_compare(failures_law_right_hand_side,failures_law_left_hand_side,lts_preorder::lts_pre_trace_anti_chain));
+  BOOST_CHECK(preorder_compare(failures_law_left_hand_side,failures_law_right_hand_side,lts_preorder::lts_pre_failures_divergence_refinement));
+  BOOST_CHECK(preorder_compare(failures_law_right_hand_side,failures_law_left_hand_side,lts_preorder::lts_pre_failures_divergence_refinement));
 }
 
 // a.b + a.(b+c)
@@ -293,8 +293,8 @@ BOOST_AUTO_TEST_CASE(laws_for_failures_equivalence)
 // a.(b+c) is typically failure included in a.b+a(b+c), but not vice versa.
 BOOST_AUTO_TEST_CASE(failures_inclusion_test)
 {
-  BOOST_CHECK(preorder_compare(l1,ababc,lts_pre_failures_refinement));
-  BOOST_CHECK(!preorder_compare(ababc,l1,lts_pre_failures_refinement));
+  BOOST_CHECK(preorder_compare(l1,ababc,lts_preorder::lts_pre_failures_refinement));
+  BOOST_CHECK(!preorder_compare(ababc,l1,lts_preorder::lts_pre_failures_refinement));
 }
 
 // a.(tau.b + tau.c)
@@ -309,14 +309,14 @@ BOOST_AUTO_TEST_CASE(failures_inclusion_test)
 // a.(tau.b+tau.c) and a.b + a.c are weak failure equivalent.
 BOOST_AUTO_TEST_CASE(weak_failures_equivalence_test)
 {
-  BOOST_CHECK(!preorder_compare(l2,a_taub_tauc,lts_pre_failures_refinement));
-  BOOST_CHECK(!preorder_compare(a_taub_tauc,l2,lts_pre_failures_refinement));
-  BOOST_CHECK(preorder_compare(l2,a_taub_tauc,lts_pre_weak_trace));
-  BOOST_CHECK(preorder_compare(a_taub_tauc,l2,lts_pre_weak_trace));
-  BOOST_CHECK(preorder_compare(l2,a_taub_tauc,lts_pre_weak_trace_anti_chain));
-  BOOST_CHECK(preorder_compare(a_taub_tauc,l2,lts_pre_weak_trace_anti_chain));
-  BOOST_CHECK(preorder_compare(l2,a_taub_tauc,lts_pre_weak_failures_refinement));
-  BOOST_CHECK(preorder_compare(a_taub_tauc,l2,lts_pre_weak_failures_refinement));
+  BOOST_CHECK(!preorder_compare(l2,a_taub_tauc,lts_preorder::lts_pre_failures_refinement));
+  BOOST_CHECK(!preorder_compare(a_taub_tauc,l2,lts_preorder::lts_pre_failures_refinement));
+  BOOST_CHECK(preorder_compare(l2,a_taub_tauc,lts_preorder::lts_pre_weak_trace));
+  BOOST_CHECK(preorder_compare(a_taub_tauc,l2,lts_preorder::lts_pre_weak_trace));
+  BOOST_CHECK(preorder_compare(l2,a_taub_tauc,lts_preorder::lts_pre_weak_trace_anti_chain));
+  BOOST_CHECK(preorder_compare(a_taub_tauc,l2,lts_preorder::lts_pre_weak_trace_anti_chain));
+  BOOST_CHECK(preorder_compare(l2,a_taub_tauc,lts_preorder::lts_pre_weak_failures_refinement));
+  BOOST_CHECK(preorder_compare(a_taub_tauc,l2,lts_preorder::lts_pre_weak_failures_refinement));
 }
 
 // a.b + a.(b+c)
@@ -331,16 +331,16 @@ BOOST_AUTO_TEST_CASE(weak_failures_equivalence_test)
 // But a.tau*.(b+c) is not failures-divergence included in a.(b+c). The reverse however holds.
 BOOST_AUTO_TEST_CASE(failures_divergence_inclusion_test)
 {
-  BOOST_CHECK(!preorder_compare(l1,abc_div,lts_pre_failures_refinement));
-  BOOST_CHECK(!preorder_compare(abc_div,l1,lts_pre_failures_refinement));
-  BOOST_CHECK(preorder_compare(abc_div,l1,lts_pre_weak_trace));
-  BOOST_CHECK(preorder_compare(l1,abc_div,lts_pre_weak_trace));
-  BOOST_CHECK(preorder_compare(abc_div,l1,lts_pre_weak_trace_anti_chain));
-  BOOST_CHECK(preorder_compare(l1,abc_div,lts_pre_weak_trace_anti_chain));
-  BOOST_CHECK(!preorder_compare(l1,abc_div,lts_pre_weak_failures_refinement));
-  BOOST_CHECK(preorder_compare(abc_div,l1,lts_pre_weak_failures_refinement));
-  BOOST_CHECK(preorder_compare(l1,abc_div,lts_pre_failures_divergence_refinement));
-  BOOST_CHECK(!preorder_compare(abc_div,l1,lts_pre_failures_divergence_refinement));
+  BOOST_CHECK(!preorder_compare(l1,abc_div,lts_preorder::lts_pre_failures_refinement));
+  BOOST_CHECK(!preorder_compare(abc_div,l1,lts_preorder::lts_pre_failures_refinement));
+  BOOST_CHECK(preorder_compare(abc_div,l1,lts_preorder::lts_pre_weak_trace));
+  BOOST_CHECK(preorder_compare(l1,abc_div,lts_preorder::lts_pre_weak_trace));
+  BOOST_CHECK(preorder_compare(abc_div,l1,lts_preorder::lts_pre_weak_trace_anti_chain));
+  BOOST_CHECK(preorder_compare(l1,abc_div,lts_preorder::lts_pre_weak_trace_anti_chain));
+  BOOST_CHECK(!preorder_compare(l1,abc_div,lts_preorder::lts_pre_weak_failures_refinement));
+  BOOST_CHECK(preorder_compare(abc_div,l1,lts_preorder::lts_pre_weak_failures_refinement));
+  BOOST_CHECK(preorder_compare(l1,abc_div,lts_preorder::lts_pre_failures_divergence_refinement));
+  BOOST_CHECK(!preorder_compare(abc_div,l1,lts_preorder::lts_pre_failures_divergence_refinement));
 }
 
 //  Example by Verum showing an error in the weak failures inclusion check. Did not work with 
@@ -368,21 +368,21 @@ BOOST_AUTO_TEST_CASE(failures_divergence_inclusion_test)
   
 BOOST_AUTO_TEST_CASE(verum_test)
 {
-  BOOST_CHECK(!preorder_compare(lts_impl,lts_spec,lts_pre_failures_refinement));
-  BOOST_CHECK(!preorder_compare(lts_impl,lts_spec,lts_pre_failures_divergence_refinement));
-  BOOST_CHECK(!preorder_compare(lts_impl,lts_spec,lts_pre_weak_failures_refinement));
-  BOOST_CHECK(!preorder_compare(lts_impl,lts_spec,lts_pre_weak_trace));
-  BOOST_CHECK(!preorder_compare(lts_impl,lts_spec,lts_pre_trace));
-  BOOST_CHECK(!preorder_compare(lts_impl,lts_spec,lts_pre_weak_trace_anti_chain));
-  BOOST_CHECK(!preorder_compare(lts_impl,lts_spec,lts_pre_trace_anti_chain));
+  BOOST_CHECK(!preorder_compare(lts_impl,lts_spec,lts_preorder::lts_pre_failures_refinement));
+  BOOST_CHECK(!preorder_compare(lts_impl,lts_spec,lts_preorder::lts_pre_failures_divergence_refinement));
+  BOOST_CHECK(!preorder_compare(lts_impl,lts_spec,lts_preorder::lts_pre_weak_failures_refinement));
+  BOOST_CHECK(!preorder_compare(lts_impl,lts_spec,lts_preorder::lts_pre_weak_trace));
+  BOOST_CHECK(!preorder_compare(lts_impl,lts_spec,lts_preorder::lts_pre_trace));
+  BOOST_CHECK(!preorder_compare(lts_impl,lts_spec,lts_preorder::lts_pre_weak_trace_anti_chain));
+  BOOST_CHECK(!preorder_compare(lts_impl,lts_spec,lts_preorder::lts_pre_trace_anti_chain));
 
-  BOOST_CHECK(!preorder_compare(lts_spec,lts_impl,lts_pre_failures_refinement));
-  BOOST_CHECK(preorder_compare(lts_spec,lts_impl,lts_pre_failures_divergence_refinement));
-  BOOST_CHECK(preorder_compare(lts_spec,lts_impl,lts_pre_weak_failures_refinement));
-  BOOST_CHECK(preorder_compare(lts_spec,lts_impl,lts_pre_weak_trace));
-  BOOST_CHECK(!preorder_compare(lts_spec,lts_impl,lts_pre_trace));
-  BOOST_CHECK(preorder_compare(lts_spec,lts_impl,lts_pre_weak_trace_anti_chain));
-  BOOST_CHECK(!preorder_compare(lts_spec,lts_impl,lts_pre_trace_anti_chain));
+  BOOST_CHECK(!preorder_compare(lts_spec,lts_impl,lts_preorder::lts_pre_failures_refinement));
+  BOOST_CHECK(preorder_compare(lts_spec,lts_impl,lts_preorder::lts_pre_failures_divergence_refinement));
+  BOOST_CHECK(preorder_compare(lts_spec,lts_impl,lts_preorder::lts_pre_weak_failures_refinement));
+  BOOST_CHECK(preorder_compare(lts_spec,lts_impl,lts_preorder::lts_pre_weak_trace));
+  BOOST_CHECK(!preorder_compare(lts_spec,lts_impl,lts_preorder::lts_pre_trace));
+  BOOST_CHECK(preorder_compare(lts_spec,lts_impl,lts_preorder::lts_pre_weak_trace_anti_chain));
+  BOOST_CHECK(!preorder_compare(lts_spec,lts_impl,lts_preorder::lts_pre_trace_anti_chain));
 }
 
 // P = a.P + tau.P
@@ -403,8 +403,8 @@ const std::string bP =
 // not hold.
 BOOST_AUTO_TEST_CASE(failures_divergence_incomparable_test)
 {
-  BOOST_CHECK(!preorder_compare(aPtauP, bP, lts_pre_failures_refinement)); // empty = failures(aPtauP) subset failures(bP); traces(aPtauP) nsubset traces(bP).
-  BOOST_CHECK(preorder_compare(bP, aPtauP, lts_pre_failures_divergence_refinement)); // failures(bP) subset failures(aPtau) != empty because divergences.
+  BOOST_CHECK(!preorder_compare(aPtauP, bP, lts_preorder::lts_pre_failures_refinement)); // empty = failures(aPtauP) subset failures(bP); traces(aPtauP) nsubset traces(bP).
+  BOOST_CHECK(preorder_compare(bP, aPtauP, lts_preorder::lts_pre_failures_divergence_refinement)); // failures(bP) subset failures(aPtau) != empty because divergences.
 }
 
 

--- a/tools/release/ltscompare/ltscompare.cpp
+++ b/tools/release/ltscompare/ltscompare.cpp
@@ -30,7 +30,7 @@ struct t_tool_options
   lts_type        format_for_first = lts_none;
   lts_type        format_for_second = lts_none;
   lts_equivalence equivalence = lts_eq_none;
-  lts_preorder    preorder = lts_pre_none;
+  lts_preorder    preorder = lts_preorder::lts_pre_none;
   mcrl2::lps::exploration_strategy strategy = mcrl2::lps::es_breadth;
   std::vector<std::string> tau_actions;   // Actions with these labels must be considered equal to tau.
   bool generate_counter_examples = false;
@@ -50,12 +50,12 @@ class ltscompare_tool : public ltscompare_base
     // --equivalence or --preorder options
     void check_preconditions()
     {
-      if (tool_options.equivalence != lts_eq_none && tool_options.preorder != lts_pre_none)
+      if (tool_options.equivalence != lts_eq_none && tool_options.preorder != lts_preorder::lts_pre_none)
       {
         throw mcrl2::runtime_error("options -e/--equivalence and -p/--preorder cannot be used simultaneously");
       }
 
-      if (tool_options.equivalence == lts_eq_none && tool_options.preorder == lts_pre_none)
+      if (tool_options.equivalence == lts_eq_none && tool_options.preorder == lts_preorder::lts_pre_none)
       {
         throw mcrl2::runtime_error("one of the options -e/--equivalence and -p/--preorder must be used");
       }
@@ -108,7 +108,7 @@ class ltscompare_tool : public ltscompare_base
                        << description(tool_options.equivalence) << ")\n";
       }
 
-      if (tool_options.preorder != lts_pre_none)
+      if (tool_options.preorder != lts_preorder::lts_pre_none)
       {
         mCRL2log(verbose) << "comparing LTSs for " <<
                      description(tool_options.preorder) << "..."
@@ -243,16 +243,16 @@ class ltscompare_tool : public ltscompare_base
                  .add_value(lts_eq_coupled_sim),
                  "use equivalence NAME (not allowed in combination with -p/--preorder):", 'e').
       add_option("preorder", make_enum_argument<lts_preorder>("NAME")
-                 .add_value(lts_pre_none, true)
-                 .add_value(lts_pre_sim)
-                 .add_value(lts_pre_ready_sim)
-                 .add_value(lts_pre_trace)
-                 .add_value(lts_pre_weak_trace)
-                 .add_value(lts_pre_trace_anti_chain)
-                 .add_value(lts_pre_weak_trace_anti_chain)
-                 .add_value(lts_pre_failures_refinement)
-                 .add_value(lts_pre_weak_failures_refinement)
-                 .add_value(lts_pre_failures_divergence_refinement),
+                 .add_value(lts_preorder::lts_pre_none, true)
+                 .add_value(lts_preorder::lts_pre_sim)
+                 .add_value(lts_preorder::lts_pre_ready_sim)
+                 .add_value(lts_preorder::lts_pre_trace)
+                 .add_value(lts_preorder::lts_pre_weak_trace)
+                 .add_value(lts_preorder::lts_pre_trace_anti_chain)
+                 .add_value(lts_preorder::lts_pre_weak_trace_anti_chain)
+                 .add_value(lts_preorder::lts_pre_failures_refinement)
+                 .add_value(lts_preorder::lts_pre_weak_failures_refinement)
+                 .add_value(lts_preorder::lts_pre_failures_divergence_refinement),
                  "use preorder NAME (not allowed in combination with -e/--equivalence):", 'p').
       add_option("strategy", make_enum_argument<mcrl2::lps::exploration_strategy>("NAME")
                  .add_value_short(mcrl2::lps::es_breadth, "b", true)
@@ -282,19 +282,19 @@ class ltscompare_tool : public ltscompare_base
 
       if (parser.has_option("counter-example") && parser.has_option("preorder"))
       {
-        if (tool_options.preorder == lts_pre_sim)
+        if (tool_options.preorder == lts_preorder::lts_pre_sim)
         {
           parser.error("counter examples cannot be used with simulation pre-order");
         }
-        if (tool_options.preorder == lts_pre_ready_sim)
+        if (tool_options.preorder == lts_preorder::lts_pre_ready_sim)
         {
           parser.error("counter examples cannot be used with ready simulation pre-order");
         }
-        if (tool_options.preorder == lts_pre_trace)
+        if (tool_options.preorder == lts_preorder::lts_pre_trace)
         {
           parser.error("counter examples cannot be used with the plain trace pre-order (use trace-ac instead)");
         }
-        if (tool_options.preorder == lts_pre_weak_trace)
+        if (tool_options.preorder == lts_preorder::lts_pre_weak_trace)
         {
           parser.error("counter examples cannot be used with the plain weak trace pre-order (use weak-trace-ac instead");
         }
@@ -338,11 +338,11 @@ class ltscompare_tool : public ltscompare_base
           mCRL2log(mcrl2::log::warning) << "Generated counter example might not be the shortest with the " << print_exploration_strategy(tool_options.strategy) << " strategy.\n";
         }
 
-        if (tool_options.preorder != lts_pre_trace_anti_chain
-            && tool_options.preorder != lts_pre_weak_trace_anti_chain
-            && tool_options.preorder != lts_pre_failures_refinement
-            && tool_options.preorder != lts_pre_weak_failures_refinement
-            && tool_options.preorder != lts_pre_failures_divergence_refinement)
+        if (tool_options.preorder != lts_preorder::lts_pre_trace_anti_chain
+            && tool_options.preorder != lts_preorder::lts_pre_weak_trace_anti_chain
+            && tool_options.preorder != lts_preorder::lts_pre_failures_refinement
+            && tool_options.preorder != lts_preorder::lts_pre_weak_failures_refinement
+            && tool_options.preorder != lts_preorder::lts_pre_failures_divergence_refinement)
         {
           parser.error("strategy can only be chosen for antichain based algorithms.");
         }

--- a/tools/release/ltscompare/ltscompare.cpp
+++ b/tools/release/ltscompare/ltscompare.cpp
@@ -252,7 +252,8 @@ class ltscompare_tool : public ltscompare_base
                  .add_value(lts_preorder::lts_pre_weak_trace_anti_chain)
                  .add_value(lts_preorder::lts_pre_failures_refinement)
                  .add_value(lts_preorder::lts_pre_weak_failures_refinement)
-                 .add_value(lts_preorder::lts_pre_failures_divergence_refinement),
+                 .add_value(lts_preorder::lts_pre_failures_divergence_refinement)
+                 .add_value(lts_preorder::lts_pre_impossible_futures),
                  "use preorder NAME (not allowed in combination with -e/--equivalence):", 'p').
       add_option("strategy", make_enum_argument<mcrl2::lps::exploration_strategy>("NAME")
                  .add_value_short(mcrl2::lps::es_breadth, "b", true)


### PR DESCRIPTION
The preorder can be checked with the new flag `-pimpossible-futures` and checks for impossible futures refinement between the implementation and the specification LTS.