### PR TITLE
Bug: SMT translation of natural/positive parameters

### DIFF
--- a/libraries/smt/include/mcrl2/smt/translate_expression.h
+++ b/libraries/smt/include/mcrl2/smt/translate_expression.h
@@ -215,33 +215,29 @@ void translate_variable_declaration(const Container& vars,
       translate_sort_expression(s, o, nt);
       o << " ";
       // This does not seem to work when translating variables of a function sort.
-       if(s == data::sort_pos::pos())
-       {
-         vars_conditions = data::lazy::and_(vars_conditions, greater_equal(v, data::sort_pos::c1()));
-       }
-       else if(s == data::sort_nat::nat())
-       {
-         vars_conditions = data::lazy::and_(vars_conditions, greater_equal(v, data::sort_nat::c0()));
-       }
+      // if(s == data::sort_pos::pos())
+      // {
+      //   vars_conditions = data::lazy::and_(vars_conditions, greater_equal(v, data::sort_pos::c1()));
+      // }
+      // else if(s == data::sort_nat::nat())
+      // {
+      //   vars_conditions = data::lazy::and_(vars_conditions, greater_equal(v, data::sort_nat::c0()));
+      // }
     }
+    // Add assertions for positive and natural numbers
     if(v.sort() == data::sort_pos::pos())
     {
-      vars_pos_nat.push_front(v);
-      //         vars_pos_nat = data::lazy::and_(vars_pos_nat, greater_equal(var_int, data::sort_int::int_(1)));
+         vars_conditions = data::lazy::and_(vars_conditions, greater_equal(v, data::sort_pos::c1()));
     }
     else if(v.sort() == data::sort_nat::nat())
     {
-      vars_pos_nat.push_front(v);
-      //         vars_pos_nat = data::lazy::and_(vars_pos_nat, greater_equal(var_int, data::sort_int::int_(0)));
+         vars_conditions = data::lazy::and_(vars_conditions, greater_equal(v, data::sort_nat::c0()));
     }
     o << ") ";
     translate_sort_expression(v.sort().target_sort(), o, nt);
     o << ")\n";
   }
 
-  for (const auto& v : vars_pos_nat) {
-    o << "(assert (>= " << v.name() << " " << (v == data::sort_pos::pos() ? 1 : 0) << ") )\n";
-  }
   translate_assertion(vars_conditions, o, c, nt);
 }
 

--- a/libraries/smt/include/mcrl2/smt/translate_expression.h
+++ b/libraries/smt/include/mcrl2/smt/translate_expression.h
@@ -10,7 +10,6 @@
 #define MCRL2_SMT_TRANSLATE_EXPRESSION_H
 
 #include "mcrl2/smt/translate_sort.h"
-#include <cstdio>
 
 namespace mcrl2
 {
@@ -62,7 +61,6 @@ declare_variables_binder(const data::variable_list& vars, OutputStream& out, con
     }
     else if (var.sort() == data::sort_nat::nat())
     {
-
       result = data::lazy::and_(result, greater_equal(var, data::sort_nat::c0()));
     }
   }
@@ -201,12 +199,10 @@ void translate_variable_declaration(const Container& vars,
     const native_translations& nt)
 {
   data::data_expression vars_conditions = data::sort_bool::true_();
-  data::variable_list vars_pos_nat;
   for (const data::variable& v : vars)
   {
     o << "(declare-fun " << translate_identifier(v.name()) << " (";
 
-  mCRL2log(log::debug) << "Make use? 2 " << translate_identifier(v.name()) <<  v.sort() << std::endl;
     data::sort_expression_list domain = data::is_function_sort(v.sort())
                                             ? atermpp::down_cast<data::function_sort>(v.sort()).domain()
                                             : data::sort_expression_list();
@@ -237,7 +233,6 @@ void translate_variable_declaration(const Container& vars,
     translate_sort_expression(v.sort().target_sort(), o, nt);
     o << ")\n";
   }
-
   translate_assertion(vars_conditions, o, c, nt);
 }
 


### PR DESCRIPTION
When translating the expression to be evaluated by the sat solver, the assertion of `>= 0` and `>= 1` for natural and positive numbers was missing. 

```
...

(declare-fun n_P () Int)
(declare-fun s2_P () Enum5)
(declare-fun n_P1 () Int)
(assert (not (and (=> (and (and (and (and (and (and (and (and (and 
```

and now

```
...

(declare-fun n_P () Int)
(declare-fun s2_P () Enum5)
(declare-fun n_P1 () Int)
(assert (and (>= n_P 0 ) (>= n_P1 0 ) ) )
(assert (not (and (=> (and (and (and (and (and (and (and (and (and 
```