### PR TITLE
Add logging statement for the calculation of process operators over linear processes

### DIFF
--- a/libraries/lps/include/mcrl2/lps/detail/configuration.h
+++ b/libraries/lps/include/mcrl2/lps/detail/configuration.h
@@ -1,0 +1,23 @@
+// Author(s): Maurice Laveaux
+// Copyright: see the accompanying file COPYING or copy at
+// https://github.com/mCRL2org/mCRL2/blob/master/COPYING
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+// \file mcrl2/lps/detail/configuration.h
+// \brief Configuration options for the LPS library.
+
+#ifndef MCRL2_LPS_DETAIL_CONFIGURATION_H_
+#define MCRL2_LPS_DETAIL_CONFIGURATION_H_
+
+namespace mcrl2::lps::detail
+{
+
+/// \brief If true, statistics are logged for the linearisation of allow and block operators.
+constexpr bool EnableLineariseStatistics = false;
+
+} // namespace mcrl2::lps::detail
+
+#endif // MCRL2_LPS_DETAIL_CONFIGURATION_H_

--- a/libraries/lps/include/mcrl2/lps/linearise_allow_block.h
+++ b/libraries/lps/include/mcrl2/lps/linearise_allow_block.h
@@ -14,10 +14,10 @@
 
 #include "mcrl2/atermpp/aterm_list.h"
 #include "mcrl2/lps/deadlock_summand.h"
-#include "mcrl2/lps/stochastic_action_summand.h"
+#include "mcrl2/lps/detail/configuration.h"
 #include "mcrl2/lps/linearise_utility.h"
+#include "mcrl2/lps/stochastic_action_summand.h"
 #include "mcrl2/process/process_expression.h"
