### PR TITLE
Improvements for pbesiteration

### DIFF
--- a/libraries/pbes/include/mcrl2/pbes/tools/pbesiteration.h
+++ b/libraries/pbes/include/mcrl2/pbes/tools/pbesiteration.h
@@ -43,8 +43,6 @@ struct pbesiteration_options
   bool smt = false;
 };
 
-
-
 void substitute(pbes_equation& into,
     const pbes_equation& by,
     detail::substitute_propositional_variables_builder<pbes_system::pbes_expression_builder>& substituter)
@@ -57,7 +55,8 @@ void substitute(pbes_equation& into,
 }
 
 data::data_expression pbestodata(pbes_equation& equation,
-    detail::replace_other_propositional_variables_with_functions_builder<pbes_system::pbes_expression_builder>& replace_substituter)
+    detail::replace_other_propositional_variables_with_functions_builder<pbes_system::pbes_expression_builder>&
+        replace_substituter)
 {
   pbes_expression expr;
   replace_substituter.set_forward(true);
@@ -82,7 +81,8 @@ enum class InvResult
 // Equation should be in full form.
 InvResult global_invariant_check(pbes_equation& equation,
     detail::substitute_propositional_variables_builder<pbes_system::pbes_expression_builder>& substituter,
-    detail::replace_other_propositional_variables_with_functions_builder<pbes_system::pbes_expression_builder>& replace_substituter,
+    detail::replace_other_propositional_variables_with_functions_builder<pbes_system::pbes_expression_builder>&
+        replace_substituter,
     data::data_specification data_spec,
     simplify_data_rewriter<data::rewriter> pbes_rewriter,
     std::set<data::variable>& global_variables)
@@ -222,7 +222,8 @@ InvResult global_invariant_check(pbes_equation& equation,
 
 void perform_iteration(pbes_equation& equation,
     detail::substitute_propositional_variables_builder<pbes_system::pbes_expression_builder>& substituter,
-    detail::replace_other_propositional_variables_with_functions_builder<pbes_system::pbes_expression_builder>& replace_substituter,
+    detail::replace_other_propositional_variables_with_functions_builder<pbes_system::pbes_expression_builder>&
+        replace_substituter,
     data::data_specification data_spec,
     bool use_smt)
 {
@@ -266,7 +267,16 @@ void perform_iteration(pbes_equation& equation,
     replace_substituter.reset_variable_list();
     data::data_expression eq_data = pbestodata(eq, replace_substituter);
     data::data_expression p_data = pbestodata(p_eq, replace_substituter);
-    data::data_expression formula = data::and_(data::imp(eq_data, p_data), data::imp(p_data, eq_data));
+    data::data_expression formula;
+    // Due to mononicity, only one way implication needs to be tested
+    if (equation.symbol().is_nu())
+    {
+      formula = data::imp(eq_data, p_data);
+    }
+    else
+    {
+      formula = data::imp(p_data, eq_data);
+    }
 
     if (use_smt)
     {
@@ -320,7 +330,8 @@ struct pbesiteration_pbes_fixpoint_iterator
     simplify_data_rewriter<data::rewriter> pbes_rewriter(data_rewriter);
     detail::substitute_propositional_variables_builder<pbes_system::pbes_expression_builder> substituter(pbes_rewriter);
 
-    detail::replace_other_propositional_variables_with_functions_builder<pbes_system::pbes_expression_builder> replace_substituter(pbes_rewriter);
+    detail::replace_other_propositional_variables_with_functions_builder<pbes_system::pbes_expression_builder>
+        replace_substituter(pbes_rewriter);
 
     for (std::vector<pbes_equation>::reverse_iterator i = p.equations().rbegin(); i != p.equations().rend(); i++)
     {

--- a/tests/specifications/pbesiteration.yml
+++ b/tests/specifications/pbesiteration.yml
@@ -5,6 +5,8 @@ nodes:
     type: pbes
   l3:
     type: pbes
+  l4:
+    type: pbes
 
 tools:
   t1:
@@ -17,6 +19,11 @@ tools:
     output: [l3]
     args: []
     name: pbesiteration
+  t5:
+    input: [l2]
+    output: [l4]
+    args: [-e]
+    name: pbesiteration
   t3:
     input: [l2]
     output: []
@@ -27,5 +34,10 @@ tools:
     output: []
     args: []
     name: pbes2bool
+  t6:
+    input: [l4]
+    output: []
+    args: []
+    name: pbes2bool
 result: |
-  result = t3.value['solution'] == t4.value['solution']
+  result = t3.value['solution'] == t4.value['solution'] and t3.value['solution'] == t6.value['solution']

--- a/tools/experimental/pbesiteration/pbesiteration.cpp
+++ b/tools/experimental/pbesiteration/pbesiteration.cpp
@@ -38,6 +38,7 @@ class pbesiteration_tool: public pbes_input_tool<pbes_output_tool<pbes_rewriter_
       super::parse_options(parser);
       m_options.check_global_invariant = parser.has_option("check-global-invariant");
       m_options.smt = parser.has_option("smt");
+      m_options.early_stopping = parser.has_option("early-stopping");
     }
 
     void add_options(interface_description& desc) override
@@ -47,6 +48,9 @@ class pbesiteration_tool: public pbes_input_tool<pbes_output_tool<pbes_rewriter_
                   "check in nu-formulae if the core constraint is a global invariant for each equation (slow)", 'g');
       desc.add_option("smt",
                   "use SMT-based fixpoint checking instead of EQ-BDD-based checking (limited support)", 's');
+      desc.add_option("early-stopping",
+                  "stop early based on the initial state data parameters", 'e');
+
     }
 
   public:


### PR DESCRIPTION
- Only check the equivalence one way depending on if the fixpoint is $\mu$ or $\nu$
- Added an early stopping option based in the `init' data parameters of the pbes 