-
 
 namespace mcrl2
 {
@@ -25,16 +25,14 @@ namespace mcrl2
 namespace lps
 {
 
-#ifdef MCRL2_LOG_LPS_LINEARISE_STATISTICS
-inline
-std::string log_allow_block_application(const lps_statistics_t& lps_statistics_before,
-                                 const lps_statistics_t& lps_statistics_after,
-                                 const bool is_allow,
-                                 const std::size_t num_allowed_multiactions,
-                                 const std::size_t num_blocked_actions,
-                                 const bool apply_delta_elimination,
-                                 const bool ignore_time,
-                                 size_t indent = 0)
+inline std::string log_allow_block_application(const lps_statistics_t& lps_statistics_before,
+    const lps_statistics_t& lps_statistics_after,
+    const bool is_allow,
+    const std::size_t num_allowed_multiactions,
+    const std::size_t num_blocked_actions,
+    const bool apply_delta_elimination,
+    const bool ignore_time,
+    size_t indent = 0)
 {
   std::string indent_str(indent, ' ');
   std::ostringstream os;
@@ -58,12 +56,12 @@ std::string log_allow_block_application(const lps_statistics_t& lps_statistics_b
 
   os << indent_str << std::boolalpha << "apply delta elimination: " << apply_delta_elimination << std::endl
      << indent_str << "ignore time: " << ignore_time << std::endl
-     << indent_str << "before:" << std::endl << print(lps_statistics_before, indent+2)
-     << indent_str << "after:" << std::endl << print(lps_statistics_after, indent+2);
+     << indent_str << "before:" << std::endl
+     << print(lps_statistics_before, indent + 2) << indent_str << "after:" << std::endl
+     << print(lps_statistics_after, indent + 2);
 
   return os.str();
 }
-#endif //MCRL2_LOG_LPS_LINEARISE_STATISTICS
 
 /**************** allow/block *************************************/
 
@@ -73,15 +71,14 @@ std::string log_allow_block_application(const lps_statistics_t& lps_statistics_b
 /// \param multi_action A multiaction b1(d1)|...|bm(dm)
 /// \param termination_action The action that encodes successful termination (used only in debug mode)
 /// \returns n == m and ai == bi for 1 <= i <= n
-inline
-bool allow_(const process::action_name_multiset& allow_action,
-            const process::action_list& multi_action,
-            const process::action& termination_action)
+inline bool allow_(const process::action_name_multiset& allow_action,
+    const process::action_list& multi_action,
+    const process::action& termination_action)
 {
   /* The special cases where multiaction==tau and multiaction=={ Terminated } must have been
      dealt with separately. */
   assert(!multi_action.empty());
-  assert(multi_action != process::action_list({ termination_action }));
+  assert(multi_action != process::action_list({termination_action}));
   assert(std::is_sorted(allow_action.names().begin(), allow_action.names().end(), action_name_compare()));
   assert(std::is_sorted(multi_action.begin(), multi_action.end(), action_compare()));
 
@@ -114,18 +111,17 @@ bool allow_(const process::action_name_multiset& allow_action,
 ///
 /// Calculates if the names of the action in multi_action match with an expression in allow_list.
 /// If multi_action is the termination action, or multi_action is the empty multiaction, the result is also true.
-inline
-bool allow_(const process::action_name_multiset_list& allow_list,
-            const process::action_list& multi_action,
-            const process::action& termination_action)
+inline bool allow_(const process::action_name_multiset_list& allow_list,
+    const process::action_list& multi_action,
+    const process::action& termination_action)
 {
   // The empty multiaction and the termination action can never be blocked by allows.
-  if (multi_action.empty() || multi_action == process::action_list({ termination_action }))
+  if (multi_action.empty() || multi_action == process::action_list({termination_action}))
   {
     return true;
   }
 
-  for (const process::action_name_multiset& allow_action: allow_list)
+  for (const process::action_name_multiset& allow_action : allow_list)
   {
     if (allow_(allow_action, multi_action, termination_action))
     {
@@ -140,8 +136,7 @@ bool allow_(const process::action_name_multiset_list& allow_list,
 /// \param encap_list is a list of action_name_multisets of size 1. Its single element contains all the blocked actions.
 /// \param multi_action contains a multiaction a1(d1)|...|an(dn)
 /// \returns \exists i: ai \in encap_list
-inline
-bool encap(const process::action_name_multiset_list& encaplist, const process::action_list& multiaction)
+inline bool encap(const process::action_name_multiset_list& encaplist, const process::action_list& multiaction)
 {
   assert(encaplist.size() == 1);
   assert(std::is_sorted(multiaction.begin(), multiaction.end(), action_compare()));
@@ -184,27 +179,27 @@ bool encap(const process::action_name_multiset_list& encaplist, const process::a
 /// \param action_summands the summands over which to compute the operator
 /// \param deadlock_summands the deadlock summands tha may be extended.
 /// \param termination_action the termination action generated by the linearizer. This action is always allowed.
-/// \param ignore_time if true, and nodeltaelimination is false, a true->delta summand is added that subsumes all other deadlock summands
-/// \param nodeltaaelimination do not eliminate deadlock summands.
-void allowblockcomposition(
-      const process::action_name_multiset_list& allowlist1,  // This is a list of list of identifierstring.
-      const bool is_allow,
-      stochastic_action_summand_vector& action_summands,
-      deadlock_summand_vector& deadlock_summands,
-      const process::action& termination_action,
-      bool ignore_time,
-      bool nodeltaelimination)
+/// \param ignore_time if true, and nodeltaelimination is false, a true->delta summand is added that subsumes all other
+/// deadlock summands \param nodeltaaelimination do not eliminate deadlock summands.
+inline void allowblockcomposition(
+    const process::action_name_multiset_list& allowlist1, // This is a list of list of identifierstring.
+    const bool is_allow,
+    stochastic_action_summand_vector& action_summands,
+    deadlock_summand_vector& deadlock_summands,
+    const process::action& termination_action,
+    bool ignore_time,
+    bool nodeltaelimination)
 {
-#ifdef MCRL2_LOG_LPS_LINEARISE_STATISTICS
+  // Only keep statistics when these are relevant.
   lps_statistics_t lps_statistics_before = get_statistics(action_summands, deadlock_summands);
-#endif
 
-  mCRL2log(mcrl2::log::trace) << "Calculating " << ((is_allow)?"allow":"block") << " composition using a set of "
-    << ((is_allow)?allowlist1.size():allowlist1.front().size())
-    << ((is_allow)?" allowed multiactions":" blocked actions") << std::endl;
-  mCRL2log(mcrl2::log::trace) << ((is_allow)?"Allowed multiactions: ":"Blocked actions: ") << std::endl
-    << ((is_allow)?core::detail::print_set(allowlist1):core::detail::print_set(allowlist1.front()))
-    << std::endl;
+  mCRL2log(mcrl2::log::trace) << "Calculating " << ((is_allow) ? "allow" : "block") << " composition using a set of "
+                              << ((is_allow) ? allowlist1.size() : allowlist1.front().size())
+                              << ((is_allow) ? " allowed multiactions" : " blocked actions") << std::endl;
+  mCRL2log(mcrl2::log::trace) << ((is_allow) ? "Allowed multiactions: " : "Blocked actions: ") << std::endl
+                              << ((is_allow) ? core::detail::print_set(allowlist1)
+                                             : core::detail::print_set(allowlist1.front()))
+                              << std::endl;
   /* This function calculates the allow or the block operator,
    depending on whether is_allow is true */
 
@@ -215,17 +210,18 @@ void allowblockcomposition(
   deadlock_summand_vector resultsimpledeltasumlist;
   deadlock_summands.swap(resultdeltasumlist);
 
-  process::action_name_multiset_list allowlist((is_allow)?sort_multi_action_labels(allowlist1):allowlist1);
+  process::action_name_multiset_list allowlist((is_allow) ? sort_multi_action_labels(allowlist1) : allowlist1);
 
-  std::size_t sourcesumlist_length=sourcesumlist.size();
-  if (sourcesumlist_length>2 || is_allow) // This condition prevents this message to be printed
+  std::size_t sourcesumlist_length = sourcesumlist.size();
+  if (sourcesumlist_length > 2 || is_allow) // This condition prevents this message to be printed
   // when performing data elimination. In this case the
   // term delta is linearised, to determine which data
   // is essential for all processes. In these cases a
   // message about the block operator is very confusing.
   {
-  mCRL2log(mcrl2::log::verbose) << "- calculating the " << (is_allow?"allow":"block") <<
-        " operator on " << sourcesumlist.size() << " action summands and " << resultdeltasumlist.size() << " delta summands";
+    mCRL2log(mcrl2::log::verbose) << "- calculating the " << (is_allow ? "allow" : "block") << " operator on "
+                                  << sourcesumlist.size() << " action summands and " << resultdeltasumlist.size()
+                                  << " delta summands";
   }
 
   /* First add the resulting sums in two separate lists
@@ -234,16 +230,16 @@ void allowblockcomposition(
    each delta summand it is determined whether it ought
    to be added, or is superseded by an action or another
    delta summand */
-  for (const stochastic_action_summand& smmnd: sourcesumlist)
+  for (const stochastic_action_summand& smmnd : sourcesumlist)
   {
-    const data::variable_list& sumvars=smmnd.summation_variables();
-    const process::action_list& multiaction=smmnd.multi_action().actions();
-    const data::data_expression& actiontime=smmnd.multi_action().time();
-    const data::data_expression& condition=smmnd.condition();
+    const data::variable_list& sumvars = smmnd.summation_variables();
+    const process::action_list& multiaction = smmnd.multi_action().actions();
+    const data::data_expression& actiontime = smmnd.multi_action().time();
+    const data::data_expression& condition = smmnd.condition();
 
     // Explicitly allow the termination action in any allow.
-    if ((is_allow && allow_(allowlist,multiaction,termination_action)) ||
-        (!is_allow && !encap(allowlist,multiaction)))
+    if ((is_allow && allow_(allowlist, multiaction, termination_action))
+        || (!is_allow && !encap(allowlist, multiaction)))
     {
       action_summands.push_back(smmnd);
     }
@@ -252,7 +248,7 @@ void allowblockcomposition(
       resultdeltasumlist.push_back(deadlock_summand(sumvars, condition, deadlock(actiontime)));
     }
     // summand has no time.
-    else if (condition==data::sort_bool::true_())
+    else if (condition == data::sort_bool::true_())
     {
       resultsimpledeltasumlist.push_back(deadlock_summand(sumvars, condition, deadlock()));
     }
@@ -265,48 +261,54 @@ void allowblockcomposition(
   if (nodeltaelimination)
   {
     deadlock_summands.swap(resultsimpledeltasumlist);
-    copy(resultdeltasumlist.begin(),resultdeltasumlist.end(),back_inserter(deadlock_summands));
+    copy(resultdeltasumlist.begin(), resultdeltasumlist.end(), back_inserter(deadlock_summands));
   }
   else if (!ignore_time) /* if a delta summand is added, conditional, timed
                              delta's are subsumed and do not need to be added */
   {
-    for (const deadlock_summand& summand: resultsimpledeltasumlist)
+    for (const deadlock_summand& summand : resultsimpledeltasumlist)
     {
-      insert_timed_delta_summand(action_summands,deadlock_summands,summand,ignore_time);
+      insert_timed_delta_summand(action_summands, deadlock_summands, summand, ignore_time);
     }
-    for (const deadlock_summand& summand: resultdeltasumlist)
+    for (const deadlock_summand& summand : resultdeltasumlist)
     {
-      insert_timed_delta_summand(action_summands,deadlock_summands,summand,ignore_time);
+      insert_timed_delta_summand(action_summands, deadlock_summands, summand, ignore_time);
     }
   }
   else
   {
     // Add a true -> delta
-    insert_timed_delta_summand(action_summands,deadlock_summands,deadlock_summand(data::variable_list(),data::sort_bool::true_(),deadlock()), ignore_time);
+    insert_timed_delta_summand(action_summands,
+        deadlock_summands,
+        deadlock_summand(data::variable_list(), data::sort_bool::true_(), deadlock()),
+        ignore_time);
   }
-  if (mCRL2logEnabled(mcrl2::log::verbose) && (sourcesumlist_length>2 || is_allow))
+  
+  if (mCRL2logEnabled(mcrl2::log::verbose) && (sourcesumlist_length > 2 || is_allow))
   {
-    mCRL2log(mcrl2::log::verbose) << ", resulting in " << action_summands.size() << " action summands and " << deadlock_summands.size() << " delta summands\n";
+    mCRL2log(mcrl2::log::verbose) << ", resulting in " << action_summands.size() << " action summands and "
+                                  << deadlock_summands.size() << " delta summands\n";
   }
 
-#ifdef MCRL2_LOG_LPS_LINEARISE_STATISTICS
-  if (sourcesumlist_length>2 || is_allow)
+  if constexpr (detail::EnableLineariseStatistics && (sourcesumlist_length > 2 || is_allow))
   {
     // This function is also called when performing data elimination.
     // In that case, there is a block operation that linearizes the term delta.
     // It cannot be correlated to the input process, and the data is confusion.
     lps_statistics_t lps_statistics_after = get_statistics(action_summands, deadlock_summands);
-    std::cout << log_allow_block_application(lps_statistics_before, lps_statistics_after, is_allow,
-      (is_allow?allowlist.size():0), (is_allow?0:allowlist.front().size()),
-      !nodeltaelimination, ignore_time);
+
+    std::cout << log_allow_block_application(lps_statistics_before,
+        lps_statistics_after,
+        is_allow,
+        (is_allow ? allowlist.size() : 0),
+        (is_allow ? 0 : allowlist.front().size()),
+        !nodeltaelimination,
+        ignore_time);
   }
-#endif
 }
 
 } // namespace lps
 
 } // namespace mcrl2
-
-
 
 #endif // MCRL2_LPS_LINEARISE_ALLLOW_BLOCK_H

--- a/libraries/lps/include/mcrl2/lps/linearise_allow_block.h
+++ b/libraries/lps/include/mcrl2/lps/linearise_allow_block.h
@@ -25,6 +25,7 @@ namespace mcrl2
 namespace lps
 {
 
+#ifdef MCRL2_LOG_LPS_LINEARISE_STATISTICS
 inline
 std::string log_allow_block_application(const lps_statistics_t& lps_statistics_before,
                                  const lps_statistics_t& lps_statistics_after,
@@ -62,6 +63,7 @@ std::string log_allow_block_application(const lps_statistics_t& lps_statistics_b
 
   return os.str();
 }
+#endif //MCRL2_LOG_LPS_LINEARISE_STATISTICS
 
 /**************** allow/block *************************************/
 

--- a/libraries/lps/include/mcrl2/lps/linearise_communication.h
+++ b/libraries/lps/include/mcrl2/lps/linearise_communication.h
@@ -12,14 +12,16 @@
 #ifndef MCRL2_LPS_LINEARISE_COMMUNICATION_H
 #define MCRL2_LPS_LINEARISE_COMMUNICATION_H
 
-#include <optional>
 #include "mcrl2/atermpp/aterm_list.h"
 #include "mcrl2/core/detail/print_utility.h"
 #include "mcrl2/lps/linearise_allow_block.h"
 #include "mcrl2/lps/linearise_utility.h"
 #include "mcrl2/lps/stochastic_action_summand.h"
 #include "mcrl2/lps/sumelm.h"
+#include "mcrl2/lps/detail/configuration.h"
 #include "mcrl2/process/process_expression.h"
+
+#include <optional>
 
 namespace mcrl2
 {
@@ -34,8 +36,7 @@ namespace detail
 /// The result does not contain duplicates.
 /// We use this to remove possible communication results that are not relevant because they
 /// are guaranteed to be removed from the result after the fact.
-inline
-std::vector<core::identifier_string> get_actions(const process::action_name_multiset_list& allowlist)
+inline std::vector<core::identifier_string> get_actions(const process::action_name_multiset_list& allowlist)
 {
   std::vector<core::identifier_string> result;
   for (const process::action_name_multiset& l : allowlist)
@@ -54,8 +55,8 @@ std::vector<core::identifier_string> get_actions(const process::action_name_mult
 /// can occur.
 struct tuple_list
 {
-  std::vector < process::action_list > actions;
-  std::vector < data::data_expression > conditions;
+  std::vector<process::action_list> actions;
+  std::vector<data::data_expression> conditions;
 
   std::size_t size() const
   {
@@ -65,12 +66,14 @@ struct tuple_list
 
   tuple_list() = default;
 
-  tuple_list(const std::vector < process::action_list>& actions_, const std::vector< data::data_expression >& conditions_)
-    : actions(actions_), conditions(conditions_)
+  tuple_list(const std::vector<process::action_list>& actions_, const std::vector<data::data_expression>& conditions_)
+      : actions(actions_),
+        conditions(conditions_)
   {}
 
-  tuple_list(std::vector < process::action_list>&& actions_, std::vector< data::data_expression >&& conditions_)
-    : actions(std::move(actions_)), conditions(std::move(conditions_))
+  tuple_list(std::vector<process::action_list>&& actions_, std::vector<data::data_expression>&& conditions_)
+      : actions(std::move(actions_)),
+        conditions(std::move(conditions_))
   {}
 };
 
@@ -80,18 +83,20 @@ struct tuple_list
 /// and make it explicit that L should not be used by the caller afterwards.
 /// If firstaction == action(), it is not added to the multiactions in L', but the conditions will be strengthened.
 /// \pre condition != sort_bool::false_()
-inline
-void addActionCondition(const process::action& a, const data::data_expression& c, tuple_list&& L, tuple_list& S)
+inline void addActionCondition(const process::action& a, const data::data_expression& c, tuple_list&& L, tuple_list& S)
 {
-  assert(c!=data::sort_bool::false_()); // It makes no sense to add an action with condition false, as it cannot happen anyhow.
+  assert(c != data::sort_bool::false_()); // It makes no sense to add an action with condition false, as it cannot
+                                          // happen anyhow.
 
   if (a == process::action())
   {
-    S.actions.insert(S.actions.end(), std::make_move_iterator(L.actions.begin()), std::make_move_iterator(L.actions.end()));
+    S.actions.insert(S.actions.end(),
+        std::make_move_iterator(L.actions.begin()),
+        std::make_move_iterator(L.actions.end()));
   }
   else
   {
-    for (process::action_list& m: L.actions)
+    for (process::action_list& m : L.actions)
     {
       m = insert(a, m);
       S.actions.emplace_back(std::move(m));
@@ -100,12 +105,14 @@ void addActionCondition(const process::action& a, const data::data_expression& c
 
   if (c == data::sort_bool::true_())
   {
-    S.conditions.insert(S.conditions.end(), std::make_move_iterator(L.conditions.begin()), std::make_move_iterator(L.conditions.end()));
+    S.conditions.insert(S.conditions.end(),
+        std::make_move_iterator(L.conditions.begin()),
+        std::make_move_iterator(L.conditions.end()));
   }
   else
   {
     // Strengthen the conditions in L with condition and append to S.
-    for (const data::data_expression& x: L.conditions)
+    for (const data::data_expression& x : L.conditions)
     {
       S.conditions.emplace_back(data::lazy::and_(x, c));
     }
@@ -115,156 +122,158 @@ void addActionCondition(const process::action& a, const data::data_expression& c
 /// Data structure to store the communication function more efficiently.
 class comm_entry
 {
-  protected:
-    /// Left-hand sides of communication expressions
-    const std::vector<core::identifier_string_list> m_lhs;
+protected:
+  /// Left-hand sides of communication expressions
+  const std::vector<core::identifier_string_list> m_lhs;
 
-    /// Right-hand sides of communication expressions
-    const std::vector<core::identifier_string> m_rhs;
+  /// Right-hand sides of communication expressions
+  const std::vector<core::identifier_string> m_rhs;
 
-    /// Temporary data using in determining whether communication is allowed.
-    /// See usages of the data structure below.
-    std::vector<core::identifier_string_list::const_iterator> m_lhs_iters; // offset into lhs
-    std::vector<bool> m_match_failed;
+  /// Temporary data using in determining whether communication is allowed.
+  /// See usages of the data structure below.
+  std::vector<core::identifier_string_list::const_iterator> m_lhs_iters; // offset into lhs
+  std::vector<bool> m_match_failed;
 
-    void reset_temporary_data()
+  void reset_temporary_data()
+  {
+    for (std::size_t i = 0; i < size(); ++i)
     {
+      m_lhs_iters[i] = m_lhs[i].begin();
+      m_match_failed[i] = false;
+    }
+  }
+
+  /// Check if m is contained in a lhs in the communication entry. (in fact, it must be a prefix).
+  /// Returns true if this is the case, false otherwise.
+  /// Postcondition: for every i such that m is not contained in lhs[i], match_failed[i] is true.
+  /// NB: resets temporary data before performing computations.
+  bool match_multiaction(const process::action_list& multi_action)
+  {
+    assert(std::is_sorted(multi_action.begin(), multi_action.end(), action_compare()));
+
+    reset_temporary_data();
+
+    // m must match a lhs; check every action
+    for (const process::action& action : multi_action)
+    {
+      // check every lhs for actionname
+      bool comm_ok = false;
       for (std::size_t i = 0; i < size(); ++i)
       {
-        m_lhs_iters[i] = m_lhs[i].begin();
-        m_match_failed[i] = false;
-      }
-    }
-
-    /// Check if m is contained in a lhs in the communication entry. (in fact, it must be a prefix).
-    /// Returns true if this is the case, false otherwise.
-    /// Postcondition: for every i such that m is not contained in lhs[i], match_failed[i] is true.
-    /// NB: resets temporary data before performing computations.
-    bool match_multiaction(const process::action_list& multi_action) {
-      assert(std::is_sorted(multi_action.begin(), multi_action.end(), action_compare()));
-
-      reset_temporary_data();
-
-      // m must match a lhs; check every action
-      for (const process::action& action: multi_action)
-      {
-        // check every lhs for actionname
-        bool comm_ok = false;
-        for (std::size_t i=0; i < size(); ++i)
+        if (m_match_failed[i]) // lhs i does not match
         {
-          if (m_match_failed[i]) // lhs i does not match
-          {
-            continue;
-          }
-          if (m_lhs_iters[i] == m_lhs[i].end()) // lhs cannot match actionname
-          {
-            m_match_failed[i]=true;
-            continue;
-          }
-          if (action.label().name() != *m_lhs_iters[i])
-          {
-            // no match
-            m_match_failed[i] = true;
-          }
-          else
-          {
-            // possible match; on to next action
-            ++m_lhs_iters[i];
-            comm_ok = true;
-          }
+          continue;
         }
-
-        if (!comm_ok)   // no (possibly) matching lhs
+        if (m_lhs_iters[i] == m_lhs[i].end()) // lhs cannot match actionname
         {
-          return false;
+          m_match_failed[i] = true;
+          continue;
+        }
+        if (action.label().name() != *m_lhs_iters[i])
+        {
+          // no match
+          m_match_failed[i] = true;
+        }
+        else
+        {
+          // possible match; on to next action
+          ++m_lhs_iters[i];
+          comm_ok = true;
         }
       }
 
-      // There must be an lhs that contains m.
-      return true;
-    }
-
-    // Initialization of lhs, defined as static function so it can be used in the constructor.
-    // Allows lhs to be defined as const.
-    static std::vector < core::identifier_string_list > init_lhs(const process::communication_expression_list& communications)
-    {
-      std::vector<core::identifier_string_list> result;
-      for (const process::communication_expression& l: communications)
+      if (!comm_ok) // no (possibly) matching lhs
       {
-        const core::identifier_string_list& names = l.action_name().names();
-        assert(std::is_sorted(names.begin(), names.end(), action_name_compare()));
-        result.emplace_back(names.begin(), names.end());
+        return false;
       }
-      return result;
     }
 
-    // Initialization of rhs, defined as static function so it can be used in the constructor.
-    // Allows rhs to be defined as const.
-    static std::vector <core::identifier_string> init_rhs(const process::communication_expression_list& communications)
+    // There must be an lhs that contains m.
+    return true;
+  }
+
+  // Initialization of lhs, defined as static function so it can be used in the constructor.
+  // Allows lhs to be defined as const.
+  static std::vector<core::identifier_string_list> init_lhs(
+      const process::communication_expression_list& communications)
+  {
+    std::vector<core::identifier_string_list> result;
+    for (const process::communication_expression& l : communications)
     {
-      std::vector <core::identifier_string> result;
-      for (const process::communication_expression& l: communications)
+      const core::identifier_string_list& names = l.action_name().names();
+      assert(std::is_sorted(names.begin(), names.end(), action_name_compare()));
+      result.emplace_back(names.begin(), names.end());
+    }
+    return result;
+  }
+
+  // Initialization of rhs, defined as static function so it can be used in the constructor.
+  // Allows rhs to be defined as const.
+  static std::vector<core::identifier_string> init_rhs(const process::communication_expression_list& communications)
+  {
+    std::vector<core::identifier_string> result;
+    for (const process::communication_expression& l : communications)
+    {
+      result.push_back(l.name());
+    }
+    return result;
+  }
+
+public:
+  // comm_entries are not copyable.
+  comm_entry(const comm_entry&) = delete;
+  comm_entry& operator=(const comm_entry&) = delete;
+
+  explicit comm_entry(const process::communication_expression_list& communications)
+      : m_lhs(init_lhs(communications)),
+        m_rhs(init_rhs(communications)),
+        m_lhs_iters(communications.size()),
+        m_match_failed(communications.size())
+  {}
+
+  ~comm_entry() = default;
+
+  std::size_t size() const
+  {
+    assert(m_lhs.size() == m_rhs.size());
+    assert(m_rhs.size() == m_lhs_iters.size());
+    assert(m_lhs_iters.size() == m_match_failed.size());
+    return m_lhs.size();
+  }
+
+  /// Determine if there exists a communication expression a1|...|an -> b in comm_table
+  /// such that m' = a1|...|an , where m' is the multiset of actionnames for multiaction m.
+  /// That is, the actions in m consting of actions and data occur in C, such tat a communication
+  /// can take place.
+  ///
+  /// if \exists_{(b,c) \in C} b = \mu(m), return c, otherwise return action_label()
+  process::action_label can_communicate(const process::action_list& m)
+  {
+    assert(std::is_sorted(m.begin(), m.end(), action_compare()));
+
+    process::action_label result; // if no match found, return process::action_label()
+
+    if (match_multiaction(m))
+    {
+      // There is a lhs that has m as prefix. Find it, and determine if the lhs matches m completely.
+      for (std::size_t i = 0; i < size(); ++i)
       {
-        result.push_back(l.name());
-      }
-      return result;
-    }
-
-  public:
-    // comm_entries are not copyable.
-    comm_entry(const comm_entry& )=delete;
-    comm_entry& operator=(const comm_entry& )=delete;
-
-    explicit
-    comm_entry(const process::communication_expression_list& communications)
-        : m_lhs(init_lhs(communications)),
-          m_rhs(init_rhs(communications)),
-          m_lhs_iters(communications.size()),
-          m_match_failed(communications.size())
-    {}
-
-    ~comm_entry() = default;
-
-    std::size_t size() const
-    {
-      assert(m_lhs.size() == m_rhs.size());
-      assert(m_rhs.size() == m_lhs_iters.size());
-      assert(m_lhs_iters.size() == m_match_failed.size());
-      return m_lhs.size();
-    }
-
-    /// Determine if there exists a communication expression a1|...|an -> b in comm_table
-    /// such that m' = a1|...|an , where m' is the multiset of actionnames for multiaction m.
-    /// That is, the actions in m consting of actions and data occur in C, such tat a communication
-    /// can take place.
-    ///
-    /// if \exists_{(b,c) \in C} b = \mu(m), return c, otherwise return action_label()
-    process::action_label can_communicate(const process::action_list& m)
-    {
-      assert(std::is_sorted(m.begin(), m.end(), action_compare()));
-
-      process::action_label result; // if no match found, return process::action_label()
-
-      if(match_multiaction(m))
-      {
-        // There is a lhs that has m as prefix. Find it, and determine if the lhs matches m completely.
-        for (std::size_t i = 0; i < size(); ++i)
+        // lhs i matches only if comm_table[i] is empty
+        if ((!m_match_failed[i]) && m_lhs_iters[i] == m_lhs[i].end())
         {
-          // lhs i matches only if comm_table[i] is empty
-          if ((!m_match_failed[i]) && m_lhs_iters[i] == m_lhs[i].end())
+          if (m_rhs[i] == process::tau())
           {
-            if (m_rhs[i] == process::tau())
-            {
-              throw mcrl2::runtime_error("Cannot linearise a process with a communication operator, containing a communication that results in tau or that has an empty right hand side");
-            }
-            result = process::action_label(m_rhs[i], m.begin()->label().sorts());
-            break;
+            throw mcrl2::runtime_error("Cannot linearise a process with a communication operator, containing a "
+                                       "communication that results in tau or that has an empty right hand side");
           }
+          result = process::action_label(m_rhs[i], m.begin()->label().sorts());
+          break;
         }
       }
-
-      return result;
     }
+
+    return result;
+  }
 
   /// Calculate \exists_{o,c} (\mu(m) \oplus o, c) \in C, with o \subseteq n
   ///
@@ -272,82 +281,82 @@ class comm_entry
   /// of a communication a1|...|ak -> b in C (that is, the names of m are a subbag of a1|...|ak), and the actions
   /// a1|...|ak that are not in m are in n. I.e., there is a subbag o of n such that m+o can communicate.
   bool might_communicate(const process::action_list& m, const process::action_list& n)
+  {
+    assert(std::is_sorted(m.begin(), m.end(), action_compare()));
+    assert(std::is_sorted(n.begin(), n.end(), action_compare()));
+
+    /* this function indicates whether the actions in m
+       consisting of actions and data occur in C, such that
+       a communication might take place (i.e. m is a subbag
+       of the lhs of a communication in C).
+       if n is not empty, then all actions of a matching communication
+       that are not in m should be in n (i.e. there must be a
+       subbag o of n such that m+o can communicate. */
+    bool result = false;
+
+    if (match_multiaction(m))
     {
-      assert(std::is_sorted(m.begin(), m.end(), action_compare()));
-      assert(std::is_sorted(n.begin(), n.end(), action_compare()));
+      // the rest of actions of lhs that are not in m should be in n
+      // rest[i] contains the part of n in which lhs i has to find matching actions
+      // if rest[i] cannot match the next remaining action in the left hand side, stored in m_lhs_iters[i], i.e.,
+      // rest[i] becomes empty before matching all actions in the lhs, we set it to std::nullopt. N.B. when rest[i]
+      // becomes empty after matching all actions in the lhs, rest[i].empty() is a meaningful result: we have a
+      // successful match.
+      std::vector<std::optional<process::action_list::const_iterator>> rest(size(),
+          n.begin()); // pairs of iterator into n; the second element of the pair indicates the end of the range in n.
 
-      /* this function indicates whether the actions in m
-         consisting of actions and data occur in C, such that
-         a communication might take place (i.e. m is a subbag
-         of the lhs of a communication in C).
-         if n is not empty, then all actions of a matching communication
-         that are not in m should be in n (i.e. there must be a
-         subbag o of n such that m+o can communicate. */
-      bool result = false;
-
-      if(match_multiaction(m))
+      // check every lhs
+      for (std::size_t i = 0; i < size(); ++i)
       {
-        // the rest of actions of lhs that are not in m should be in n
-        // rest[i] contains the part of n in which lhs i has to find matching actions
-        // if rest[i] cannot match the next remaining action in the left hand side, stored in m_lhs_iters[i], i.e., rest[i] becomes empty
-        // before matching all actions in the lhs, we set it to std::nullopt.
-        // N.B. when rest[i] becomes empty after matching all actions in the lhs,
-        // rest[i].empty() is a meaningful result: we have a successful match.
-        std::vector<std::optional<process::action_list::const_iterator>>
-          rest(size(), n.begin()); // pairs of iterator into n; the second element of the pair indicates the end of the range in n.
-
-        // check every lhs
-        for (std::size_t i = 0; i < size(); ++i)
+        if (m_match_failed[i]) // lhs i did not contain m
         {
-          if (m_match_failed[i]) // lhs i did not contain m
-          {
-            continue;
-          }
+          continue;
+        }
 
-          // as long as there are still unmatched actions in lhs i...
-          while (m_lhs_iters[i] != m_lhs[i].end())
+        // as long as there are still unmatched actions in lhs i...
+        while (m_lhs_iters[i] != m_lhs[i].end())
+        {
+          assert(rest[i] != std::nullopt);
+          // .. find them in rest[i]
+          if (*rest[i] == n.end()) // no luck
           {
-            assert(rest[i] != std::nullopt);
-            // .. find them in rest[i]
-            if (*rest[i] == n.end()) // no luck
+            rest[i] = std::nullopt;
+            break;
+          }
+          // get first action in lhs i
+          const core::identifier_string& comm_name = *m_lhs_iters[i];
+          core::identifier_string rest_name = (*rest[i])->label().name();
+          // find it in rest[i]
+          while (comm_name != rest_name)
+          {
+            ++(*rest[i]);
+            if (*rest[i] == n.end()) // no more
             {
               rest[i] = std::nullopt;
               break;
             }
-            // get first action in lhs i
-            const core::identifier_string& comm_name = *m_lhs_iters[i];
-            core::identifier_string rest_name = (*rest[i])->label().name();
-            // find it in rest[i]
-            while (comm_name != rest_name)
-            {
-              ++(*rest[i]);
-              if (*rest[i] == n.end()) // no more
-              {
-                rest[i] = std::nullopt;
-                break;
-              }
-              rest_name = (*rest[i])->label().name();
-            }
-            if (comm_name != rest_name) // action was not found
-            {
-              break;
-            }
-
-            // action found; try next
-            ++(*rest[i]);
-            ++m_lhs_iters[i];
+            rest_name = (*rest[i])->label().name();
           }
-
-          if (rest[i] != std::nullopt) // lhs was found in rest[i]
+          if (comm_name != rest_name) // action was not found
           {
-            result = true;
             break;
           }
+
+          // action found; try next
+          ++(*rest[i]);
+          ++m_lhs_iters[i];
+        }
+
+        if (rest[i] != std::nullopt) // lhs was found in rest[i]
+        {
+          result = true;
+          break;
         }
       }
-
-      return result;
     }
+
+    return result;
+  }
 };
 
 template <typename DataRewriter>
@@ -355,548 +364,569 @@ class apply_communication_algorithm
 {
 public:
   apply_communication_algorithm(const process::action& termination_action,
-                                DataRewriter& data_rewriter,
-                                const process::communication_expression_list& communications,
-                                const process::action_name_multiset_list& allowlist,
-                                bool is_allow,
-                                bool is_block)
-    : m_terminationAction(termination_action),
-      m_data_rewriter(data_rewriter),
-      m_communications(sort_communications(communications)),
-      m_allowlist(sort_multi_action_labels(allowlist)),
-      m_blocked_actions(is_block?get_actions(allowlist):std::vector<core::identifier_string>()),
-      m_allowed_actions(init_allowed_actions(is_allow, allowlist, termination_action)),
-      m_comm_table(m_communications),
-      m_is_allow(is_allow),
-      m_is_block(is_block)
+      DataRewriter& data_rewriter,
+      const process::communication_expression_list& communications,
+      const process::action_name_multiset_list& allowlist,
+      bool is_allow,
+      bool is_block)
+      : m_terminationAction(termination_action),
+        m_data_rewriter(data_rewriter),
+        m_communications(sort_communications(communications)),
+        m_allowlist(sort_multi_action_labels(allowlist)),
+        m_blocked_actions(is_block ? get_actions(allowlist) : std::vector<core::identifier_string>()),
+        m_allowed_actions(init_allowed_actions(is_allow, allowlist, termination_action)),
+        m_comm_table(m_communications),
+        m_is_allow(is_allow),
+        m_is_block(is_block)
   {}
 
   ~apply_communication_algorithm() = default;
 
-/// Calculate the communication operator applied to a multiaction.
-///
-/// As the actions in the multiaction can be parameterized with open data expressions, for every subset of communication
-/// expressions that match the multiaction, the result contains a multiaction (in which the particular subset of
-/// communication expressions has been applied), and a corresponding condition that requires that the parameters are
-/// equal for the actions in the left-hand-sides of the matching communication expressions.
-/// Multiactions whose condition is false may be removed.
-///
-/// This is the function $\overline{\gamma}$ in M. v. Weerdenburg. Calculation of Communication with Open Terms in
-/// GenSpect Process Algebra.
-///
-/// \param m The multiaction to which the communication operator is applied
-/// \param C The communication expressions to be applied
-/// \param RewriteTerm The rewriter that should be used to simplify the conditions.
-tuple_list apply(const process::action_list& m)
-{
-  assert(std::is_sorted(m.begin(), m.end(), action_compare()));
-  const process::action_list r;
-  return makeMultiActionConditionList_aux(m, r);
-}
-
-/// Apply the communication composition to a list of action summands.
-void apply(
-  stochastic_action_summand_vector& action_summands,
-  deadlock_summand_vector& deadlock_summands,
-  bool nosumelm,
-  bool nodeltaelimination,
-  bool ignore_time)
-{
-  assert(!(m_is_allow && m_is_block));
-
-  /* We follow the implementation of Muck van Weerdenburg, described in
-     a note: Calculation of communication with open terms. */
-
-  mCRL2log(mcrl2::log::verbose) <<
-        (m_is_allow ? "- calculating the communication operator modulo the allow operator on " :
-         m_is_block ? "- calculating the communication operator modulo the block operator on " :
-                    "- calculating the communication operator on ") << action_summands.size() << " action summands";
-
-#ifdef MCRL2_LOG_LPS_LINEARISE_STATISTICS
-  lps_statistics_t lps_statistics_before = get_statistics(action_summands, deadlock_summands);
-  // number of summands filtered out after construction of intermediate result (all potential results of communication
-  // that may be allowed/are not blocked)
-  std::size_t disallowed_summands = 0;      // removed by allow
-  std::size_t blocked_summands = 0;         // removed by block
-  std::size_t false_condition_summands = 0; // removed because condition is false
-#endif
-
-  mCRL2log(mcrl2::log::trace) << "Calculating communication operator using a set of " << m_communications.size() << " communication expressions." << std::endl;
-  mCRL2log(mcrl2::log::trace) << "Communication expressions: " << std::endl << core::detail::print_set(m_communications) << std::endl;
-  mCRL2log(mcrl2::log::trace) << "Allow list: " << std::endl << core::detail::print_set(m_allowlist) << std::endl;
-
-  deadlock_summand_vector resulting_deadlock_summands;
-  deadlock_summands.swap(resulting_deadlock_summands);
-
-  const bool inline_allow = m_is_allow || m_is_block;
-  if (inline_allow)
+  /// Calculate the communication operator applied to a multiaction.
+  ///
+  /// As the actions in the multiaction can be parameterized with open data expressions, for every subset of
+  /// communication expressions that match the multiaction, the result contains a multiaction (in which the particular
+  /// subset of communication expressions has been applied), and a corresponding condition that requires that the
+  /// parameters are equal for the actions in the left-hand-sides of the matching communication expressions.
+  /// Multiactions whose condition is false may be removed.
+  ///
+  /// This is the function $\overline{\gamma}$ in M. v. Weerdenburg. Calculation of Communication with Open Terms in
+  /// GenSpect Process Algebra.
+  ///
+  /// \param m The multiaction to which the communication operator is applied
+  /// \param C The communication expressions to be applied
+  /// \param RewriteTerm The rewriter that should be used to simplify the conditions.
+  tuple_list apply(const process::action_list& m)
   {
-    // Inline allow is only supported for ignore_time,
-    // for in other cases generation of delta summands cannot be inlined in any simple way.
-    assert(!nodeltaelimination && ignore_time);
-    deadlock_summands.push_back(deadlock_summand(data::variable_list(), data::sort_bool::true_(),deadlock()));
+    assert(std::is_sorted(m.begin(), m.end(), action_compare()));
+    const process::action_list r;
+    return makeMultiActionConditionList_aux(m, r);
   }
 
-  stochastic_action_summand_vector resulting_action_summands;
-
-  for (const stochastic_action_summand& smmnd: action_summands)
+  /// Apply the communication composition to a list of action summands.
+  void apply(stochastic_action_summand_vector& action_summands,
+      deadlock_summand_vector& deadlock_summands,
+      bool nosumelm,
+      bool nodeltaelimination,
+      bool ignore_time)
   {
-    const data::variable_list& sumvars = smmnd.summation_variables();
-    const process::action_list& multiaction = smmnd.multi_action().actions();
-    const data::data_expression& time = smmnd.multi_action().time();
-    const data::data_expression& condition = smmnd.condition();
-    const data::assignment_list& nextstate = smmnd.assignments();
-    const stochastic_distribution& dist = smmnd.distribution();
+    assert(!(m_is_allow && m_is_block));
 
-    if (!inline_allow)
+    /* We follow the implementation of Muck van Weerdenburg, described in
+       a note: Calculation of communication with open terms. */
+
+    mCRL2log(mcrl2::log::verbose) << (m_is_allow
+                                          ? "- calculating the communication operator modulo the allow operator on "
+                                      : m_is_block
+                                          ? "- calculating the communication operator modulo the block operator on "
+                                          : "- calculating the communication operator on ")
+                                  << action_summands.size() << " action summands";
+
+    [[maybe_unused]]
+    lps_statistics_t lps_statistics_before = get_statistics(action_summands, deadlock_summands);
+    // number of summands filtered out after construction of intermediate result (all potential results of communication
+    // that may be allowed/are not blocked)
+    [[maybe_unused]]
+    std::size_t disallowed_summands = 0;      // removed by allow
+    [[maybe_unused]]
+    std::size_t blocked_summands = 0;         // removed by block
+    [[maybe_unused]]
+    std::size_t false_condition_summands = 0; // removed because condition is false
+
+    mCRL2log(mcrl2::log::trace) << "Calculating communication operator using a set of " << m_communications.size()
+                                << " communication expressions." << std::endl;
+    mCRL2log(mcrl2::log::trace) << "Communication expressions: " << std::endl
+                                << core::detail::print_set(m_communications) << std::endl;
+    mCRL2log(mcrl2::log::trace) << "Allow list: " << std::endl << core::detail::print_set(m_allowlist) << std::endl;
+
+    deadlock_summand_vector resulting_deadlock_summands;
+    deadlock_summands.swap(resulting_deadlock_summands);
+
+    const bool inline_allow = m_is_allow || m_is_block;
+    if (inline_allow)
     {
-      /* Recall a delta summand for every non delta summand.
-       * The reason for this is that with communication, the
-       * conditions for summands can become much more complex.
-       * Many of the actions in these summands are replaced by
-       * delta's later on. Due to the more complex conditions it
-       * will be hard to remove them. By adding a default delta
-       * with a simple condition, makes this job much easier
-       * later on, and will in general reduce the number of delta
-       * summands in the whole system */
-
-      // Create new list of summand variables containing only those that occur in the condition or the timestamp.
-      data::variable_list newsumvars;
-      atermpp::make_term_list(newsumvars, sumvars.begin(), sumvars.end(), [](const data::variable& v) { return v; },
-        [&condition, &time](const data::variable& v) { return occursinterm(condition, v) || occursinterm(time, v); });
-
-      resulting_deadlock_summands.emplace_back(newsumvars, condition, deadlock(time));
+      // Inline allow is only supported for ignore_time,
+      // for in other cases generation of delta summands cannot be inlined in any simple way.
+      assert(!nodeltaelimination && ignore_time);
+      deadlock_summands.push_back(deadlock_summand(data::variable_list(), data::sort_bool::true_(), deadlock()));
     }
 
-    /* the multiactionconditionlist is a list containing
-       tuples, with a multiaction and the condition,
-       expressing whether the multiaction can happen. All
-       conditions exclude each other. Furthermore, the list
-       is not empty. If no communications can take place,
-       the original multiaction is delivered, with condition
-       true. */
+    stochastic_action_summand_vector resulting_action_summands;
 
-    // We calculate the communication operator on the multiaction in this single summand. As the actions in the
-    // multiaction can be parameterized with open data expressions, for every subset of applicable communication expressions
-    // this list in principle contains one summand (unless the condition can be rewritten to false, in which case it
-    // is omitted).
-
-    mCRL2log(mcrl2::log::trace) << "Calculating communication on multiaction with " << multiaction.size() << " actions." << std::endl;
-    mCRL2log(mcrl2::log::trace) << "  Multiaction: " << process::pp(multiaction) << std::endl;
-
-    const tuple_list multiactionconditionlist = apply(multiaction);
-
-    mCRL2log(mcrl2::log::trace) << "Calculating communication on multiaction with " << multiaction.size() << " actions results in " << multiactionconditionlist.size() << " potential summands" << std::endl;
-
-    for (std::size_t i=0 ; i<multiactionconditionlist.size(); ++i)
+    for (const stochastic_action_summand& smmnd : action_summands)
     {
+      const data::variable_list& sumvars = smmnd.summation_variables();
+      const process::action_list& multiaction = smmnd.multi_action().actions();
+      const data::data_expression& time = smmnd.multi_action().time();
+      const data::data_expression& condition = smmnd.condition();
+      const data::assignment_list& nextstate = smmnd.assignments();
+      const stochastic_distribution& dist = smmnd.distribution();
 
-      const process::action_list& multiaction=multiactionconditionlist.actions[i];
-
-      if (m_is_allow && !allow_(m_allowlist, multiaction,m_terminationAction))
+      if (!inline_allow)
       {
-#ifdef MCRL2_LOG_LPS_LINEARISE_STATISTICS
-        ++disallowed_summands;
-#endif
-        continue;
+        /* Recall a delta summand for every non delta summand.
+         * The reason for this is that with communication, the
+         * conditions for summands can become much more complex.
+         * Many of the actions in these summands are replaced by
+         * delta's later on. Due to the more complex conditions it
+         * will be hard to remove them. By adding a default delta
+         * with a simple condition, makes this job much easier
+         * later on, and will in general reduce the number of delta
+         * summands in the whole system */
+
+        // Create new list of summand variables containing only those that occur in the condition or the timestamp.
+        data::variable_list newsumvars;
+        atermpp::make_term_list(
+            newsumvars,
+            sumvars.begin(),
+            sumvars.end(),
+            [](const data::variable& v) { return v; },
+            [&condition, &time](const data::variable& v)
+            { return occursinterm(condition, v) || occursinterm(time, v); });
+
+        resulting_deadlock_summands.emplace_back(newsumvars, condition, deadlock(time));
       }
-      if (m_is_block && encap(m_allowlist,multiaction))
-      {
-#ifdef MCRL2_LOG_LPS_LINEARISE_STATISTICS
-        ++blocked_summands;
-#endif
-        continue;
-      }
 
-      const data::data_expression communicationcondition=
-        m_data_rewriter(multiactionconditionlist.conditions[i]);
+      /* the multiactionconditionlist is a list containing
+         tuples, with a multiaction and the condition,
+         expressing whether the multiaction can happen. All
+         conditions exclude each other. Furthermore, the list
+         is not empty. If no communications can take place,
+         the original multiaction is delivered, with condition
+         true. */
 
-      const data::data_expression newcondition=m_data_rewriter(
-                                           data::lazy::and_(condition,communicationcondition));
-      stochastic_action_summand new_summand(sumvars,
-                                 newcondition,
-                                 smmnd.multi_action().has_time()?multi_action(multiaction, smmnd.multi_action().time()):multi_action(multiaction),
-                                 nextstate,
-                                 dist);
-      if (!nosumelm)
+      // We calculate the communication operator on the multiaction in this single summand. As the actions in the
+      // multiaction can be parameterized with open data expressions, for every subset of applicable communication
+      // expressions this list in principle contains one summand (unless the condition can be rewritten to false, in
+      // which case it is omitted).
+
+      mCRL2log(mcrl2::log::trace) << "Calculating communication on multiaction with " << multiaction.size()
+                                  << " actions." << std::endl;
+      mCRL2log(mcrl2::log::trace) << "  Multiaction: " << process::pp(multiaction) << std::endl;
+
+      const tuple_list multiactionconditionlist = apply(multiaction);
+
+      mCRL2log(mcrl2::log::trace) << "Calculating communication on multiaction with " << multiaction.size()
+                                  << " actions results in " << multiactionconditionlist.size() << " potential summands"
+                                  << std::endl;
+
+      for (std::size_t i = 0; i < multiactionconditionlist.size(); ++i)
       {
-        if (sumelm(new_summand))
+        const process::action_list& multiaction = multiactionconditionlist.actions[i];
+
+        if (m_is_allow && !allow_(m_allowlist, multiaction, m_terminationAction))
         {
-          new_summand.condition() = m_data_rewriter(new_summand.condition());
+          if constexpr (EnableLineariseStatistics) {
+            ++disallowed_summands;
+          }
+
+          continue;
+        }
+        if (m_is_block && encap(m_allowlist, multiaction))
+        {
+          if constexpr (EnableLineariseStatistics) {
+            ++blocked_summands;
+          }
+          continue;
+        }
+
+        const data::data_expression communicationcondition = m_data_rewriter(multiactionconditionlist.conditions[i]);
+
+        const data::data_expression newcondition = m_data_rewriter(data::lazy::and_(condition, communicationcondition));
+        stochastic_action_summand new_summand(sumvars,
+            newcondition,
+            smmnd.multi_action().has_time() ? multi_action(multiaction, smmnd.multi_action().time())
+                                            : multi_action(multiaction),
+            nextstate,
+            dist);
+        if (!nosumelm)
+        {
+          if (sumelm(new_summand))
+          {
+            new_summand.condition() = m_data_rewriter(new_summand.condition());
+          }
+        }
+        if constexpr (EnableLineariseStatistics)
+        {
+          if (new_summand.condition() == data::sort_bool::false_())
+          {
+            ++false_condition_summands;
+          }
+        }
+        
+        if (new_summand.condition() != data::sort_bool::false_())
+        {
+          resulting_action_summands.push_back(new_summand);
         }
       }
-#ifdef MCRL2_LOG_LPS_LINEARISE_STATISTICS
-      if (new_summand.condition()==data::sort_bool::false_())
-      {
-        ++false_condition_summands;
-      }
-#endif
-      if (new_summand.condition()!=data::sort_bool::false_())
-      {
-        resulting_action_summands.push_back(new_summand);
-      }
     }
 
-  }
+    action_summands.swap(resulting_action_summands);
 
-  action_summands.swap(resulting_action_summands);
-
-  /* Now the resulting delta summands must be added again */
-  if (!inline_allow && !nodeltaelimination)
-  {
-    for (const deadlock_summand& summand: resulting_deadlock_summands)
+    /* Now the resulting delta summands must be added again */
+    if (!inline_allow && !nodeltaelimination)
     {
-      insert_timed_delta_summand(action_summands, deadlock_summands, summand, ignore_time);
+      for (const deadlock_summand& summand : resulting_deadlock_summands)
+      {
+        insert_timed_delta_summand(action_summands, deadlock_summands, summand, ignore_time);
+      }
     }
+
+    if constexpr (EnableLineariseStatistics)
+    {
+      lps_statistics_t lps_statistics_after = get_statistics(action_summands, deadlock_summands);
+      std::cout << log_comm_application(lps_statistics_before,
+          lps_statistics_after,
+          disallowed_summands,
+          blocked_summands,
+          false_condition_summands);
+    }
+
+    mCRL2log(mcrl2::log::verbose) << " resulting in " << action_summands.size() << " action summands and "
+                                  << deadlock_summands.size() << " delta summands\n";
   }
-
-#ifdef MCRL2_LOG_LPS_LINEARISE_STATISTICS
-  lps_statistics_t lps_statistics_after = get_statistics(action_summands, deadlock_summands);
-  std::cout << log_comm_application(lps_statistics_before, lps_statistics_after,
-    disallowed_summands, blocked_summands, false_condition_summands);
-#endif
-
-  mCRL2log(mcrl2::log::verbose) << " resulting in " << action_summands.size() << " action summands and " << deadlock_summands.size() << " delta summands\n";
-}
 
 protected:
 
-const process::action& m_terminationAction;
-DataRewriter& m_data_rewriter;
-const process::communication_expression_list m_communications;
-const process::action_name_multiset_list m_allowlist;  // This is a list of list of identifierstring.
-const std::vector<core::identifier_string> m_blocked_actions; // used only if m_is_block is set
-const std::vector<core::identifier_string> m_allowed_actions; // used only if m_is_allow is set
-comm_entry m_comm_table;
-const bool m_is_allow;                          // If is_allow or is_block is set, perform inline allow/block filtering. They are mutually exclusive
-const bool m_is_block;
+  const process::action& m_terminationAction;
+  DataRewriter& m_data_rewriter;
+  const process::communication_expression_list m_communications;
+  const process::action_name_multiset_list m_allowlist;         // This is a list of list of identifierstring.
+  const std::vector<core::identifier_string> m_blocked_actions; // used only if m_is_block is set
+  const std::vector<core::identifier_string> m_allowed_actions; // used only if m_is_allow is set
+  comm_entry m_comm_table;
+  const bool
+      m_is_allow; // If is_allow or is_block is set, perform inline allow/block filtering. They are mutually exclusive
+  const bool m_is_block;
 
-#ifdef MCRL2_LOG_LPS_LINEARISE_STATISTICS
-std::string log_comm_application(const lps_statistics_t& lps_statistics_before,
-                                 const lps_statistics_t& lps_statistics_after,
-                                 const std::size_t disallowed_summands,
-                                 const std::size_t blocked_summands,
-                                 const std::size_t false_condition_summands,
-                                 size_t indent = 0) const
-{
-  std::string indent_str(indent, ' ');
-  std::ostringstream os;
-
-  os << indent_str << "- operator: comm" << std::endl;
-
-  indent += 2;
-  indent_str = std::string(indent, ' ');
-  os << indent_str << "number of communication expressions: " << m_communications.size() << std::endl;
-  if (m_is_allow)
+  std::string log_comm_application(const lps_statistics_t& lps_statistics_before,
+      const lps_statistics_t& lps_statistics_after,
+      const std::size_t disallowed_summands,
+      const std::size_t blocked_summands,
+      const std::size_t false_condition_summands,
+      size_t indent = 0) const
   {
-    os << indent_str << "number of allow expressions: " << m_allowlist.size() << std::endl;
-  }
-  if (m_is_block)
-  {
-    os << indent_str << "number of block expressions: " << m_blocked_actions.size() << std::endl;
-  }
+    std::string indent_str(indent, ' ');
+    std::ostringstream os;
 
-  os << indent_str << "before:" << std::endl << print(lps_statistics_before, indent+2)
-     << indent_str << "after:" << std::endl << print(lps_statistics_after, indent+2)
-     << indent_str << "removed from intermediate result:" << std::endl;
+    os << indent_str << "- operator: comm" << std::endl;
 
-  indent += 2;
-  indent_str = std::string(indent, ' ');
-  if (m_is_allow)
-  {
-    os << indent_str << "disallowed summands: " << disallowed_summands << std::endl;
-  }
-  if (m_is_block)
-  {
-    os << indent_str << "blocked summands: " << blocked_summands << std::endl;
-  }
+    indent += 2;
+    indent_str = std::string(indent, ' ');
+    os << indent_str << "number of communication expressions: " << m_communications.size() << std::endl;
+    if (m_is_allow)
+    {
+      os << indent_str << "number of allow expressions: " << m_allowlist.size() << std::endl;
+    }
+    if (m_is_block)
+    {
+      os << indent_str << "number of block expressions: " << m_blocked_actions.size() << std::endl;
+    }
 
-  os << indent_str << "summands with false condition: " << false_condition_summands << std::endl;
+    os << indent_str << "before:" << std::endl
+       << print(lps_statistics_before, indent + 2) << indent_str << "after:" << std::endl
+       << print(lps_statistics_after, indent + 2) << indent_str << "removed from intermediate result:" << std::endl;
 
-  return os.str();
-}
-#endif //MCRL2_LOG_LPS_LINEARISE_STATISTICS
+    indent += 2;
+    indent_str = std::string(indent, ' ');
+    if (m_is_allow)
+    {
+      os << indent_str << "disallowed summands: " << disallowed_summands << std::endl;
+    }
+    if (m_is_block)
+    {
+      os << indent_str << "blocked summands: " << blocked_summands << std::endl;
+    }
 
-/// Static initialization function to ensure m_allowed_actions can be const.
-static const std::vector<core::identifier_string>
-init_allowed_actions(bool is_allow, const process::action_name_multiset_list& allow_list, const process::action& termination_action)
-{
-  std::vector<core::identifier_string> result;
-  if (is_allow)
-  {
-    result = get_actions(allow_list);
-    // Ensure that the termination action is always allowed, even when it is not an explicit part of
-    // the list of allowed actions.
-    // We maintains sort order of the vector
-    std::vector<core::identifier_string>::iterator it = std::upper_bound(result.begin(), result.end(), termination_action.label().name(), action_name_compare());
-    result.insert(it, termination_action.label().name());
+    os << indent_str << "summands with false condition: " << false_condition_summands << std::endl;
+
+    return os.str();
   }
 
-  return result;
-}
-
-/// Calculate data expression for pairwise equality of the elements of l1 and l2.
-///
-/// If the lengths of l1 and l2 differ, or for some index i, the sort l1[i] and l2[i] is different, the pairwise
-/// match is false, otherwise an expression equivalent to \bigwegde_i (l1[i] == l2[i]) is returned.
-data::data_expression pairwise_equal_to(const data::data_expression_list& l1, const data::data_expression_list& l2) const
-{
-  data::data_expression result = data::sort_bool::true_();
-
-  if (l1.size()!=l2.size())
+  /// Static initialization function to ensure m_allowed_actions can be const.
+  static const std::vector<core::identifier_string> init_allowed_actions(bool is_allow,
+      const process::action_name_multiset_list& allow_list,
+      const process::action& termination_action)
   {
-    result = data::sort_bool::false_();
+    std::vector<core::identifier_string> result;
+    if (is_allow)
+    {
+      result = get_actions(allow_list);
+      // Ensure that the termination action is always allowed, even when it is not an explicit part of
+      // the list of allowed actions.
+      // We maintains sort order of the vector
+      std::vector<core::identifier_string>::iterator it
+          = std::upper_bound(result.begin(), result.end(), termination_action.label().name(), action_name_compare());
+      result.insert(it, termination_action.label().name());
+    }
+
+    return result;
   }
 
-  auto i1 = l1.begin();
-  auto i2 = l2.begin();
-
-  while (i1 != l1.end() && i2 != l2.end() && result != data::sort_bool::false_())
+  /// Calculate data expression for pairwise equality of the elements of l1 and l2.
+  ///
+  /// If the lengths of l1 and l2 differ, or for some index i, the sort l1[i] and l2[i] is different, the pairwise
+  /// match is false, otherwise an expression equivalent to \bigwegde_i (l1[i] == l2[i]) is returned.
+  data::data_expression pairwise_equal_to(const data::data_expression_list& l1,
+      const data::data_expression_list& l2) const
   {
-    if (i1->sort() != i2->sort())
+    data::data_expression result = data::sort_bool::true_();
+
+    if (l1.size() != l2.size())
     {
       result = data::sort_bool::false_();
     }
-    else
+
+    auto i1 = l1.begin();
+    auto i2 = l2.begin();
+
+    while (i1 != l1.end() && i2 != l2.end() && result != data::sort_bool::false_())
     {
-      result = data::lazy::and_(result, m_data_rewriter(equal_to(*i1++, *i2++)));
-    }
-  }
-
-  return result;
-}
-
-
-/// Determine if the action is allowable, that is, it is part of an allow expression
-/// and it is not part of a block expression
-bool maybe_allowed(const process::action_label& a) const
-{
-  assert(std::is_sorted(m_allowed_actions.begin(), m_allowed_actions.end(), action_name_compare()));
-  assert(std::is_sorted(m_blocked_actions.begin(), m_blocked_actions.end(), action_name_compare()));
-  assert(!m_is_block || m_allowed_actions.empty());
-  assert(!m_is_allow || m_blocked_actions.empty());
-
-  return !(m_is_allow || m_is_block) 
-    || (m_is_allow && std::binary_search(m_allowed_actions.begin(), m_allowed_actions.end(), a.name(), action_name_compare()))
-    || (m_is_block && !std::binary_search(m_blocked_actions.begin(), m_blocked_actions.end(), a.name(), action_name_compare()));
-}
-
-
-/// Calculate the communication operator applied to a multiaction.
-///
-/// This is the function $\overline(\gamma, C, r)$ as described in M. v. Weerdenburg. Calculation of Communication
-/// with Open Terms in GenSpect Process Algebra.
-///
-/// \param m_first Start of a range of multiactions to which the communication operator should be applied
-/// \param m_last End of a range of multiactions to which the communication operator should be applied
-/// \param C The communication expressions that must be applied to the multiaction
-/// \param r
-/// \param RewriteTerm Data rewriter for simplifying expressions.
-inline
-tuple_list makeMultiActionConditionList_aux(
-  const process::action_list& m,
-  const process::action_list& r)
-{
-  assert(std::is_sorted(m.begin(), m.end(), action_compare()));
-  assert(std::is_sorted(r.begin(), r.end(), action_compare()));
-
-  tuple_list S; // result
-
-  // if m = [], then S := { (r, \psi(r, C)) }
-  if (m.empty())
-  {
-    if (r.empty())
-    {
-      S.conditions.emplace_back(data::sort_bool::true_());
-    }
-    else
-    {
-      S.conditions.emplace_back(psi(r));
-    }
-
-    // TODO: Why don't we insert r here, as van Weerdenburg writes?
-    S.actions.emplace_back();
-  }
-  else
-  {
-    // m = [a(d)] \oplus n
-    const process::action& a = m.front();
-    const process::action_list& m_tail = m.tail();
-
-    // S = \phi(a(d), d, [], n, C, r)
-    S = phi({a}, a.arguments(), process::action_list(), m_tail, r);
-
-    // addActionCondition adds a to every multiaction in T; so if a is not part of any allowed action,
-    // we can skip this part.
-    if (maybe_allowed(a.label()))
-    {
-      // T = \overline{\gamma}(n, C, [a(d)] \oplus r)
-      tuple_list T = makeMultiActionConditionList_aux(m_tail, insert(a, r));
-
-      // S := S \cup \{ (a,true) \oplus t \mid t \in T \}
-      // TODO: van Weerdenburg in his note only calculates S := S \cup T. Understand why that is not correct.
-      addActionCondition(a,data::sort_bool::true_(),std::move(T),S);
-    }
-  }
-  return S;
-}
-
-/// Calculate $\phi(m, d, w, n, C, r)$ as described in M. v. Weerdenburg. Calculation of Communication
-/// with Open Terms in GenSpect Process Algebra.
-///
-/// phi is a function that yields a list of pairs indicating how the actions in m|w|n can communicate.
-/// The pairs contain the resulting multi action and a condition on data indicating when communication can take place.
-/// In the communication all actions of m, none of w and a subset of n can take part in the communication.
-/// d is the data parameter of the communication and comm_table contains a list of multiaction action pairs
-/// indicating possible communications.
-inline
-tuple_list phi(const process::action_list& m,
-               const data::data_expression_list& d,
-               const process::action_list& w,
-               const process::action_list& n,
-               const process::action_list& r)
-{
-  assert(std::is_sorted(m.begin(), m.end(), action_compare()));
-  assert(std::is_sorted(w.begin(), w.end(), action_compare()));
-  assert(std::is_sorted(n.begin(), n.end(), action_compare()));
-  assert(std::is_sorted(r.begin(), r.end(), action_compare()));
-
-  tuple_list S;
-
-  // \exists_{o,c} (\mu(m) \oplus o, c) \in C, with o \subseteq n
-  if (m_comm_table.might_communicate(m, n))
-  {
-    if (n.empty()) // b \land n = []
-    {
-      // There is communication expression whose lhs matches m, result is c.
-      const process::action_label c = m_comm_table.can_communicate(m); /* returns process::action_label() if no communication
-                                                                is possible */
-
-      if (c!=process::action_label() && maybe_allowed(c))
+      if (i1->sort() != i2->sort())
       {
-        // \exists_{(b,c) \in C} b = \mu(m)
-        // the result of the communication is part of an allow, not in the block set.
-        // Calculate communication for multiaction w.
-        // T := \overline{\gamma}(w, C)
-        tuple_list T = makeMultiActionConditionList_aux(w, r);
-
-        // S := \{ (c(d) \oplus r, e) \mid (r,e) \in T \}
-        addActionCondition(process::action(c,d), data::sort_bool::true_(), std::move(T), S);
-      }
-    }
-    else
-    {
-      // n = [a(f)] \oplus o
-      const process::action& a = n.front();
-      const process::action_list& n_tail = n.tail();
-
-      const data::data_expression condition=pairwise_equal_to(d,a.arguments());
-      if (condition==data::sort_bool::false_())
-      {
-        // a(f) cannot take part in communication as the arguments do not match. Move to w and continue with next action
-        S = phi(m,d,insert(a, w), n_tail, r);
+        result = data::sort_bool::false_();
       }
       else
       {
-        tuple_list T=phi(insert(a, m),d,w, n_tail,r);
-
-        S = phi(m,d,insert(a, w), n_tail,r);
-        addActionCondition(process::action(), condition, std::move(T), S);
+        result = data::lazy::and_(result, m_data_rewriter(equal_to(*i1++, *i2++)));
       }
     }
+
+    return result;
   }
 
-  return S;
-}
-
-bool xi(const process::action_list& alpha,
-        const process::action_list& beta)
-{
-  bool result = false;
-
-  if (beta.empty())
+  /// Determine if the action is allowable, that is, it is part of an allow expression
+  /// and it is not part of a block expression
+  bool maybe_allowed(const process::action_label& a) const
   {
-    result = m_comm_table.can_communicate(alpha)!=process::action_label();
+    assert(std::is_sorted(m_allowed_actions.begin(), m_allowed_actions.end(), action_name_compare()));
+    assert(std::is_sorted(m_blocked_actions.begin(), m_blocked_actions.end(), action_name_compare()));
+    assert(!m_is_block || m_allowed_actions.empty());
+    assert(!m_is_allow || m_blocked_actions.empty());
+
+    return !(m_is_allow || m_is_block)
+           || (m_is_allow
+               && std::binary_search(m_allowed_actions.begin(),
+                   m_allowed_actions.end(),
+                   a.name(),
+                   action_name_compare()))
+           || (m_is_block
+               && !std::binary_search(m_blocked_actions.begin(),
+                   m_blocked_actions.end(),
+                   a.name(),
+                   action_name_compare()));
   }
-  else
-  {
-    const process::action_list alpha_ = insert(beta.front(), alpha);
 
-    if (m_comm_table.can_communicate(alpha_)!=process::action_label())
+  /// Calculate the communication operator applied to a multiaction.
+  ///
+  /// This is the function $\overline(\gamma, C, r)$ as described in M. v. Weerdenburg. Calculation of Communication
+  /// with Open Terms in GenSpect Process Algebra.
+  ///
+  /// \param m_first Start of a range of multiactions to which the communication operator should be applied
+  /// \param m_last End of a range of multiactions to which the communication operator should be applied
+  /// \param C The communication expressions that must be applied to the multiaction
+  /// \param r
+  /// \param RewriteTerm Data rewriter for simplifying expressions.
+  inline tuple_list makeMultiActionConditionList_aux(const process::action_list& m, const process::action_list& r)
+  {
+    assert(std::is_sorted(m.begin(), m.end(), action_compare()));
+    assert(std::is_sorted(r.begin(), r.end(), action_compare()));
+
+    tuple_list S; // result
+
+    // if m = [], then S := { (r, \psi(r, C)) }
+    if (m.empty())
     {
-      result = true;
+      if (r.empty())
+      {
+        S.conditions.emplace_back(data::sort_bool::true_());
+      }
+      else
+      {
+        S.conditions.emplace_back(psi(r));
+      }
+
+      // TODO: Why don't we insert r here, as van Weerdenburg writes?
+      S.actions.emplace_back();
     }
     else
     {
-      const process::action_list& beta_tail = beta.tail();
-      if (m_comm_table.might_communicate(alpha_, beta_tail))
+      // m = [a(d)] \oplus n
+      const process::action& a = m.front();
+      const process::action_list& m_tail = m.tail();
+
+      // S = \phi(a(d), d, [], n, C, r)
+      S = phi({a}, a.arguments(), process::action_list(), m_tail, r);
+
+      // addActionCondition adds a to every multiaction in T; so if a is not part of any allowed action,
+      // we can skip this part.
+      if (maybe_allowed(a.label()))
       {
-        result = xi(alpha, beta_tail);
+        // T = \overline{\gamma}(n, C, [a(d)] \oplus r)
+        tuple_list T = makeMultiActionConditionList_aux(m_tail, insert(a, r));
+
+        // S := S \cup \{ (a,true) \oplus t \mid t \in T \}
+        // TODO: van Weerdenburg in his note only calculates S := S \cup T. Understand why that is not correct.
+        addActionCondition(a, data::sort_bool::true_(), std::move(T), S);
       }
-
-      result = result || xi(alpha, beta_tail);
     }
+    return S;
   }
-  return result;
-}
 
-data::data_expression psi(process::action_list alpha)
-{
-  assert(std::is_sorted(alpha.begin(), alpha.end(), action_compare()));
-  data::data_expression cond = data::sort_bool::false_();
-
-  process::action_list actl; // used in inner loop.
-  while (!alpha.empty())
+  /// Calculate $\phi(m, d, w, n, C, r)$ as described in M. v. Weerdenburg. Calculation of Communication
+  /// with Open Terms in GenSpect Process Algebra.
+  ///
+  /// phi is a function that yields a list of pairs indicating how the actions in m|w|n can communicate.
+  /// The pairs contain the resulting multi action and a condition on data indicating when communication can take place.
+  /// In the communication all actions of m, none of w and a subset of n can take part in the communication.
+  /// d is the data parameter of the communication and comm_table contains a list of multiaction action pairs
+  /// indicating possible communications.
+  inline tuple_list phi(const process::action_list& m,
+      const data::data_expression_list& d,
+      const process::action_list& w,
+      const process::action_list& n,
+      const process::action_list& r)
   {
-    process::action_list beta = alpha.tail();
+    assert(std::is_sorted(m.begin(), m.end(), action_compare()));
+    assert(std::is_sorted(w.begin(), w.end(), action_compare()));
+    assert(std::is_sorted(n.begin(), n.end(), action_compare()));
+    assert(std::is_sorted(r.begin(), r.end(), action_compare()));
 
-    while (!beta.empty())
+    tuple_list S;
+
+    // \exists_{o,c} (\mu(m) \oplus o, c) \in C, with o \subseteq n
+    if (m_comm_table.might_communicate(m, n))
     {
-      actl = process::action_list();
-      actl = insert(alpha.front(), actl);
-      actl = insert(beta.front(), actl);
-      const process::action_list& beta_tail = beta.tail();
-      if (m_comm_table.might_communicate(actl, beta_tail) && xi(actl, beta_tail))
+      if (n.empty()) // b \land n = []
       {
-        // sort and remove duplicates??
-        cond = data::lazy::or_(cond,pairwise_equal_to(alpha.front().arguments(), beta.front().arguments()));
+        // There is communication expression whose lhs matches m, result is c.
+        const process::action_label c = m_comm_table.can_communicate(m); /* returns process::action_label() if no
+                                                                  communication is possible */
+
+        if (c != process::action_label() && maybe_allowed(c))
+        {
+          // \exists_{(b,c) \in C} b = \mu(m)
+          // the result of the communication is part of an allow, not in the block set.
+          // Calculate communication for multiaction w.
+          // T := \overline{\gamma}(w, C)
+          tuple_list T = makeMultiActionConditionList_aux(w, r);
+
+          // S := \{ (c(d) \oplus r, e) \mid (r,e) \in T \}
+          addActionCondition(process::action(c, d), data::sort_bool::true_(), std::move(T), S);
+        }
       }
-      beta = beta_tail;
+      else
+      {
+        // n = [a(f)] \oplus o
+        const process::action& a = n.front();
+        const process::action_list& n_tail = n.tail();
+
+        const data::data_expression condition = pairwise_equal_to(d, a.arguments());
+        if (condition == data::sort_bool::false_())
+        {
+          // a(f) cannot take part in communication as the arguments do not match. Move to w and continue with next
+          // action
+          S = phi(m, d, insert(a, w), n_tail, r);
+        }
+        else
+        {
+          tuple_list T = phi(insert(a, m), d, w, n_tail, r);
+
+          S = phi(m, d, insert(a, w), n_tail, r);
+          addActionCondition(process::action(), condition, std::move(T), S);
+        }
+      }
     }
 
-    alpha = alpha.tail();
+    return S;
   }
-  cond = data::lazy::not_(cond);
-  return cond;
-}
 
+  bool xi(const process::action_list& alpha, const process::action_list& beta)
+  {
+    bool result = false;
+
+    if (beta.empty())
+    {
+      result = m_comm_table.can_communicate(alpha) != process::action_label();
+    }
+    else
+    {
+      const process::action_list alpha_ = insert(beta.front(), alpha);
+
+      if (m_comm_table.can_communicate(alpha_) != process::action_label())
+      {
+        result = true;
+      }
+      else
+      {
+        const process::action_list& beta_tail = beta.tail();
+        if (m_comm_table.might_communicate(alpha_, beta_tail))
+        {
+          result = xi(alpha, beta_tail);
+        }
+
+        result = result || xi(alpha, beta_tail);
+      }
+    }
+    return result;
+  }
+
+  data::data_expression psi(process::action_list alpha)
+  {
+    assert(std::is_sorted(alpha.begin(), alpha.end(), action_compare()));
+    data::data_expression cond = data::sort_bool::false_();
+
+    process::action_list actl; // used in inner loop.
+    while (!alpha.empty())
+    {
+      process::action_list beta = alpha.tail();
+
+      while (!beta.empty())
+      {
+        actl = process::action_list();
+        actl = insert(alpha.front(), actl);
+        actl = insert(beta.front(), actl);
+        const process::action_list& beta_tail = beta.tail();
+        if (m_comm_table.might_communicate(actl, beta_tail) && xi(actl, beta_tail))
+        {
+          // sort and remove duplicates??
+          cond = data::lazy::or_(cond, pairwise_equal_to(alpha.front().arguments(), beta.front().arguments()));
+        }
+        beta = beta_tail;
+      }
+
+      alpha = alpha.tail();
+    }
+    cond = data::lazy::not_(cond);
+    return cond;
+  }
 };
-}
+} // namespace detail
 
-inline
-void communicationcomposition(
-  const process::communication_expression_list& communications,
-  const process::action_name_multiset_list& allowlist,  // This is a list of list of identifierstring.
-  const bool is_allow,                          // If is_allow or is_block is set, perform inline allow/block filtering.
-  const bool is_block,
-  stochastic_action_summand_vector& action_summands,
-  deadlock_summand_vector& deadlock_summands,
-  const process::action& terminationAction,
-  const bool nosumelm,
-  const bool nodeltaelimination,
-  const bool ignore_time,
-  const std::function<data::data_expression(const data::data_expression&)>& RewriteTerm)
+inline void communicationcomposition(const process::communication_expression_list& communications,
+    const process::action_name_multiset_list& allowlist, // This is a list of list of identifierstring.
+    const bool is_allow, // If is_allow or is_block is set, perform inline allow/block filtering.
+    const bool is_block,
+    stochastic_action_summand_vector& action_summands,
+    deadlock_summand_vector& deadlock_summands,
+    const process::action& terminationAction,
+    const bool nosumelm,
+    const bool nodeltaelimination,
+    const bool ignore_time,
+    const std::function<data::data_expression(const data::data_expression&)>& RewriteTerm)
 
 {
-  return detail::apply_communication_algorithm(terminationAction, RewriteTerm, communications, allowlist, is_allow, is_block).apply(
-    action_summands, deadlock_summands, nosumelm, nodeltaelimination, ignore_time);
+  return detail::apply_communication_algorithm(terminationAction,
+      RewriteTerm,
+      communications,
+      allowlist,
+      is_allow,
+      is_block)
+      .apply(action_summands, deadlock_summands, nosumelm, nodeltaelimination, ignore_time);
 }
-
 
 } // namespace lps
 
 } // namespace mcrl2
-
-
 
 #endif // MCRL2_LPS_LINEARISE_COMMUNICATION_H

--- a/libraries/lps/include/mcrl2/lps/linearise_communication.h
+++ b/libraries/lps/include/mcrl2/lps/linearise_communication.h
@@ -571,6 +571,7 @@ comm_entry m_comm_table;
 const bool m_is_allow;                          // If is_allow or is_block is set, perform inline allow/block filtering. They are mutually exclusive
 const bool m_is_block;
 
+#ifdef MCRL2_LOG_LPS_LINEARISE_STATISTICS
 std::string log_comm_application(const lps_statistics_t& lps_statistics_before,
                                  const lps_statistics_t& lps_statistics_after,
                                  const std::size_t disallowed_summands,
@@ -614,6 +615,7 @@ std::string log_comm_application(const lps_statistics_t& lps_statistics_before,
 
   return os.str();
 }
+#endif //MCRL2_LOG_LPS_LINEARISE_STATISTICS
 
 /// Static initialization function to ensure m_allowed_actions can be const.
 static const std::vector<core::identifier_string>

--- a/libraries/lps/include/mcrl2/lps/linearise_rename.h
+++ b/libraries/lps/include/mcrl2/lps/linearise_rename.h
@@ -24,6 +24,7 @@ namespace mcrl2
 namespace lps
 {
 
+#ifdef MCRL2_LOG_LPS_LINEARISE_STATISTICS
   inline
   std::string log_rename_application(const lps_statistics_t& lps_statistics_before,
                                    const lps_statistics_t& lps_statistics_after,
@@ -43,6 +44,7 @@ namespace lps
 
     return os.str();
   }
+#endif
 
   /// Apply renamings to a single action
   inline

--- a/libraries/lps/include/mcrl2/lps/linearise_rename.h
+++ b/libraries/lps/include/mcrl2/lps/linearise_rename.h
@@ -24,6 +24,26 @@ namespace mcrl2
 namespace lps
 {
 
+  inline
+  std::string log_rename_application(const lps_statistics_t& lps_statistics_before,
+                                   const lps_statistics_t& lps_statistics_after,
+                                   const std::size_t num_rename_expressions,
+                                   size_t indent = 0)
+  {
+    std::string indent_str(indent, ' ');
+    std::ostringstream os;
+
+    os << indent_str << "- operator: rename" << std::endl;
+
+    indent += 2;
+    indent_str = std::string(indent, ' ');
+    os << indent_str << "number of rename expressions: " << num_rename_expressions << std::endl
+       << indent_str << "before:" << std::endl << print(lps_statistics_before, indent+2)
+       << indent_str << "after:" << std::endl << print(lps_statistics_after, indent+2);
+
+    return os.str();
+  }
+
   /// Apply renamings to a single action
   inline
   process::action rename(const process::rename_expression_list& renamings, const process::action& action)
@@ -79,10 +99,19 @@ namespace lps
     const process::rename_expression_list& renamings,
     lps::stochastic_action_summand_vector& action_summands)
   {
+#ifdef MCRL2_LOG_LPS_LINEARISE_STATISTICS
+    lps_statistics_t lps_statistics_before = get_statistics(action_summands);
+#endif
+
     for (auto& action_summand: action_summands)
     {
       action_summand = rename(renamings, action_summand);
     }
+
+#ifdef MCRL2_LOG_LPS_LINEARISE_STATISTICS
+    lps_statistics_t lps_statistics_after = get_statistics(action_summands);
+    std::cout << log_rename_application(lps_statistics_before, lps_statistics_after, renamings.size());
+#endif
   }
 
 } // namespace lps

--- a/libraries/lps/include/mcrl2/lps/linearise_rename.h
+++ b/libraries/lps/include/mcrl2/lps/linearise_rename.h
@@ -12,9 +12,9 @@
 #ifndef MCRL2_LPS_LINEARISE_RENAME_H
 #define MCRL2_LPS_LINEARISE_RENAME_H
 
-#include "mcrl2/atermpp/aterm_list.h"
 #include "mcrl2/lps/stochastic_action_summand.h"
 #include "mcrl2/lps/linearise_utility.h"
+#include "mcrl2/lps/detail/configuration.h"
 #include "mcrl2/process/process_expression.h"
 
 
@@ -24,7 +24,6 @@ namespace mcrl2
 namespace lps
 {
 
-#ifdef MCRL2_LOG_LPS_LINEARISE_STATISTICS
   inline
   std::string log_rename_application(const lps_statistics_t& lps_statistics_before,
                                    const lps_statistics_t& lps_statistics_after,
@@ -44,7 +43,6 @@ namespace lps
 
     return os.str();
   }
-#endif
 
   /// Apply renamings to a single action
   inline
@@ -101,19 +99,19 @@ namespace lps
     const process::rename_expression_list& renamings,
     lps::stochastic_action_summand_vector& action_summands)
   {
-#ifdef MCRL2_LOG_LPS_LINEARISE_STATISTICS
+    [[maybe_unused]]    
     lps_statistics_t lps_statistics_before = get_statistics(action_summands);
-#endif
 
-    for (auto& action_summand: action_summands)
+    for (stochastic_action_summand& action_summand: action_summands)
     {
       action_summand = rename(renamings, action_summand);
     }
 
-#ifdef MCRL2_LOG_LPS_LINEARISE_STATISTICS
-    lps_statistics_t lps_statistics_after = get_statistics(action_summands);
-    std::cout << log_rename_application(lps_statistics_before, lps_statistics_after, renamings.size());
-#endif
+    if constexpr (detail::EnableLineariseStatistics)
+    {
+      lps_statistics_t lps_statistics_after = get_statistics(action_summands);
+      std::cout << log_rename_application(lps_statistics_before, lps_statistics_after, renamings.size());
+    }
   }
 
 } // namespace lps

--- a/libraries/lps/include/mcrl2/lps/linearise_utility.h
+++ b/libraries/lps/include/mcrl2/lps/linearise_utility.h
@@ -13,10 +13,12 @@
 #define MCRL2_LPS_LINEARISE_UTILITY_H
 
 #include "mcrl2/data/data_expression.h"
+#include "mcrl2/lps/detail/configuration.h"
 #include "mcrl2/process/process_expression.h"
 #include "mcrl2/lps/deadlock_summand.h"
 #include "mcrl2/lps/stochastic_action_summand.h"
 
+#include <optional>
 
 namespace mcrl2
 {
@@ -56,11 +58,14 @@ inline
 lps_statistics_t get_statistics(const stochastic_action_summand_vector& action_summands)
 {
   lps_statistics_t statistics;
-  statistics.action_summand_count = action_summands.size();
-
-  for (const auto& s: action_summands)
+  if constexpr (detail::EnableLineariseStatistics)
   {
-    statistics.total_action_count += s.multi_action().actions().size();
+    statistics.action_summand_count = action_summands.size();
+
+    for (const auto& s: action_summands)
+    {
+      statistics.total_action_count += s.multi_action().actions().size();
+    }
   }
 
   return statistics;

--- a/libraries/lps/include/mcrl2/lps/linearise_utility.h
+++ b/libraries/lps/include/mcrl2/lps/linearise_utility.h
@@ -28,7 +28,7 @@ namespace lps
 struct lps_statistics_t
 {
   size_t action_summand_count = 0;
-  size_t deadlock_summand_count = 0;
+  std::optional<size_t> deadlock_summand_count;
   size_t total_action_count = 0; // The sum of the number of actions in all the multiactions in the action summands.
 };
 
@@ -40,7 +40,7 @@ std::string print(const lps_statistics_t& stats, std::size_t indent = 0)
   std::string indent_str = std::string(indent, ' ');
 
   ss << indent_str << "action_summand_count: " << stats.action_summand_count << std::endl;
-  ss << indent_str << "deadlock_summand_count: " << stats.deadlock_summand_count << std::endl;
+  ss << indent_str << "deadlock_summand_count: " << (stats.deadlock_summand_count.has_value()?std::to_string(*stats.deadlock_summand_count):"n/a") << std::endl;
   ss << indent_str << "total_action_count: " << stats.total_action_count << std::endl;
   if (stats.action_summand_count > 0)
   {
@@ -53,16 +53,25 @@ std::string print(const lps_statistics_t& stats, std::size_t indent = 0)
 /// Utility function to calculate the number of summands and the sizes of multiactions in those summands for printing
 /// statistics
 inline
-lps_statistics_t get_statistics(const stochastic_action_summand_vector& action_summands, const deadlock_summand_vector& deadlock_summands)
+lps_statistics_t get_statistics(const stochastic_action_summand_vector& action_summands)
 {
   lps_statistics_t statistics;
   statistics.action_summand_count = action_summands.size();
-  statistics.deadlock_summand_count = deadlock_summands.size();
 
   for (const auto& s: action_summands)
   {
     statistics.total_action_count += s.multi_action().actions().size();
   }
+
+  return statistics;
+}
+
+/// Get statistics for action and deadlock summands
+inline
+lps_statistics_t get_statistics(const stochastic_action_summand_vector& action_summands, const deadlock_summand_vector& deadlock_summands)
+{
+  lps_statistics_t statistics = get_statistics(action_summands);
+  statistics.deadlock_summand_count = deadlock_summands.size();
 
   return statistics;
 }

--- a/libraries/lps/include/mcrl2/lps/linearise_utility.h
+++ b/libraries/lps/include/mcrl2/lps/linearise_utility.h
@@ -24,6 +24,49 @@ namespace mcrl2
 namespace lps
 {
 
+/// Data structure to store the statistics about summands in a linear process
+struct lps_statistics_t
+{
+  size_t action_summand_count = 0;
+  size_t deadlock_summand_count = 0;
+  size_t total_action_count = 0; // The sum of the number of actions in all the multiactions in the action summands.
+};
+
+/// Print statistics of lps as indented block in YAML format
+inline
+std::string print(const lps_statistics_t& stats, std::size_t indent = 0)
+{
+  std::stringstream ss;
+  std::string indent_str = std::string(indent, ' ');
+
+  ss << indent_str << "action_summand_count: " << stats.action_summand_count << std::endl;
+  ss << indent_str << "deadlock_summand_count: " << stats.deadlock_summand_count << std::endl;
+  ss << indent_str << "total_action_count: " << stats.total_action_count << std::endl;
+  if (stats.action_summand_count > 0)
+  {
+    ss << indent_str << "average multiaction size (total_action_count / action_summand_count): "
+       << static_cast<double>(stats.total_action_count) / static_cast<double>(stats.action_summand_count) << std::endl;
+  }
+  return ss.str();
+}
+
+/// Utility function to calculate the number of summands and the sizes of multiactions in those summands for printing
+/// statistics
+inline
+lps_statistics_t get_statistics(const stochastic_action_summand_vector& action_summands, const deadlock_summand_vector& deadlock_summands)
+{
+  lps_statistics_t statistics;
+  statistics.action_summand_count = action_summands.size();
+  statistics.deadlock_summand_count = deadlock_summands.size();
+
+  for (const auto& s: action_summands)
+  {
+    statistics.total_action_count += s.multi_action().actions().size();
+  }
+
+  return statistics;
+}
+
 struct action_name_compare
 {
   bool operator()(const core::identifier_string& s1, const core::identifier_string& s2) const

--- a/libraries/lps/source/linearise.cpp
+++ b/libraries/lps/source/linearise.cpp
@@ -7248,6 +7248,7 @@ class specification_basic_type
 
     /**************** hiding *****************************************/
 
+#ifdef MCRL2_LOG_LPS_LINEARISE_STATISTICS
     static
     std::string log_hide_application(const lps_statistics_t& lps_statistics_before,
                                      const lps_statistics_t& lps_statistics_after,
@@ -7267,6 +7268,7 @@ class specification_basic_type
 
       return os.str();
     }
+#endif // MCRL2_LOG_LPS_LINEARISE_STATISTICS
 
     static
     action_list hide_(const identifier_string_list& hidelist, const action_list& multiaction)
@@ -7921,6 +7923,7 @@ class specification_basic_type
       }
     }
 
+#ifdef MCRL2_LOG_LPS_LINEARISE_STATISTICS
     static std::string log_leftmerge_application(const lps_statistics_t& lps_statistics_before,
         const lps_statistics_t& lps_statistics_result_before,
         const lps_statistics_t& lps_statistics_result_after,
@@ -7956,6 +7959,7 @@ class specification_basic_type
 
       return os.str();
     }
+#endif
 
     void calculate_left_merge(
       const stochastic_action_summand_vector& action_summands1,
@@ -8207,6 +8211,7 @@ class specification_basic_type
       }
     }
 
+#ifdef MCRL2_LOG_LPS_LINEARISE_STATISTICS
     static std::string log_communicationmerge_application(const lps_statistics_t& lps1_statistics_before,
         const lps_statistics_t& lps2_statistics_before,
         const lps_statistics_t& lps_result_statistics_before,
@@ -8241,6 +8246,7 @@ class specification_basic_type
 
       return os.str();
     }
+#endif
 
     void calculate_communication_merge(
           const stochastic_action_summand_vector& action_summands1,
@@ -8320,6 +8326,7 @@ class specification_basic_type
     }
 
 
+#ifdef MCRL2_LOG_LPS_LINEARISE_STATISTICS
     static
     std::string log_parallelcomposition_application_start(
                                     const lps_statistics_t& lps1_statistics_before,
@@ -8368,6 +8375,7 @@ class specification_basic_type
 
       return os.str();
     }
+#endif
 
     void parallelcomposition(
       const stochastic_action_summand_vector& action_summands1,

--- a/libraries/lps/source/linearise.cpp
+++ b/libraries/lps/source/linearise.cpp
@@ -26,6 +26,15 @@
 */
 
 //mCRL2 data
+
+// The following define allows collecting and printing statistics about the operations performed in the linearizer.
+// Currently, we collect and print information about:
+// the operations performed on processes,
+// the number of summands and the total number of actions in the multications in these summands.
+// Note that all logs are written to std::cout, so if this flag is enabled, tool output can not be streamed through std::cout
+//#define MCRL2_LOG_LPS_LINEARISE_STATISTICS 1
+
+
 #include "mcrl2/data/substitutions/maintain_variables_in_rhs.h"
 #include "mcrl2/data/fourier_motzkin.h"
 #include "mcrl2/data/enumerator.h" 

--- a/libraries/lps/source/linearise.cpp
+++ b/libraries/lps/source/linearise.cpp
@@ -25,8 +25,6 @@
    the use of this software.
 */
 
-//mCRL2 data
-
 // The following define allows collecting and printing statistics about the operations performed in the linearizer.
 // Currently, we collect and print information about:
 // the operations performed on processes,
@@ -34,7 +32,7 @@
 // Note that all logs are written to std::cout, so if this flag is enabled, tool output can not be streamed through std::cout
 //#define MCRL2_LOG_LPS_LINEARISE_STATISTICS 1
 
-
+//mCRL2 data
 #include "mcrl2/data/substitutions/maintain_variables_in_rhs.h"
 #include "mcrl2/data/fourier_motzkin.h"
 #include "mcrl2/data/enumerator.h" 
@@ -7251,6 +7249,26 @@ class specification_basic_type
     /**************** hiding *****************************************/
 
     static
+    std::string log_hide_application(const lps_statistics_t& lps_statistics_before,
+                                     const lps_statistics_t& lps_statistics_after,
+                                     const std::size_t num_hidden_actions,
+                                     size_t indent = 0)
+    {
+      std::string indent_str(indent, ' ');
+      std::ostringstream os;
+
+      os << indent_str << "- operator: hide" << std::endl;
+
+      indent += 2;
+      indent_str = std::string(indent, ' ');
+      os << indent_str << "number of hidden actions: " << num_hidden_actions << std::endl
+         << indent_str << "before:" << std::endl << print(lps_statistics_before, indent+2)
+         << indent_str << "after:" << std::endl << print(lps_statistics_after, indent+2);
+
+      return os.str();
+    }
+
+    static
     action_list hide_(const identifier_string_list& hidelist, const action_list& multiaction)
     {
       action_list resultactionlist;
@@ -7264,12 +7282,16 @@ class specification_basic_type
       }
 
       /* reverse the actionlist to maintain the ordering */
-      return reverse(resultactionlist);
+      resultactionlist = reverse(resultactionlist);
+      return resultactionlist;
     }
 
     static
     void hidecomposition(const identifier_string_list& hidelist, stochastic_action_summand_vector& action_summands)
     {
+#ifdef MCRL2_LOG_LPS_LINEARISE_STATISTICS
+      lps_statistics_t lps_statistics_before = get_statistics(action_summands);
+#endif
       for (stochastic_action_summand_vector::iterator i=action_summands.begin(); i!=action_summands.end() ; ++i)
       {
         const action_list acts=hide_(hidelist,i->multi_action().actions());
@@ -7279,6 +7301,11 @@ class specification_basic_type
                           i->assignments(),
                           i->distribution());
       }
+
+#ifdef MCRL2_LOG_LPS_LINEARISE_STATISTICS
+      lps_statistics_t lps_statistics_after = get_statistics(action_summands);
+      std::cout << log_hide_application(lps_statistics_before, lps_statistics_after, hidelist.size());
+#endif
     }
 
     /**************** equalargs ****************************************/

--- a/libraries/lps/source/linearise.cpp
+++ b/libraries/lps/source/linearise.cpp
@@ -35,7 +35,7 @@
 //mCRL2 data
 #include "mcrl2/data/substitutions/maintain_variables_in_rhs.h"
 #include "mcrl2/data/fourier_motzkin.h"
-#include "mcrl2/data/enumerator.h" 
+#include "mcrl2/data/enumerator.h"
 #include "mcrl2/data/real_utilities.h"
 
 // linear process libraries.
@@ -330,17 +330,17 @@ class specification_basic_type
         }
       }
     }
-    objectdatatype& objectIndex(const aterm& o) 
+    objectdatatype& objectIndex(const aterm& o)
     {
       detail_check_objectdata(o);
       return objectdata.find(o)->second;
-    } 
+    }
 
     const objectdatatype& objectIndex(const aterm& o) const
     {
       detail_check_objectdata(o);
       return objectdata.find(o)->second;
-    } 
+    }
 
     void addString(const identifier_string& str)
     {
@@ -386,8 +386,8 @@ class specification_basic_type
 
     /// Convert the process expression to a sorted action list.
     static
-    action_list to_sorted_action_list(const process_expression& p) 
-    { 
+    action_list to_sorted_action_list(const process_expression& p)
+    {
       return sort_actions(to_action_list(p));
     }
 
@@ -489,7 +489,7 @@ class specification_basic_type
       if (isnew)
       {
         objectdatatype object;
-              
+
         // tempvar is needed as objectdata can change during a call
         // of getparameters.
         const variable_list templist=getparameters(multiAction);
@@ -502,7 +502,7 @@ class specification_basic_type
         object.processbody=action_list_to_process(tempvar);
         object.free_variables=std::set<variable>(object.parameters.begin(), object.parameters.end());
         object.free_variables_defined=true;
-        
+
         objectdata[actionnames]=object;
       }
       return objectdata.find(actionnames)->second;
@@ -713,7 +713,7 @@ class specification_basic_type
       object.objectname=str;
       object.object=act;
       object.process_representing_action=process_identifier();
-      
+
       objectdata[actionId]=object;
       return objectdata.find(actionId)->second;
     }
@@ -729,8 +729,8 @@ class specification_basic_type
     /************ storeprocs *************************************************/
 
     objectdatatype& insert_process_declaration(
-      const process_identifier& procId, 
-      const variable_list& parameters,  
+      const process_identifier& procId,
+      const variable_list& parameters,
       const process_expression& body,
       processstatustype s,
       const bool canterminate,
@@ -818,7 +818,7 @@ class specification_basic_type
     action_list linMergeMultiActionList(const action_list& ma1, const action_list& ma2)
     {
       action_list result=ma2;
-      for (const action& a: ma1) 
+      for (const action& a: ma1)
       {
         result=insert(a,result);
       }
@@ -1538,7 +1538,7 @@ class specification_basic_type
       }
       if (is_if_then(p))
       {
-        for(const variable& v: find_free_variables(if_then(p).condition())) 
+        for(const variable& v: find_free_variables(if_then(p).condition()))
         {
           free_variables_in_p.insert(v);
         }
@@ -1897,7 +1897,7 @@ class specification_basic_type
        all variables that are bound by a sum in p by unique
        variables */
 
-   
+
     /* The function below cannot be replace by replace_variables_capture_avoiding although
      * the interfaces are the same. As yet it is unclear why, but the difference shows itself
      * for instance when linearising lift3_final.mcrl2 and lift3_init.mcrl2 */
@@ -1924,7 +1924,7 @@ class specification_basic_type
       {
         process_expression q=substitute_pCRLproc(seq(p).left(),sigma);
         if (q==delta_at_zero())
-        { 
+        {
           return q;
         }
         return seq(q, substitute_pCRLproc(seq(p).right(),sigma));
@@ -2102,8 +2102,8 @@ class specification_basic_type
       const variable_list& parameters,
       const process_expression& body)
     {
-      variable_vector result; 
-      for(const variable& p: parameters) 
+      variable_vector result;
+      for(const variable& p: parameters)
       {
         if (occursinpCRLterm(p,body,false))
         {
@@ -2385,9 +2385,9 @@ class specification_basic_type
 
 
     process_expression bodytovarheadGNF(
-      const process_expression& body, 
+      const process_expression& body,
       const state s,
-      const variable_list& freevars, 
+      const variable_list& freevars,
       const variableposition v,
       const std::set<variable>& variables_bound_in_sum)
     {
@@ -2909,11 +2909,11 @@ class specification_basic_type
 
       throw mcrl2::runtime_error("Internal error. Unexpected process format in distribute condition " + process::pp(body1) +".");
     }
-    
+
     /* This process calculates the equivalent of sum sumvars dist stochvars[distribution] body
        where the distribution occurs in front. This can only be done under limited circumstances.
        Assume we can enumerate the values of sumvars by e1,...,en. Introduce n copies of stochvars,
-       i.e., stochvars1,...,stochvarsn. The new process becomes 
+       i.e., stochvars1,...,stochvarsn. The new process becomes
 
            dist stochvars1,stochvars2,...,stochvarsn
                 [distribution(e1,stochvars1)*distribution(e2,stochvars2)*...*distribution(en,stochvarsn)].
@@ -2925,8 +2925,8 @@ class specification_basic_type
     */
 
     process_expression enumerate_distribution_and_sums(
-                         const variable_list& sumvars, 
-                         const variable_list& stochvars, 
+                         const variable_list& sumvars,
+                         const variable_list& stochvars,
                          const data_expression& distribution,
                          const process_expression& body)
     {
@@ -2937,7 +2937,7 @@ class specification_basic_type
 
 
       std::vector < data_expression_vector > data_vector(1,data_expression_vector());
-      for(const variable& v:sumvars) 
+      for(const variable& v:sumvars)
       {
         std::vector < data_expression_vector > new_data_vector;
 
@@ -2954,13 +2954,13 @@ class specification_basic_type
             new_dv.push_back(d);
             new_data_vector.push_back(new_dv);
           }
-           
+
         }
         data_vector.swap(new_data_vector);
-        
-      } 
+
+      }
       assert(!data_vector.empty());
-      
+
       process_expression resulting_body;
       data_expression resulting_distribution;
       variable_list resulting_stochastic_variables;
@@ -2992,15 +2992,15 @@ class specification_basic_type
           resulting_stochastic_variables=vl;
           result_defined=true;
         }
-      } 
+      }
       /* Put the distribution in front. */
 
       return stochastic_operator(resulting_stochastic_variables, resulting_distribution, resulting_body);
     }
 
     process_expression distribute_sum_over_a_stochastic_operator(
-                         const variable_list& sumvars, 
-                         const variable_list& stochastic_variables, 
+                         const variable_list& sumvars,
+                         const variable_list& stochastic_variables,
                          const data_expression& distribution,
                          const process_expression& body)
     {
@@ -3032,8 +3032,8 @@ class specification_basic_type
         alphaconvert(inner_stoch_vars,sigma,sumvars,data_expression_list());
         const process_expression new_body=substitute_pCRLproc(sto.operand(), sigma);
         const data_expression new_distribution=replace_variables_capture_avoiding_alt(sto.distribution(), sigma);
-        return distribute_sum_over_a_stochastic_operator(sumvars, 
-                                                         stochastic_variables + inner_stoch_vars, 
+        return distribute_sum_over_a_stochastic_operator(sumvars,
+                                                         stochastic_variables + inner_stoch_vars,
                                                          sort_real::times(distribution,new_distribution), new_body);
       }
 
@@ -3225,7 +3225,7 @@ class specification_basic_type
             assert(check_valid_process_instance_assignment(procId,assignment_list(new_assignment.begin(),new_assignment.end())));
             newbody=seq(process_instance_assignment(procId,assignment_list(new_assignment.begin(),new_assignment.end())),newbody);
             const variable_list result=pars1+pars;
-            assert(std::set<variable>(result.begin(),result.end()).size()==result.size()); // all elements in the result are unique. 
+            assert(std::set<variable>(result.begin(),result.end()).size()==result.size()); // all elements in the result are unique.
             return result;
           }
           else
@@ -3245,7 +3245,7 @@ class specification_basic_type
                          const std::set<variable>& variables_bound_in_sum)
     {
       assignment_vector result;
-      for(const variable& v: vl) 
+      for(const variable& v: vl)
       {
         if (variables_bound_in_sum.count(v)>0 && occursinpCRLterm(v,t,false))
         {
@@ -3344,7 +3344,7 @@ class specification_basic_type
         std::set<variable> variables_bound_in_sum_new=variables_bound_in_sum;
         variables_bound_in_sum_new.insert(sto.variables().begin(),sto.variables().end());
         return stochastic_operator(sto.variables(),
-                                   sto.distribution(), 
+                                   sto.distribution(),
                                    create_regular_invocation(sto.operand(),todo,freevars+sto.variables(),variables_bound_in_sum_new));
       }
 
@@ -5078,13 +5078,13 @@ class specification_basic_type
         /* // Check whether it is a stochastic variable.
         if (std::find(stochastic_variables.begin(),stochastic_variables.end(),par)!=pars.end())
         {
-          result.push_back(assignment(par,par)); 
-        } 
+          result.push_back(assignment(par,par));
+        }
         // Otherwise, check that is is an ordinary parameter.
-        else */ 
+        else */
         if (std::find(pars.begin(),pars.end(),par)!=pars.end())
         {
-          result.push_back(par); 
+          result.push_back(par);
         }
         /* otherwise the value of this argument is irrelevant, so
            make it a don't care variable. */
@@ -5112,7 +5112,7 @@ class specification_basic_type
         // Check whether it is a stochastic variable.
         if (std::find(stochastic_variables.begin(),stochastic_variables.end(),par)!=pars.end())
         {
-          result.push_back(assignment(par,par)); 
+          result.push_back(assignment(par,par));
         }
         // Otherwise, check that is is an ordinary parameter.
         else if (std::find(pars.begin(),pars.end(),par)!=pars.end())
@@ -5244,7 +5244,7 @@ class specification_basic_type
     {
       assert(distribution != stochastic_distribution());
       assert(std::is_sorted(multiAction.begin(), multiAction.end(), action_compare()));
-        
+
       const data_expression rewritten_condition=RewriteTerm(condition);
       if (rewritten_condition==sort_bool::false_())
       {
@@ -5893,8 +5893,8 @@ class specification_basic_type
     static
     data_expression_list extend(const data_expression& c, const data_expression_list& cl)
     {
-      return data_expression_list(cl.begin(), 
-                                  cl.end(), 
+      return data_expression_list(cl.begin(),
+                                  cl.end(),
                                   [&c](const data_expression& e)->data_expression { return lazy::and_(c,e);} );
 
     }
@@ -5915,7 +5915,7 @@ class specification_basic_type
       const variable& var,
       const data_expression_list& conditionlist)
     {
-      try 
+      try
       {
         const data_expression unique=representative_generator_internal(var.sort(),false);
         const data_expression newcondition=equal_to(var,unique);
@@ -5923,10 +5923,10 @@ class specification_basic_type
       }
       catch (mcrl2::runtime_error&)
       {
-        // The representative generator failed to find a term of var.sort(). 
+        // The representative generator failed to find a term of var.sort().
         // No condition is generated, meaning that var will be unrestrained. This
         // is correct, and as the var.sort() has no concrete value, this will most
-        // likely not effect matters as state space generation. 
+        // likely not effect matters as state space generation.
         return conditionlist;
       }
     }
@@ -5944,7 +5944,7 @@ class specification_basic_type
         }
         catch (mcrl2::runtime_error&)
         {
-          // No representant for sort v.sort() could be found. No condition is added. 
+          // No representant for sort v.sort() could be found. No condition is added.
         }
       }
       return result;
@@ -6140,7 +6140,7 @@ class specification_basic_type
           return a.rhs();
         }
       }
-      return  var; 
+      return  var;
     }
 
     stochastic_action_summand collect_sum_arg_arg_cond(
@@ -6211,7 +6211,7 @@ class specification_basic_type
              i!=auxpars.end(); ++i, ++j)
         {
           /* Substitutions are carried out from left to right. The first applicable substitution counts */
-          if (sigma(*i)==*i)  // sigma *i is undefined. 
+          if (sigma(*i)==*i)  // sigma *i is undefined.
           {
             sigma[*i]=*j;
           }
@@ -6331,13 +6331,13 @@ class specification_basic_type
             data_expression_list::const_iterator d1=(a1->arguments()).begin();
             for (std::size_t i=1; i<fcnt; ++i, ++d1) {};
             f= *d1;
-            maintain_variables_in_rhs< mutable_map_substitution<> > sigma; 
+            maintain_variables_in_rhs< mutable_map_substitution<> > sigma;
             data_expression_list::const_iterator j=auxargs.begin();
             for (variable_list::const_iterator i=auxpars.begin();
                  i!=auxpars.end(); ++i, ++j)
             {
               /* Substitutions are carried out from left to right. The first applicable substitution counts */
-              if (sigma(*i)==*i)  // *i is not assigned in sigma. 
+              if (sigma(*i)==*i)  // *i is not assigned in sigma.
               {
                 sigma[*i]=*j;
               }
@@ -6695,7 +6695,7 @@ class specification_basic_type
                  i!=auxpars.end(); ++i, ++j)
           {
             /* Substitutions are carried out from left to right. The first applicable substitution counts */
-            if (sigma(*i)==*i)  // sigma is not defined for *i. 
+            if (sigma(*i)==*i)  // sigma is not defined for *i.
             {
               sigma[*i]=*j;
             }
@@ -6832,7 +6832,7 @@ class specification_basic_type
              i!=auxpars.end(); ++i, ++j)
         {
           /* Substitutions are carried out from left to right. The first applicable substitution counts */
-          if (sigma(*i)== *i) // sigma is not defined for *i. 
+          if (sigma(*i)== *i) // sigma is not defined for *i.
           {
             sigma[*i]=*j;
           }
@@ -6958,7 +6958,7 @@ class specification_basic_type
             const data_expression_list auxargs= *auxrename_list_args;
             ++auxrename_list_args;
 
-            maintain_variables_in_rhs< mutable_map_substitution<> > sigma; 
+            maintain_variables_in_rhs< mutable_map_substitution<> > sigma;
             data_expression_list::const_iterator j=auxargs.begin();
             for (variable_list::const_iterator i=auxpars.begin();
                  i!=auxpars.end(); ++i, ++j)
@@ -7611,7 +7611,7 @@ class specification_basic_type
         const variable_list& auxpars=*renamings_par;
         const data_expression_list& auxargs=*renamings_arg;
 
-        maintain_variables_in_rhs< mutable_map_substitution<> > sigma; 
+        maintain_variables_in_rhs< mutable_map_substitution<> > sigma;
         data_expression_list::const_iterator j1=auxargs.begin();
         for (variable_list::const_iterator i1=auxpars.begin();
              i1!=auxpars.end(); ++i1, ++j1)
@@ -7644,7 +7644,7 @@ class specification_basic_type
 
       for(const variable& var: var_list)
       {
-        const data::variable v = 
+        const data::variable v =
               get_fresh_variable(std::string(var.name()) + ((hint.empty())?"":"_") + hint, var.sort());
         sigma[var] = v;
       }
@@ -7774,7 +7774,7 @@ class specification_basic_type
       alphaconvert(renameable_variables, sigma, delay1.variables(), data_expression_list());
       // Additionally map the time variable of the second ultimate delay to that of the first.
       sigma[delay2.time_var()]=delay1.time_var();
-      data_expression new_constraint; 
+      data_expression new_constraint;
       optimized_and(new_constraint, delay1.constraint(), replace_variables_capture_avoiding_alt(delay2.constraint(),sigma));
       variable_list new_existential_variables = delay1.variables()+renameable_variables;
 
@@ -7921,6 +7921,42 @@ class specification_basic_type
       }
     }
 
+    static std::string log_leftmerge_application(const lps_statistics_t& lps_statistics_before,
+        const lps_statistics_t& lps_statistics_result_before,
+        const lps_statistics_t& lps_statistics_result_after,
+        const bool is_allow,
+        const bool is_block,
+        const std::size_t num_allow_block_actions,
+        size_t indent = 0)
+    {
+      std::string indent_str(indent, ' ');
+      std::ostringstream os;
+
+      os << indent_str << "- operator: leftmerge" << std::endl;
+
+      indent += 2;
+      indent_str = std::string(indent, ' ');
+      os << indent_str << "is_allow: " << std::boolalpha << is_allow << std::endl;
+      os << indent_str << "is_block: " << std::boolalpha << is_block << std::endl;
+      if (is_allow)
+      {
+        os << indent_str << "number of allow expressions: " << num_allow_block_actions << std::endl;
+      }
+      if (is_block)
+      {
+        os << indent_str << "number of block expressions: " << num_allow_block_actions << std::endl;
+      }
+
+      os << indent_str << "LPS before:" << std::endl
+         << print(lps_statistics_before, indent + 2)
+         << indent_str << "result before:" << std::endl
+         << print(lps_statistics_result_before, indent + 2)
+         << indent_str << "result after:" << std::endl
+         << print(lps_statistics_result_after, indent + 2);
+
+      return os.str();
+    }
+
     void calculate_left_merge(
       const stochastic_action_summand_vector& action_summands1,
       const deadlock_summand_vector& deadlock_summands1,
@@ -7931,12 +7967,27 @@ class specification_basic_type
       stochastic_action_summand_vector& action_summands,
       deadlock_summand_vector& deadlock_summands)
     {
+#ifdef MCRL2_LOG_LPS_LINEARISE_STATISTICS
+      lps_statistics_t lps_statistics_before = get_statistics(action_summands1, deadlock_summands1);
+      lps_statistics_t lps_statistics_result_before = get_statistics(action_summands, deadlock_summands);
+#endif
+
       calculate_left_merge_deadlock(ultimate_delay_condition2, deadlock_summands1,
                                     is_allow, is_block, action_summands, deadlock_summands);
       calculate_left_merge_action(ultimate_delay_condition2, action_summands1,
                                     allowlist, is_allow, is_block, action_summands);
-    }
 
+#ifdef MCRL2_LOG_LPS_LINEARISE_STATISTICS
+      lps_statistics_t lps_statistics_result_after = get_statistics(action_summands, deadlock_summands);
+
+      std::cout << log_leftmerge_application(lps_statistics_before,
+          lps_statistics_result_before,
+          lps_statistics_result_after,
+          is_allow,
+          is_block,
+          (is_block ? allowlist.front().size() : allowlist.size()), 4);
+#endif
+    }
 
 
     void calculate_communication_merge_action_summands(
@@ -8156,6 +8207,41 @@ class specification_basic_type
       }
     }
 
+    static std::string log_communicationmerge_application(const lps_statistics_t& lps1_statistics_before,
+        const lps_statistics_t& lps2_statistics_before,
+        const lps_statistics_t& lps_result_statistics_before,
+        const lps_statistics_t& lps_statistics_after,
+        const bool is_allow,
+        const bool is_block,
+        const std::size_t num_allow_block_actions,
+        size_t indent = 0)
+    {
+      std::string indent_str(indent, ' ');
+      std::ostringstream os;
+
+      os << indent_str << "- operator: communicationmerge" << std::endl;
+
+      indent += 2;
+      indent_str = std::string(indent, ' ');
+      os << indent_str << "is_allow: " << std::boolalpha << is_allow << std::endl;
+      os << indent_str << "is_block: " << std::boolalpha << is_block << std::endl;
+      if (is_allow)
+      {
+        os << indent_str << "number of allow expressions: " << num_allow_block_actions << std::endl;
+      }
+      if (is_block)
+      {
+        os << indent_str << "number of block expressions: " << num_allow_block_actions << std::endl;
+      }
+
+      os << indent_str << "first LPS before:" << std::endl << print(lps1_statistics_before, indent + 2)
+         << indent_str << "second LPS before:" << std::endl << print(lps2_statistics_before, indent + 2)
+         << indent_str << "result LPS before:" << std::endl << print(lps_result_statistics_before, indent + 2)
+         << indent_str << "result LPS after:" << std::endl << print(lps_statistics_after, indent + 2);
+
+      return os.str();
+    }
+
     void calculate_communication_merge(
           const stochastic_action_summand_vector& action_summands1,
           const deadlock_summand_vector& deadlock_summands1,
@@ -8167,10 +8253,23 @@ class specification_basic_type
           stochastic_action_summand_vector& action_summands,
           deadlock_summand_vector& deadlock_summands)
     {
+#ifdef MCRL2_LOG_LPS_LINEARISE_STATISTICS
+      lps_statistics_t lps1_statistics_before = get_statistics(action_summands1, deadlock_summands1);
+      lps_statistics_t lps2_statistics_before = get_statistics(action_summands2, deadlock_summands2);
+      lps_statistics_t lps_result_statistics_before = get_statistics(action_summands, deadlock_summands);
+#endif
+
       calculate_communication_merge_action_summands(action_summands1, action_summands2, allowlist, is_allow, is_block, action_summands);
       calculate_communication_merge_action_deadlock_summands(action_summands1, deadlock_summands2, action_summands, deadlock_summands);
       calculate_communication_merge_action_deadlock_summands(action_summands2, deadlock_summands1, action_summands, deadlock_summands);
       calculate_communication_merge_deadlock_summands(deadlock_summands1, deadlock_summands2, action_summands, deadlock_summands);
+
+#ifdef MCRL2_LOG_LPS_LINEARISE_STATISTICS
+      lps_statistics_t lps_statistics_after = get_statistics(action_summands, deadlock_summands);
+
+      std::cout << log_communicationmerge_application(lps1_statistics_before, lps2_statistics_before, lps_result_statistics_before,
+          lps_statistics_after, is_allow, is_block, (is_block ? allowlist.front().size() : allowlist.size()), 4);
+#endif
     }
 
 
@@ -8221,6 +8320,55 @@ class specification_basic_type
     }
 
 
+    static
+    std::string log_parallelcomposition_application_start(
+                                    const lps_statistics_t& lps1_statistics_before,
+                                    const lps_statistics_t& lps2_statistics_before,
+                                    const bool is_allow,
+                                    const bool is_block,
+                                    const std::size_t num_allow_block_actions,
+                                    size_t indent = 0)
+    {
+      std::string indent_str(indent, ' ');
+      std::ostringstream os;
+
+      os << indent_str << "- operator: parallel" << std::endl;
+
+      indent += 2;
+      indent_str = std::string(indent, ' ');
+      os << indent_str << "is_allow: " << std::boolalpha << is_allow << std::endl;
+      os << indent_str << "is_block: " << std::boolalpha << is_block << std::endl;
+      if (is_allow)
+      {
+        os << indent_str << "number of allow expressions: " << num_allow_block_actions << std::endl;
+      }
+      if (is_block)
+      {
+        os << indent_str << "number of block expressions: " << num_allow_block_actions << std::endl;
+      }
+
+      os << indent_str << "first LPS before:" << std::endl << print(lps1_statistics_before, indent+2)
+         << indent_str << "second LPS before:" << std::endl << print(lps2_statistics_before, indent+2);
+
+      os << indent_str << "subcalls:" << std::endl;
+
+      return os.str();
+    }
+
+  static
+  std::string log_parallelcomposition_application_end(
+                                      const lps_statistics_t& lps_statistics_after,
+                                      size_t indent = 0)
+    {
+      indent += 2;
+      std::string indent_str(indent, ' ');
+      std::ostringstream os;
+
+      os << indent_str << "after:" << std::endl << print(lps_statistics_after, indent+2);
+
+      return os.str();
+    }
+
     void parallelcomposition(
       const stochastic_action_summand_vector& action_summands1,
       const deadlock_summand_vector& deadlock_summands1,
@@ -8256,6 +8404,13 @@ class specification_basic_type
       // At this point the parameters of pars1 and pars2 are unique, except for
       // those that are constant in both processes.
 
+#ifdef MCRL2_LOG_LPS_LINEARISE_STATISTICS
+      lps_statistics_t lps1_statistics_before = get_statistics(action_summands1, deadlock_summands1);
+      lps_statistics_t lps2_statistics_before = get_statistics(action_summands2, deadlock_summands2);
+
+      std::cout << log_parallelcomposition_application_start(lps1_statistics_before, lps2_statistics_before, is_allow, is_block, (is_block?allowlist1.front().size():allowlist1.size()));
+#endif
+
       variable_list pars3;
       for (const variable& v: pars2)
       {
@@ -8284,6 +8439,12 @@ class specification_basic_type
       {
         ultimate_delay_condition=combine_ultimate_delays(ultimate_delay_condition1, ultimate_delay_condition2);
       }
+
+#ifdef MCRL2_LOG_LPS_LINEARISE_STATISTICS
+      lps_statistics_t lps_statistics_after = get_statistics(action_summands, deadlock_summands);
+
+      std::cout << log_parallelcomposition_application_end(lps_statistics_after);
+#endif
     }
 
     /**************** GENERaTE LPEmCRL **********************************/
@@ -8296,7 +8457,7 @@ class specification_basic_type
     void generateLPEmCRLterm(
       stochastic_action_summand_vector& action_summands,
       deadlock_summand_vector& deadlock_summands,
-      const process_expression& t,    
+      const process_expression& t,
       const bool regular,
       const bool rename_variables,
       variable_list& pars,
@@ -8311,7 +8472,7 @@ class specification_basic_type
 
         objectdatatype& object=objectIndex(process_instance_assignment(t).identifier());
 
-        // Now apply the assignment in this process to the obtained initial process and the distribution. 
+        // Now apply the assignment in this process to the obtained initial process and the distribution.
         maintain_variables_in_rhs<mutable_map_substitution<> > sigma;
         for (const assignment& a: process_instance_assignment(t).assignments())
         {
@@ -8319,7 +8480,7 @@ class specification_basic_type
         }
 
         init=replace_variables_capture_avoiding_alt(init,sigma);
-        initial_stochastic_distribution = 
+        initial_stochastic_distribution =
                    stochastic_distribution(
                          initial_stochastic_distribution.variables(),
                          replace_variables_capture_avoiding_alt(initial_stochastic_distribution.distribution(), sigma));
@@ -8349,7 +8510,7 @@ class specification_basic_type
           // stacks are being used.
 
           stochastic_linear_process lps(pars,deadlock_summands,action_summands);
-          stochastic_process_initializer initializer(init,initial_stochastic_distribution); 
+          stochastic_process_initializer initializer(init,initial_stochastic_distribution);
 
           stochastic_specification temporary_spec(data,acts,global_variables,lps,initializer);
           constelm_algorithm < rewriter, stochastic_specification > alg(temporary_spec,rewr);
@@ -8365,7 +8526,7 @@ class specification_basic_type
           }
 
           // Reconstruct the variables from the temporary specification
-          init=temporary_spec.initial_process().expressions();     
+          init=temporary_spec.initial_process().expressions();
           pars=temporary_spec.process().process_parameters();
           assert(init.size()==pars.size());
           // Add all free variables in object.parameters that are not already in the parameter list
@@ -8391,7 +8552,7 @@ class specification_basic_type
         }
         // Now constelm has been applied.
         return;
-      } // End process assignment. 
+      } // End process assignment.
 
       if (is_merge(t))
       {
@@ -8541,7 +8702,7 @@ class specification_basic_type
     /* The result are a list of action summands, deadlock summand, the parameters of this
        linear process and its initial values. A initial stochastic distribution that must
        precede the initial linear process and the ultimate delay condition of this
-       linear process that can be used or be ignored. 
+       linear process that can be used or be ignored.
 
     */
 
@@ -8984,14 +9145,14 @@ class specification_basic_type
           const variable_list new_parameters=object.parameters;
           const stochastic_operator& sto=down_cast<stochastic_operator>(new_process);
           assignment_list new_assignments;
-          
+
           const variable_list relevant_stochastic_variables=parameters_that_occur_in_body(sto.variables(),object.processbody);
           assert(relevant_stochastic_variables.size()<=new_parameters.size());
           // The variables in sto.variables() may clash with local variables u and therefore need to be rename.
           variable_list renamed_sto_variables=sto.variables();
           mutable_indexed_substitution<> local_sigma1;
           alphaconvertprocess(renamed_sto_variables, local_sigma1, t);
-          
+
 
           variable_list::const_iterator i=new_parameters.begin();
           for(const variable& v: relevant_stochastic_variables)
@@ -9005,7 +9166,7 @@ class specification_basic_type
           // Therefore, the assignments must be filtered.
           new_assignments=filter_assignments(new_assignments + u.assignments(),object.parameters);
 
-          // The variables bound in the distribution may conflict 
+          // The variables bound in the distribution may conflict
 
           // Furthermore, the old assignment must be applied to the distribution, when it is moved
           // outside of the process body.
@@ -9642,7 +9803,7 @@ class specification_basic_type
       {
         throw mcrl2::runtime_error("Process " + pp(t.identifier()) + " is unguardedly defined in itself");
       };
-      
+
       visited_processes.insert(t.identifier());
       objectdatatype& object=objectIndex(t.identifier());
       if (is_process_instance_assignment(object.processbody))
@@ -9675,16 +9836,16 @@ class specification_basic_type
  *   All assignments in a process_instance_assignment of the form x=x where
  *   x is not a bound variable are removed.
  *   Furthermore, process occurrences X where X is defined as X=X1, X1=X2...Xn-1=Xn
- *   are replaced by Xn, with the necessary substitutions for data parameters. 
+ *   are replaced by Xn, with the necessary substitutions for data parameters.
  *   The reason for this is that only Xn will become a process in the linear
  *   process, with its own state. Otherwise there is a risk that all process
  *   variables X, X1, X2, etc. have separate states, and worse, for all of them
- *   a copy of the summands will be added. 
+ *   a copy of the summands will be added.
 */
 
 
     /* This function replaces all process instances by a process instance assignment,
-       furthermore, if a process consists of only a process instantionation, i.e., X=Y, it is removed. 
+       furthermore, if a process consists of only a process instantionation, i.e., X=Y, it is removed.
        Nested stochastic operators are merged into one. */
     void transform_process_arguments(
             const process_identifier& procId,
@@ -9702,7 +9863,7 @@ class specification_basic_type
       }
     }
 
-    /* This function replaces all process instances by a process instance assignment and 
+    /* This function replaces all process instances by a process instance assignment and
        merges nested stochastic operators into one.  */
     void transform_process_arguments(const process_identifier& procId)
     {
@@ -9710,10 +9871,10 @@ class specification_basic_type
       transform_process_arguments(procId,visited_processes);
     }
 
-    /* This function replaces all process instances by a process instance assignment 
+    /* This function replaces all process instances by a process instance assignment
        and merges nested stochastic operators into one. */
     process_expression transform_process_arguments_body(
-      const process_expression& t, 
+      const process_expression& t,
       const std::set<variable>& bound_variables,
       std::set<process_identifier>& visited_processes)
     {
@@ -9912,7 +10073,7 @@ class specification_basic_type
     }
 
     process_expression guarantee_that_parameters_have_unique_type_body(
-      const process_expression& t, 
+      const process_expression& t,
       std::set<process_identifier>& visited_processes,
       std::set<identifier_string>& used_variable_names,
       maintain_variables_in_rhs<mutable_map_substitution<> >& parameter_mapping,
@@ -10079,10 +10240,10 @@ class specification_basic_type
 /* -----------------------------   split body  --------------------------- */
 
     process_expression split_body(
-      const process_expression& t, 
+      const process_expression& t,
       std::map < process_identifier,process_identifier >& visited_id,
       std::map < process_expression,process_expression>& visited_proc,
-      const variable_list& parameters)  
+      const variable_list& parameters)
     {
       /* Replace pCRL process terms that occur in the scope of mCRL processes
          by a process identifier. E.g. (a+b)||c is replaced by X||c and
@@ -10205,7 +10366,7 @@ class specification_basic_type
         if (multiaction == action_list({ terminationAction }))
         {
           acts.push_front(terminationAction.label());
-          mCRL2log(mcrl2::log::warning) << "The action " << process::pp(terminationAction) << 
+          mCRL2log(mcrl2::log::warning) << "The action " << process::pp(terminationAction) <<
                            " followed by a deadlock is added to signal termination of the linear process. \n";
           return;
         }
@@ -10296,7 +10457,7 @@ class specification_basic_type
     {
       /* Then select the BPA processes, and check that the others
          are proper parallel processes */
-      transform_process_arguments(init);   // Also merges nested stochastic operators. 
+      transform_process_arguments(init);   // Also merges nested stochastic operators.
       guarantee_that_parameters_have_unique_type(init);
       determine_process_status(init,mCRL);
       determinewhetherprocessescanterminate(init);
@@ -10324,7 +10485,7 @@ class specification_basic_type
       lps::detail::ultimate_delay dummy_ultimate_delay_condition;
       generateLPEmCRL(action_summands,
                       deadlock_summands,
-                      init_, 
+                      init_,
                       options.lin_method!=lmStack,
                       parameters,
                       initial_state,
@@ -10351,14 +10512,14 @@ mcrl2::lps::stochastic_specification mcrl2::lps::linearise(
   mcrl2::process::process_specification input_process=type_checked_spec;
   data_specification data_spec=input_process.data();
 
-  if (lin_options.balance_summands) // Make a balanced tree of long expressions of the shape p1 + p2 + p3 + ... + p4. 
+  if (lin_options.balance_summands) // Make a balanced tree of long expressions of the shape p1 + p2 + p3 + ... + p4.
                                     // By default the parser provides a skewed tree, and for very long sequences of summands this overflows the
                                     // stack.
   {
     balance_summands(input_process);
   }
 
-  if (lin_options.apply_alphabet_axioms) // Apply alphabet reduction if requested. 
+  if (lin_options.apply_alphabet_axioms) // Apply alphabet reduction if requested.
   {
     alphabet_reduce(input_process, 1000ul);
   }


### PR DESCRIPTION
I am currently looking into the performance of the application of process operators to linear processes. This commit adds logging information about the size of LPEs and multiactions to the following process operators, and writes them as YAML output on standard output:
- allow
- block
- hide
- rename
- communication
- parallel composition
- leftmerge

The prints are guarded by an #ifdef, and are not enabled by default.