### PR TITLE
Add pick mapping to FSett and FBag

### DIFF
--- a/libraries/data/include/mcrl2/data/fbag1.h
+++ b/libraries/data/include/mcrl2/data/fbag1.h
@@ -770,6 +770,68 @@ namespace mcrl2 {
       {
         return is_application(e) && is_count_all_function_symbol(atermpp::down_cast<application>(e).head());
       }
+
+      /// \brief Generate identifier pick.
+      /// \return Identifier pick.
+      inline
+      const core::identifier_string& pick_name()
+      {
+        static core::identifier_string pick_name = core::identifier_string("pick");
+        return pick_name;
+      }
+
+      /// \brief Constructor for function symbol pick.
+      /// \param s A sort expression.
+      /// \return Function symbol pick.
+      inline
+      function_symbol pick(const sort_expression& s)
+      {
+        function_symbol pick(pick_name(), make_function_sort_(fbag(s), s));
+        return pick;
+      }
+
+      /// \brief Recogniser for function pick.
+      /// \param e A data expression.
+      /// \return true iff e is the function symbol matching pick.
+      inline
+      bool is_pick_function_symbol(const atermpp::aterm& e)
+      {
+        if (is_function_symbol(e))
+        {
+          return atermpp::down_cast<function_symbol>(e).name() == pick_name();
+        }
+        return false;
+      }
+
+      /// \brief Application of function symbol pick.
+      /// \param s A sort expression.
+      /// \param arg0 A data expression.
+      /// \return Application of pick to a number of arguments.
+      inline
+      application pick(const sort_expression& s, const data_expression& arg0)
+      {
+        return sort_fbag::pick(s)(arg0);
+      }
+
+      /// \brief Make an application of function symbol pick.
+      /// \param result The data expression where the pick expression is put.
+      /// \param s A sort expression.
+      /// \param arg0 A data expression.
+      inline
+      void make_pick(data_expression& result, const sort_expression& s, const data_expression& arg0)
+      {
+        make_application(result, sort_fbag::pick(s),arg0);
+      }
+
+      /// \brief Recogniser for application of pick.
+      /// \param e A data expression.
+      /// \return true iff e is an application of function symbol pick to a
+      ///     number of arguments.
+      inline
+      bool is_pick_application(const atermpp::aterm& e)
+      {
+        return is_application(e) && is_pick_function_symbol(atermpp::down_cast<application>(e).head());
+      }
       /// \brief Give all system defined mappings for fbag
       /// \param s A sort expression
       /// \return All system defined mappings for fbag
@@ -786,6 +848,7 @@ namespace mcrl2 {
         result.push_back(sort_fbag::intersection(s));
         result.push_back(sort_fbag::difference(s));
         result.push_back(sort_fbag::count_all(s));
+        result.push_back(sort_fbag::pick(s));
         return result;
       }
       
@@ -819,6 +882,7 @@ namespace mcrl2 {
         result.push_back(sort_fbag::intersection(s));
         result.push_back(sort_fbag::difference(s));
         result.push_back(sort_fbag::count_all(s));
+        result.push_back(sort_fbag::pick(s));
         return result;
       }
 
@@ -903,7 +967,7 @@ namespace mcrl2 {
       inline
       const data_expression& arg(const data_expression& e)
       {
-        assert(is_fset2fbag_application(e) || is_count_all_application(e));
+        assert(is_fset2fbag_application(e) || is_count_all_application(e) || is_pick_application(e));
         return atermpp::down_cast<application>(e)[0];
       }
 
@@ -964,6 +1028,7 @@ namespace mcrl2 {
         result.push_back(data_equation(variable_list(), count_all(s, empty(s)), sort_nat::c0()));
         result.push_back(data_equation(variable_list({vd, vp}), count_all(s, cons_(s, vd, vp, empty(s))), sort_nat::cnat(vp)));
         result.push_back(data_equation(variable_list({vb, vd, ve, vp, vq}), count_all(s, cons_(s, vd, vp, cons_(s, ve, vq, vb))), sort_nat::cnat(sort_pos::add_with_carry(sort_bool::false_(), vp, sort_nat::nat2pos(count_all(s, cons_(s, ve, vq, vb)))))));
+        result.push_back(data_equation(variable_list({vb, vd, vp}), pick(s, cons_(s, vd, vp, vb)), vd));
         return result;
       }
 

--- a/libraries/data/include/mcrl2/data/fbag64.h
+++ b/libraries/data/include/mcrl2/data/fbag64.h
@@ -708,6 +708,68 @@ namespace mcrl2 {
       {
         return is_application(e) && is_count_all_function_symbol(atermpp::down_cast<application>(e).head());
       }
+
+      /// \brief Generate identifier pick.
+      /// \return Identifier pick.
+      inline
+      const core::identifier_string& pick_name()
+      {
+        static core::identifier_string pick_name = core::identifier_string("pick");
+        return pick_name;
+      }
+
+      /// \brief Constructor for function symbol pick.
+      /// \param s A sort expression.
+      /// \return Function symbol pick.
+      inline
+      function_symbol pick(const sort_expression& s)
+      {
+        function_symbol pick(pick_name(), make_function_sort_(fbag(s), s));
+        return pick;
+      }
+
+      /// \brief Recogniser for function pick.
+      /// \param e A data expression.
+      /// \return true iff e is the function symbol matching pick.
+      inline
+      bool is_pick_function_symbol(const atermpp::aterm& e)
+      {
+        if (is_function_symbol(e))
+        {
+          return atermpp::down_cast<function_symbol>(e).name() == pick_name();
+        }
+        return false;
+      }
+
+      /// \brief Application of function symbol pick.
+      /// \param s A sort expression.
+      /// \param arg0 A data expression.
+      /// \return Application of pick to a number of arguments.
+      inline
+      application pick(const sort_expression& s, const data_expression& arg0)
+      {
+        return sort_fbag::pick(s)(arg0);
+      }
+
+      /// \brief Make an application of function symbol pick.
+      /// \param result The data expression where the pick expression is put.
+      /// \param s A sort expression.
+      /// \param arg0 A data expression.
+      inline
+      void make_pick(data_expression& result, const sort_expression& s, const data_expression& arg0)
+      {
+        make_application(result, sort_fbag::pick(s),arg0);
+      }
+
+      /// \brief Recogniser for application of pick.
+      /// \param e A data expression.
+      /// \return true iff e is an application of function symbol pick to a
+      ///     number of arguments.
+      inline
+      bool is_pick_application(const atermpp::aterm& e)
+      {
+        return is_application(e) && is_pick_function_symbol(atermpp::down_cast<application>(e).head());
+      }
       /// \brief Give all system defined mappings for fbag
       /// \param s A sort expression
       /// \return All system defined mappings for fbag
@@ -723,6 +785,7 @@ namespace mcrl2 {
         result.push_back(sort_fbag::intersection(s));
         result.push_back(sort_fbag::difference(s));
         result.push_back(sort_fbag::count_all(s));
+        result.push_back(sort_fbag::pick(s));
         return result;
       }
       
@@ -755,6 +818,7 @@ namespace mcrl2 {
         result.push_back(sort_fbag::intersection(s));
         result.push_back(sort_fbag::difference(s));
         result.push_back(sort_fbag::count_all(s));
+        result.push_back(sort_fbag::pick(s));
         return result;
       }
 
@@ -839,7 +903,7 @@ namespace mcrl2 {
       inline
       const data_expression& arg(const data_expression& e)
       {
-        assert(is_count_all_application(e));
+        assert(is_count_all_application(e) || is_pick_application(e));
         return atermpp::down_cast<application>(e)[0];
       }
 
@@ -900,6 +964,7 @@ namespace mcrl2 {
         result.push_back(data_equation(variable_list(), count_all(s, empty(s)), sort_nat::c0()));
         result.push_back(data_equation(variable_list({vd, vp}), count_all(s, cons_(s, vd, vp, empty(s))), sort_nat::pos2nat(vp)));
         result.push_back(data_equation(variable_list({vb, vd, ve, vp, vq}), count_all(s, cons_(s, vd, vp, cons_(s, ve, vq, vb))), sort_nat::pos2nat(sort_pos::auxiliary_plus_pos(vp, sort_nat::nat2pos(count_all(s, cons_(s, ve, vq, vb)))))));
+        result.push_back(data_equation(variable_list({vb, vd, vp}), pick(s, cons_(s, vd, vp, vb)), vd));
         return result;
       }
 

--- a/libraries/data/include/mcrl2/data/fset1.h
+++ b/libraries/data/include/mcrl2/data/fset1.h
@@ -638,6 +638,68 @@ namespace mcrl2 {
       {
         return is_application(e) && is_count_function_symbol(atermpp::down_cast<application>(e).head());
       }
+
+      /// \brief Generate identifier pick.
+      /// \return Identifier pick.
+      inline
+      const core::identifier_string& pick_name()
+      {
+        static core::identifier_string pick_name = core::identifier_string("pick");
+        return pick_name;
+      }
+
+      /// \brief Constructor for function symbol pick.
+      /// \param s A sort expression.
+      /// \return Function symbol pick.
+      inline
+      function_symbol pick(const sort_expression& s)
+      {
+        function_symbol pick(pick_name(), make_function_sort_(fset(s), s));
+        return pick;
+      }
+
+      /// \brief Recogniser for function pick.
+      /// \param e A data expression.
+      /// \return true iff e is the function symbol matching pick.
+      inline
+      bool is_pick_function_symbol(const atermpp::aterm& e)
+      {
+        if (is_function_symbol(e))
+        {
+          return atermpp::down_cast<function_symbol>(e).name() == pick_name();
+        }
+        return false;
+      }
+
+      /// \brief Application of function symbol pick.
+      /// \param s A sort expression.
+      /// \param arg0 A data expression.
+      /// \return Application of pick to a number of arguments.
+      inline
+      application pick(const sort_expression& s, const data_expression& arg0)
+      {
+        return sort_fset::pick(s)(arg0);
+      }
+
+      /// \brief Make an application of function symbol pick.
+      /// \param result The data expression where the pick expression is put.
+      /// \param s A sort expression.
+      /// \param arg0 A data expression.
+      inline
+      void make_pick(data_expression& result, const sort_expression& s, const data_expression& arg0)
+      {
+        make_application(result, sort_fset::pick(s),arg0);
+      }
+
+      /// \brief Recogniser for application of pick.
+      /// \param e A data expression.
+      /// \return true iff e is an application of function symbol pick to a
+      ///     number of arguments.
+      inline
+      bool is_pick_application(const atermpp::aterm& e)
+      {
+        return is_application(e) && is_pick_function_symbol(atermpp::down_cast<application>(e).head());
+      }
       /// \brief Give all system defined mappings for fset
       /// \param s A sort expression
       /// \return All system defined mappings for fset
@@ -652,6 +714,7 @@ namespace mcrl2 {
         result.push_back(sort_fset::union_(s));
         result.push_back(sort_fset::intersection(s));
         result.push_back(sort_fset::count(s));
+        result.push_back(sort_fset::pick(s));
         return result;
       }
       
@@ -683,6 +746,7 @@ namespace mcrl2 {
         result.push_back(sort_fset::union_(s));
         result.push_back(sort_fset::intersection(s));
         result.push_back(sort_fset::count(s));
+        result.push_back(sort_fset::pick(s));
         return result;
       }
 
@@ -767,7 +831,7 @@ namespace mcrl2 {
       inline
       const data_expression& arg(const data_expression& e)
       {
-        assert(is_count_application(e));
+        assert(is_count_application(e) || is_pick_application(e));
         return atermpp::down_cast<application>(e)[0];
       }
 
@@ -819,6 +883,7 @@ namespace mcrl2 {
         result.push_back(data_equation(variable_list(), count(s, empty(s)), sort_nat::c0()));
         result.push_back(data_equation(variable_list({vd, vs}), count(s, cons_(s, vd, vs)), sort_nat::cnat(sort_nat::succ(count(s, vs)))));
         result.push_back(data_equation(variable_list({vs, vt}), not_equal_to(vs, vt), sort_bool::not_(equal_to(vs, vt))));
+        result.push_back(data_equation(variable_list({vd, vs}), pick(s, cons_(s, vd, vs)), vd));
         return result;
       }
 

--- a/libraries/data/include/mcrl2/data/fset64.h
+++ b/libraries/data/include/mcrl2/data/fset64.h
@@ -638,6 +638,68 @@ namespace mcrl2 {
       {
         return is_application(e) && is_count_function_symbol(atermpp::down_cast<application>(e).head());
       }
+
+      /// \brief Generate identifier pick.
+      /// \return Identifier pick.
+      inline
+      const core::identifier_string& pick_name()
+      {
+        static core::identifier_string pick_name = core::identifier_string("pick");
+        return pick_name;
+      }
+
+      /// \brief Constructor for function symbol pick.
+      /// \param s A sort expression.
+      /// \return Function symbol pick.
+      inline
+      function_symbol pick(const sort_expression& s)
+      {
+        function_symbol pick(pick_name(), make_function_sort_(fset(s), s));
+        return pick;
+      }
+
+      /// \brief Recogniser for function pick.
+      /// \param e A data expression.
+      /// \return true iff e is the function symbol matching pick.
+      inline
+      bool is_pick_function_symbol(const atermpp::aterm& e)
+      {
+        if (is_function_symbol(e))
+        {
+          return atermpp::down_cast<function_symbol>(e).name() == pick_name();
+        }
+        return false;
+      }
+
+      /// \brief Application of function symbol pick.
+      /// \param s A sort expression.
+      /// \param arg0 A data expression.
+      /// \return Application of pick to a number of arguments.
+      inline
+      application pick(const sort_expression& s, const data_expression& arg0)
+      {
+        return sort_fset::pick(s)(arg0);
+      }
+
+      /// \brief Make an application of function symbol pick.
+      /// \param result The data expression where the pick expression is put.
+      /// \param s A sort expression.
+      /// \param arg0 A data expression.
+      inline
+      void make_pick(data_expression& result, const sort_expression& s, const data_expression& arg0)
+      {
+        make_application(result, sort_fset::pick(s),arg0);
+      }
+
+      /// \brief Recogniser for application of pick.
+      /// \param e A data expression.
+      /// \return true iff e is an application of function symbol pick to a
+      ///     number of arguments.
+      inline
+      bool is_pick_application(const atermpp::aterm& e)
+      {
+        return is_application(e) && is_pick_function_symbol(atermpp::down_cast<application>(e).head());
+      }
       /// \brief Give all system defined mappings for fset
       /// \param s A sort expression
       /// \return All system defined mappings for fset
@@ -652,6 +714,7 @@ namespace mcrl2 {
         result.push_back(sort_fset::union_(s));
         result.push_back(sort_fset::intersection(s));
         result.push_back(sort_fset::count(s));
+        result.push_back(sort_fset::pick(s));
         return result;
       }
       
@@ -683,6 +746,7 @@ namespace mcrl2 {
         result.push_back(sort_fset::union_(s));
         result.push_back(sort_fset::intersection(s));
         result.push_back(sort_fset::count(s));
+        result.push_back(sort_fset::pick(s));
         return result;
       }
 
@@ -767,7 +831,7 @@ namespace mcrl2 {
       inline
       const data_expression& arg(const data_expression& e)
       {
-        assert(is_count_application(e));
+        assert(is_count_application(e) || is_pick_application(e));
         return atermpp::down_cast<application>(e)[0];
       }
 
@@ -821,6 +885,7 @@ namespace mcrl2 {
         result.push_back(data_equation(variable_list(), count(s, empty(s)), sort_nat::c0()));
         result.push_back(data_equation(variable_list({vd, vs}), count(s, cons_(s, vd, vs)), sort_nat::succ_nat(count(s, vs))));
         result.push_back(data_equation(variable_list({vs, vt}), not_equal_to(vs, vt), sort_bool::not_(equal_to(vs, vt))));
+        result.push_back(data_equation(variable_list({vd, vs}), pick(s, cons_(s, vd, vs)), vd));
         return result;
       }
 

--- a/libraries/data/include/mcrl2/data/function_update.h
+++ b/libraries/data/include/mcrl2/data/function_update.h
@@ -260,14 +260,14 @@ namespace mcrl2 {
       }
 
       /// \brief The data expression of an application of the function symbol \@is_not_an_update.
-      /// \details This function is to be implemented manually. 
+      /// \details This function is to be implemented manually.
       /// \param arg0 A data expression.
       /// \return The data expression corresponding to an application of \@is_not_an_update to a number of arguments.
       inline
       void is_not_a_function_update_manual_implementation(data_expression& result, const data_expression& arg0);
 
 
-      /// \brief Application of a function that is user defined instead of by rewrite rules. It does not have sort parameters. 
+      /// \brief Application of a function that is user defined instead of by rewrite rules. It does not have sort parameters.
       inline
       void is_not_a_function_update_application(data_expression& result, const data_expression& a1)
       {
@@ -348,7 +348,7 @@ namespace mcrl2 {
       }
 
       /// \brief The data expression of an application of the function symbol \@if_always_else.
-      /// \details This function is to be implemented manually. 
+      /// \details This function is to be implemented manually.
       /// \param arg0 A data expression.
       /// \param arg1 A data expression.
       /// \param arg2 A data expression.
@@ -357,7 +357,7 @@ namespace mcrl2 {
       void if_always_else_manual_implementation(data_expression& result, const data_expression& arg0, const data_expression& arg1, const data_expression& arg2);
 
 
-      /// \brief Application of a function that is user defined instead of by rewrite rules. It does not have sort parameters. 
+      /// \brief Application of a function that is user defined instead of by rewrite rules. It does not have sort parameters.
       inline
       void if_always_else_application(data_expression& result, const data_expression& a1)
       {

--- a/libraries/data/include/mcrl2/data/machine_word.h
+++ b/libraries/data/include/mcrl2/data/machine_word.h
@@ -173,14 +173,14 @@ namespace mcrl2 {
       }
 
       /// \brief The data expression of an application of the function symbol \@succ_word.
-      /// \details This function is to be implemented manually. 
+      /// \details This function is to be implemented manually.
       /// \param arg0 A data expression.
       /// \return The data expression corresponding to an application of \@succ_word to a number of arguments.
       inline
       void succ_word_manual_implementation(data_expression& result, const data_expression& arg0);
 
 
-      /// \brief Application of a function that is user defined instead of by rewrite rules. It does not have sort parameters. 
+      /// \brief Application of a function that is user defined instead of by rewrite rules. It does not have sort parameters.
       inline
       void succ_word_application(data_expression& result, const data_expression& a1)
       {
@@ -529,14 +529,14 @@ namespace mcrl2 {
       }
 
       /// \brief The data expression of an application of the function symbol \@equals_zero_word.
-      /// \details This function is to be implemented manually. 
+      /// \details This function is to be implemented manually.
       /// \param arg0 A data expression.
       /// \return The data expression corresponding to an application of \@equals_zero_word to a number of arguments.
       inline
       void equals_zero_word_manual_implementation(data_expression& result, const data_expression& arg0);
 
 
-      /// \brief Application of a function that is user defined instead of by rewrite rules. It does not have sort parameters. 
+      /// \brief Application of a function that is user defined instead of by rewrite rules. It does not have sort parameters.
       inline
       void equals_zero_word_application(data_expression& result, const data_expression& a1)
       {
@@ -610,14 +610,14 @@ namespace mcrl2 {
       }
 
       /// \brief The data expression of an application of the function symbol \@not_equals_zero_word.
-      /// \details This function is to be implemented manually. 
+      /// \details This function is to be implemented manually.
       /// \param arg0 A data expression.
       /// \return The data expression corresponding to an application of \@not_equals_zero_word to a number of arguments.
       inline
       void not_equals_zero_word_manual_implementation(data_expression& result, const data_expression& arg0);
 
 
-      /// \brief Application of a function that is user defined instead of by rewrite rules. It does not have sort parameters. 
+      /// \brief Application of a function that is user defined instead of by rewrite rules. It does not have sort parameters.
       inline
       void not_equals_zero_word_application(data_expression& result, const data_expression& a1)
       {
@@ -691,14 +691,14 @@ namespace mcrl2 {
       }
 
       /// \brief The data expression of an application of the function symbol \@equals_one_word.
-      /// \details This function is to be implemented manually. 
+      /// \details This function is to be implemented manually.
       /// \param arg0 A data expression.
       /// \return The data expression corresponding to an application of \@equals_one_word to a number of arguments.
       inline
       void equals_one_word_manual_implementation(data_expression& result, const data_expression& arg0);
 
 
-      /// \brief Application of a function that is user defined instead of by rewrite rules. It does not have sort parameters. 
+      /// \brief Application of a function that is user defined instead of by rewrite rules. It does not have sort parameters.
       inline
       void equals_one_word_application(data_expression& result, const data_expression& a1)
       {
@@ -772,14 +772,14 @@ namespace mcrl2 {
       }
 
       /// \brief The data expression of an application of the function symbol \@equals_max_word.
-      /// \details This function is to be implemented manually. 
+      /// \details This function is to be implemented manually.
       /// \param arg0 A data expression.
       /// \return The data expression corresponding to an application of \@equals_max_word to a number of arguments.
       inline
       void equals_max_word_manual_implementation(data_expression& result, const data_expression& arg0);
 
 
-      /// \brief Application of a function that is user defined instead of by rewrite rules. It does not have sort parameters. 
+      /// \brief Application of a function that is user defined instead of by rewrite rules. It does not have sort parameters.
       inline
       void equals_max_word_application(data_expression& result, const data_expression& a1)
       {
@@ -855,7 +855,7 @@ namespace mcrl2 {
       }
 
       /// \brief The data expression of an application of the function symbol \@add_word.
-      /// \details This function is to be implemented manually. 
+      /// \details This function is to be implemented manually.
       /// \param arg0 A data expression.
       /// \param arg1 A data expression.
       /// \return The data expression corresponding to an application of \@add_word to a number of arguments.
@@ -863,7 +863,7 @@ namespace mcrl2 {
       void add_word_manual_implementation(data_expression& result, const data_expression& arg0, const data_expression& arg1);
 
 
-      /// \brief Application of a function that is user defined instead of by rewrite rules. It does not have sort parameters. 
+      /// \brief Application of a function that is user defined instead of by rewrite rules. It does not have sort parameters.
       inline
       void add_word_application(data_expression& result, const data_expression& a1)
       {
@@ -939,7 +939,7 @@ namespace mcrl2 {
       }
 
       /// \brief The data expression of an application of the function symbol \@add_with_carry_word.
-      /// \details This function is to be implemented manually. 
+      /// \details This function is to be implemented manually.
       /// \param arg0 A data expression.
       /// \param arg1 A data expression.
       /// \return The data expression corresponding to an application of \@add_with_carry_word to a number of arguments.
@@ -947,7 +947,7 @@ namespace mcrl2 {
       void add_with_carry_word_manual_implementation(data_expression& result, const data_expression& arg0, const data_expression& arg1);
 
 
-      /// \brief Application of a function that is user defined instead of by rewrite rules. It does not have sort parameters. 
+      /// \brief Application of a function that is user defined instead of by rewrite rules. It does not have sort parameters.
       inline
       void add_with_carry_word_application(data_expression& result, const data_expression& a1)
       {
@@ -1023,7 +1023,7 @@ namespace mcrl2 {
       }
 
       /// \brief The data expression of an application of the function symbol \@add_overflow_word.
-      /// \details This function is to be implemented manually. 
+      /// \details This function is to be implemented manually.
       /// \param arg0 A data expression.
       /// \param arg1 A data expression.
       /// \return The data expression corresponding to an application of \@add_overflow_word to a number of arguments.
@@ -1031,7 +1031,7 @@ namespace mcrl2 {
       void add_overflow_word_manual_implementation(data_expression& result, const data_expression& arg0, const data_expression& arg1);
 
 
-      /// \brief Application of a function that is user defined instead of by rewrite rules. It does not have sort parameters. 
+      /// \brief Application of a function that is user defined instead of by rewrite rules. It does not have sort parameters.
       inline
       void add_overflow_word_application(data_expression& result, const data_expression& a1)
       {
@@ -1107,7 +1107,7 @@ namespace mcrl2 {
       }
 
       /// \brief The data expression of an application of the function symbol \@add_with_carry_overflow_word.
-      /// \details This function is to be implemented manually. 
+      /// \details This function is to be implemented manually.
       /// \param arg0 A data expression.
       /// \param arg1 A data expression.
       /// \return The data expression corresponding to an application of \@add_with_carry_overflow_word to a number of arguments.
@@ -1115,7 +1115,7 @@ namespace mcrl2 {
       void add_with_carry_overflow_word_manual_implementation(data_expression& result, const data_expression& arg0, const data_expression& arg1);
 
 
-      /// \brief Application of a function that is user defined instead of by rewrite rules. It does not have sort parameters. 
+      /// \brief Application of a function that is user defined instead of by rewrite rules. It does not have sort parameters.
       inline
       void add_with_carry_overflow_word_application(data_expression& result, const data_expression& a1)
       {
@@ -1191,7 +1191,7 @@ namespace mcrl2 {
       }
 
       /// \brief The data expression of an application of the function symbol \@times_word.
-      /// \details This function is to be implemented manually. 
+      /// \details This function is to be implemented manually.
       /// \param arg0 A data expression.
       /// \param arg1 A data expression.
       /// \return The data expression corresponding to an application of \@times_word to a number of arguments.
@@ -1199,7 +1199,7 @@ namespace mcrl2 {
       void times_word_manual_implementation(data_expression& result, const data_expression& arg0, const data_expression& arg1);
 
 
-      /// \brief Application of a function that is user defined instead of by rewrite rules. It does not have sort parameters. 
+      /// \brief Application of a function that is user defined instead of by rewrite rules. It does not have sort parameters.
       inline
       void times_word_application(data_expression& result, const data_expression& a1)
       {
@@ -1277,7 +1277,7 @@ namespace mcrl2 {
       }
 
       /// \brief The data expression of an application of the function symbol \@times_with_carry_word.
-      /// \details This function is to be implemented manually. 
+      /// \details This function is to be implemented manually.
       /// \param arg0 A data expression.
       /// \param arg1 A data expression.
       /// \param arg2 A data expression.
@@ -1286,7 +1286,7 @@ namespace mcrl2 {
       void times_with_carry_word_manual_implementation(data_expression& result, const data_expression& arg0, const data_expression& arg1, const data_expression& arg2);
 
 
-      /// \brief Application of a function that is user defined instead of by rewrite rules. It does not have sort parameters. 
+      /// \brief Application of a function that is user defined instead of by rewrite rules. It does not have sort parameters.
       inline
       void times_with_carry_word_application(data_expression& result, const data_expression& a1)
       {
@@ -1362,7 +1362,7 @@ namespace mcrl2 {
       }
 
       /// \brief The data expression of an application of the function symbol \@times_overflow_word.
-      /// \details This function is to be implemented manually. 
+      /// \details This function is to be implemented manually.
       /// \param arg0 A data expression.
       /// \param arg1 A data expression.
       /// \return The data expression corresponding to an application of \@times_overflow_word to a number of arguments.
@@ -1370,7 +1370,7 @@ namespace mcrl2 {
       void times_overflow_word_manual_implementation(data_expression& result, const data_expression& arg0, const data_expression& arg1);
 
 
-      /// \brief Application of a function that is user defined instead of by rewrite rules. It does not have sort parameters. 
+      /// \brief Application of a function that is user defined instead of by rewrite rules. It does not have sort parameters.
       inline
       void times_overflow_word_application(data_expression& result, const data_expression& a1)
       {
@@ -1448,7 +1448,7 @@ namespace mcrl2 {
       }
 
       /// \brief The data expression of an application of the function symbol \@times_with_carry_overflow_word.
-      /// \details This function is to be implemented manually. 
+      /// \details This function is to be implemented manually.
       /// \param arg0 A data expression.
       /// \param arg1 A data expression.
       /// \param arg2 A data expression.
@@ -1457,7 +1457,7 @@ namespace mcrl2 {
       void times_with_carry_overflow_word_manual_implementation(data_expression& result, const data_expression& arg0, const data_expression& arg1, const data_expression& arg2);
 
 
-      /// \brief Application of a function that is user defined instead of by rewrite rules. It does not have sort parameters. 
+      /// \brief Application of a function that is user defined instead of by rewrite rules. It does not have sort parameters.
       inline
       void times_with_carry_overflow_word_application(data_expression& result, const data_expression& a1)
       {
@@ -1533,7 +1533,7 @@ namespace mcrl2 {
       }
 
       /// \brief The data expression of an application of the function symbol \@minus_word.
-      /// \details This function is to be implemented manually. 
+      /// \details This function is to be implemented manually.
       /// \param arg0 A data expression.
       /// \param arg1 A data expression.
       /// \return The data expression corresponding to an application of \@minus_word to a number of arguments.
@@ -1541,7 +1541,7 @@ namespace mcrl2 {
       void minus_word_manual_implementation(data_expression& result, const data_expression& arg0, const data_expression& arg1);
 
 
-      /// \brief Application of a function that is user defined instead of by rewrite rules. It does not have sort parameters. 
+      /// \brief Application of a function that is user defined instead of by rewrite rules. It does not have sort parameters.
       inline
       void minus_word_application(data_expression& result, const data_expression& a1)
       {
@@ -1617,7 +1617,7 @@ namespace mcrl2 {
       }
 
       /// \brief The data expression of an application of the function symbol \@monus_word.
-      /// \details This function is to be implemented manually. 
+      /// \details This function is to be implemented manually.
       /// \param arg0 A data expression.
       /// \param arg1 A data expression.
       /// \return The data expression corresponding to an application of \@monus_word to a number of arguments.
@@ -1625,7 +1625,7 @@ namespace mcrl2 {
       void monus_word_manual_implementation(data_expression& result, const data_expression& arg0, const data_expression& arg1);
 
 
-      /// \brief Application of a function that is user defined instead of by rewrite rules. It does not have sort parameters. 
+      /// \brief Application of a function that is user defined instead of by rewrite rules. It does not have sort parameters.
       inline
       void monus_word_application(data_expression& result, const data_expression& a1)
       {
@@ -1701,7 +1701,7 @@ namespace mcrl2 {
       }
 
       /// \brief The data expression of an application of the function symbol \@div_word.
-      /// \details This function is to be implemented manually. 
+      /// \details This function is to be implemented manually.
       /// \param arg0 A data expression.
       /// \param arg1 A data expression.
       /// \return The data expression corresponding to an application of \@div_word to a number of arguments.
@@ -1709,7 +1709,7 @@ namespace mcrl2 {
       void div_word_manual_implementation(data_expression& result, const data_expression& arg0, const data_expression& arg1);
 
 
-      /// \brief Application of a function that is user defined instead of by rewrite rules. It does not have sort parameters. 
+      /// \brief Application of a function that is user defined instead of by rewrite rules. It does not have sort parameters.
       inline
       void div_word_application(data_expression& result, const data_expression& a1)
       {
@@ -1785,7 +1785,7 @@ namespace mcrl2 {
       }
 
       /// \brief The data expression of an application of the function symbol \@mod_word.
-      /// \details This function is to be implemented manually. 
+      /// \details This function is to be implemented manually.
       /// \param arg0 A data expression.
       /// \param arg1 A data expression.
       /// \return The data expression corresponding to an application of \@mod_word to a number of arguments.
@@ -1793,7 +1793,7 @@ namespace mcrl2 {
       void mod_word_manual_implementation(data_expression& result, const data_expression& arg0, const data_expression& arg1);
 
 
-      /// \brief Application of a function that is user defined instead of by rewrite rules. It does not have sort parameters. 
+      /// \brief Application of a function that is user defined instead of by rewrite rules. It does not have sort parameters.
       inline
       void mod_word_application(data_expression& result, const data_expression& a1)
       {
@@ -1867,14 +1867,14 @@ namespace mcrl2 {
       }
 
       /// \brief The data expression of an application of the function symbol \@sqrt_word.
-      /// \details This function is to be implemented manually. 
+      /// \details This function is to be implemented manually.
       /// \param arg0 A data expression.
       /// \return The data expression corresponding to an application of \@sqrt_word to a number of arguments.
       inline
       void sqrt_word_manual_implementation(data_expression& result, const data_expression& arg0);
 
 
-      /// \brief Application of a function that is user defined instead of by rewrite rules. It does not have sort parameters. 
+      /// \brief Application of a function that is user defined instead of by rewrite rules. It does not have sort parameters.
       inline
       void sqrt_word_application(data_expression& result, const data_expression& a1)
       {
@@ -1952,7 +1952,7 @@ namespace mcrl2 {
       }
 
       /// \brief The data expression of an application of the function symbol \@div_doubleword.
-      /// \details This function is to be implemented manually. 
+      /// \details This function is to be implemented manually.
       /// \param arg0 A data expression.
       /// \param arg1 A data expression.
       /// \param arg2 A data expression.
@@ -1961,7 +1961,7 @@ namespace mcrl2 {
       void div_doubleword_manual_implementation(data_expression& result, const data_expression& arg0, const data_expression& arg1, const data_expression& arg2);
 
 
-      /// \brief Application of a function that is user defined instead of by rewrite rules. It does not have sort parameters. 
+      /// \brief Application of a function that is user defined instead of by rewrite rules. It does not have sort parameters.
       inline
       void div_doubleword_application(data_expression& result, const data_expression& a1)
       {
@@ -2041,7 +2041,7 @@ namespace mcrl2 {
       }
 
       /// \brief The data expression of an application of the function symbol \@div_double_doubleword.
-      /// \details This function is to be implemented manually. 
+      /// \details This function is to be implemented manually.
       /// \param arg0 A data expression.
       /// \param arg1 A data expression.
       /// \param arg2 A data expression.
@@ -2051,7 +2051,7 @@ namespace mcrl2 {
       void div_double_doubleword_manual_implementation(data_expression& result, const data_expression& arg0, const data_expression& arg1, const data_expression& arg2, const data_expression& arg3);
 
 
-      /// \brief Application of a function that is user defined instead of by rewrite rules. It does not have sort parameters. 
+      /// \brief Application of a function that is user defined instead of by rewrite rules. It does not have sort parameters.
       inline
       void div_double_doubleword_application(data_expression& result, const data_expression& a1)
       {
@@ -2133,7 +2133,7 @@ namespace mcrl2 {
       }
 
       /// \brief The data expression of an application of the function symbol \@div_triple_doubleword.
-      /// \details This function is to be implemented manually. 
+      /// \details This function is to be implemented manually.
       /// \param arg0 A data expression.
       /// \param arg1 A data expression.
       /// \param arg2 A data expression.
@@ -2144,7 +2144,7 @@ namespace mcrl2 {
       void div_triple_doubleword_manual_implementation(data_expression& result, const data_expression& arg0, const data_expression& arg1, const data_expression& arg2, const data_expression& arg3, const data_expression& arg4);
 
 
-      /// \brief Application of a function that is user defined instead of by rewrite rules. It does not have sort parameters. 
+      /// \brief Application of a function that is user defined instead of by rewrite rules. It does not have sort parameters.
       inline
       void div_triple_doubleword_application(data_expression& result, const data_expression& a1)
       {
@@ -2222,7 +2222,7 @@ namespace mcrl2 {
       }
 
       /// \brief The data expression of an application of the function symbol \@mod_doubleword.
-      /// \details This function is to be implemented manually. 
+      /// \details This function is to be implemented manually.
       /// \param arg0 A data expression.
       /// \param arg1 A data expression.
       /// \param arg2 A data expression.
@@ -2231,7 +2231,7 @@ namespace mcrl2 {
       void mod_doubleword_manual_implementation(data_expression& result, const data_expression& arg0, const data_expression& arg1, const data_expression& arg2);
 
 
-      /// \brief Application of a function that is user defined instead of by rewrite rules. It does not have sort parameters. 
+      /// \brief Application of a function that is user defined instead of by rewrite rules. It does not have sort parameters.
       inline
       void mod_doubleword_application(data_expression& result, const data_expression& a1)
       {
@@ -2307,7 +2307,7 @@ namespace mcrl2 {
       }
 
       /// \brief The data expression of an application of the function symbol \@sqrt_doubleword.
-      /// \details This function is to be implemented manually. 
+      /// \details This function is to be implemented manually.
       /// \param arg0 A data expression.
       /// \param arg1 A data expression.
       /// \return The data expression corresponding to an application of \@sqrt_doubleword to a number of arguments.
@@ -2315,7 +2315,7 @@ namespace mcrl2 {
       void sqrt_doubleword_manual_implementation(data_expression& result, const data_expression& arg0, const data_expression& arg1);
 
 
-      /// \brief Application of a function that is user defined instead of by rewrite rules. It does not have sort parameters. 
+      /// \brief Application of a function that is user defined instead of by rewrite rules. It does not have sort parameters.
       inline
       void sqrt_doubleword_application(data_expression& result, const data_expression& a1)
       {
@@ -2393,7 +2393,7 @@ namespace mcrl2 {
       }
 
       /// \brief The data expression of an application of the function symbol \@sqrt_tripleword.
-      /// \details This function is to be implemented manually. 
+      /// \details This function is to be implemented manually.
       /// \param arg0 A data expression.
       /// \param arg1 A data expression.
       /// \param arg2 A data expression.
@@ -2402,7 +2402,7 @@ namespace mcrl2 {
       void sqrt_tripleword_manual_implementation(data_expression& result, const data_expression& arg0, const data_expression& arg1, const data_expression& arg2);
 
 
-      /// \brief Application of a function that is user defined instead of by rewrite rules. It does not have sort parameters. 
+      /// \brief Application of a function that is user defined instead of by rewrite rules. It does not have sort parameters.
       inline
       void sqrt_tripleword_application(data_expression& result, const data_expression& a1)
       {
@@ -2480,7 +2480,7 @@ namespace mcrl2 {
       }
 
       /// \brief The data expression of an application of the function symbol \@sqrt_tripleword_overflow.
-      /// \details This function is to be implemented manually. 
+      /// \details This function is to be implemented manually.
       /// \param arg0 A data expression.
       /// \param arg1 A data expression.
       /// \param arg2 A data expression.
@@ -2489,7 +2489,7 @@ namespace mcrl2 {
       void sqrt_tripleword_overflow_manual_implementation(data_expression& result, const data_expression& arg0, const data_expression& arg1, const data_expression& arg2);
 
 
-      /// \brief Application of a function that is user defined instead of by rewrite rules. It does not have sort parameters. 
+      /// \brief Application of a function that is user defined instead of by rewrite rules. It does not have sort parameters.
       inline
       void sqrt_tripleword_overflow_application(data_expression& result, const data_expression& a1)
       {
@@ -2569,7 +2569,7 @@ namespace mcrl2 {
       }
 
       /// \brief The data expression of an application of the function symbol \@sqrt_quadrupleword.
-      /// \details This function is to be implemented manually. 
+      /// \details This function is to be implemented manually.
       /// \param arg0 A data expression.
       /// \param arg1 A data expression.
       /// \param arg2 A data expression.
@@ -2579,7 +2579,7 @@ namespace mcrl2 {
       void sqrt_quadrupleword_manual_implementation(data_expression& result, const data_expression& arg0, const data_expression& arg1, const data_expression& arg2, const data_expression& arg3);
 
 
-      /// \brief Application of a function that is user defined instead of by rewrite rules. It does not have sort parameters. 
+      /// \brief Application of a function that is user defined instead of by rewrite rules. It does not have sort parameters.
       inline
       void sqrt_quadrupleword_application(data_expression& result, const data_expression& a1)
       {
@@ -2659,7 +2659,7 @@ namespace mcrl2 {
       }
 
       /// \brief The data expression of an application of the function symbol \@sqrt_quadrupleword_overflow.
-      /// \details This function is to be implemented manually. 
+      /// \details This function is to be implemented manually.
       /// \param arg0 A data expression.
       /// \param arg1 A data expression.
       /// \param arg2 A data expression.
@@ -2669,7 +2669,7 @@ namespace mcrl2 {
       void sqrt_quadrupleword_overflow_manual_implementation(data_expression& result, const data_expression& arg0, const data_expression& arg1, const data_expression& arg2, const data_expression& arg3);
 
 
-      /// \brief Application of a function that is user defined instead of by rewrite rules. It does not have sort parameters. 
+      /// \brief Application of a function that is user defined instead of by rewrite rules. It does not have sort parameters.
       inline
       void sqrt_quadrupleword_overflow_application(data_expression& result, const data_expression& a1)
       {
@@ -2743,14 +2743,14 @@ namespace mcrl2 {
       }
 
       /// \brief The data expression of an application of the function symbol \@pred_word.
-      /// \details This function is to be implemented manually. 
+      /// \details This function is to be implemented manually.
       /// \param arg0 A data expression.
       /// \return The data expression corresponding to an application of \@pred_word to a number of arguments.
       inline
       void pred_word_manual_implementation(data_expression& result, const data_expression& arg0);
 
 
-      /// \brief Application of a function that is user defined instead of by rewrite rules. It does not have sort parameters. 
+      /// \brief Application of a function that is user defined instead of by rewrite rules. It does not have sort parameters.
       inline
       void pred_word_application(data_expression& result, const data_expression& a1)
       {
@@ -2826,7 +2826,7 @@ namespace mcrl2 {
       }
 
       /// \brief The data expression of an application of the function symbol \@equal.
-      /// \details This function is to be implemented manually. 
+      /// \details This function is to be implemented manually.
       /// \param arg0 A data expression.
       /// \param arg1 A data expression.
       /// \return The data expression corresponding to an application of \@equal to a number of arguments.
@@ -2834,7 +2834,7 @@ namespace mcrl2 {
       void equal_word_manual_implementation(data_expression& result, const data_expression& arg0, const data_expression& arg1);
 
 
-      /// \brief Application of a function that is user defined instead of by rewrite rules. It does not have sort parameters. 
+      /// \brief Application of a function that is user defined instead of by rewrite rules. It does not have sort parameters.
       inline
       void equal_word_application(data_expression& result, const data_expression& a1)
       {
@@ -2910,7 +2910,7 @@ namespace mcrl2 {
       }
 
       /// \brief The data expression of an application of the function symbol \@not_equal.
-      /// \details This function is to be implemented manually. 
+      /// \details This function is to be implemented manually.
       /// \param arg0 A data expression.
       /// \param arg1 A data expression.
       /// \return The data expression corresponding to an application of \@not_equal to a number of arguments.
@@ -2918,7 +2918,7 @@ namespace mcrl2 {
       void not_equal_word_manual_implementation(data_expression& result, const data_expression& arg0, const data_expression& arg1);
 
 
-      /// \brief Application of a function that is user defined instead of by rewrite rules. It does not have sort parameters. 
+      /// \brief Application of a function that is user defined instead of by rewrite rules. It does not have sort parameters.
       inline
       void not_equal_word_application(data_expression& result, const data_expression& a1)
       {
@@ -2994,7 +2994,7 @@ namespace mcrl2 {
       }
 
       /// \brief The data expression of an application of the function symbol \@less.
-      /// \details This function is to be implemented manually. 
+      /// \details This function is to be implemented manually.
       /// \param arg0 A data expression.
       /// \param arg1 A data expression.
       /// \return The data expression corresponding to an application of \@less to a number of arguments.
@@ -3002,7 +3002,7 @@ namespace mcrl2 {
       void less_word_manual_implementation(data_expression& result, const data_expression& arg0, const data_expression& arg1);
 
 
-      /// \brief Application of a function that is user defined instead of by rewrite rules. It does not have sort parameters. 
+      /// \brief Application of a function that is user defined instead of by rewrite rules. It does not have sort parameters.
       inline
       void less_word_application(data_expression& result, const data_expression& a1)
       {
@@ -3078,7 +3078,7 @@ namespace mcrl2 {
       }
 
       /// \brief The data expression of an application of the function symbol \@less_equal.
-      /// \details This function is to be implemented manually. 
+      /// \details This function is to be implemented manually.
       /// \param arg0 A data expression.
       /// \param arg1 A data expression.
       /// \return The data expression corresponding to an application of \@less_equal to a number of arguments.
@@ -3086,7 +3086,7 @@ namespace mcrl2 {
       void less_equal_word_manual_implementation(data_expression& result, const data_expression& arg0, const data_expression& arg1);
 
 
-      /// \brief Application of a function that is user defined instead of by rewrite rules. It does not have sort parameters. 
+      /// \brief Application of a function that is user defined instead of by rewrite rules. It does not have sort parameters.
       inline
       void less_equal_word_application(data_expression& result, const data_expression& a1)
       {
@@ -3162,7 +3162,7 @@ namespace mcrl2 {
       }
 
       /// \brief The data expression of an application of the function symbol \@greater.
-      /// \details This function is to be implemented manually. 
+      /// \details This function is to be implemented manually.
       /// \param arg0 A data expression.
       /// \param arg1 A data expression.
       /// \return The data expression corresponding to an application of \@greater to a number of arguments.
@@ -3170,7 +3170,7 @@ namespace mcrl2 {
       void greater_word_manual_implementation(data_expression& result, const data_expression& arg0, const data_expression& arg1);
 
 
-      /// \brief Application of a function that is user defined instead of by rewrite rules. It does not have sort parameters. 
+      /// \brief Application of a function that is user defined instead of by rewrite rules. It does not have sort parameters.
       inline
       void greater_word_application(data_expression& result, const data_expression& a1)
       {
@@ -3246,7 +3246,7 @@ namespace mcrl2 {
       }
 
       /// \brief The data expression of an application of the function symbol \@greater_equal.
-      /// \details This function is to be implemented manually. 
+      /// \details This function is to be implemented manually.
       /// \param arg0 A data expression.
       /// \param arg1 A data expression.
       /// \return The data expression corresponding to an application of \@greater_equal to a number of arguments.
@@ -3254,7 +3254,7 @@ namespace mcrl2 {
       void greater_equal_word_manual_implementation(data_expression& result, const data_expression& arg0, const data_expression& arg1);
 
 
-      /// \brief Application of a function that is user defined instead of by rewrite rules. It does not have sort parameters. 
+      /// \brief Application of a function that is user defined instead of by rewrite rules. It does not have sort parameters.
       inline
       void greater_equal_word_application(data_expression& result, const data_expression& a1)
       {
@@ -3328,14 +3328,14 @@ namespace mcrl2 {
       }
 
       /// \brief The data expression of an application of the function symbol \@rightmost_bit.
-      /// \details This function is to be implemented manually. 
+      /// \details This function is to be implemented manually.
       /// \param arg0 A data expression.
       /// \return The data expression corresponding to an application of \@rightmost_bit to a number of arguments.
       inline
       void rightmost_bit_manual_implementation(data_expression& result, const data_expression& arg0);
 
 
-      /// \brief Application of a function that is user defined instead of by rewrite rules. It does not have sort parameters. 
+      /// \brief Application of a function that is user defined instead of by rewrite rules. It does not have sort parameters.
       inline
       void rightmost_bit_application(data_expression& result, const data_expression& a1)
       {
@@ -3411,7 +3411,7 @@ namespace mcrl2 {
       }
 
       /// \brief The data expression of an application of the function symbol \@shift_right.
-      /// \details This function is to be implemented manually. 
+      /// \details This function is to be implemented manually.
       /// \param arg0 A data expression.
       /// \param arg1 A data expression.
       /// \return The data expression corresponding to an application of \@shift_right to a number of arguments.
@@ -3419,7 +3419,7 @@ namespace mcrl2 {
       void shift_right_manual_implementation(data_expression& result, const data_expression& arg0, const data_expression& arg1);
 
 
-      /// \brief Application of a function that is user defined instead of by rewrite rules. It does not have sort parameters. 
+      /// \brief Application of a function that is user defined instead of by rewrite rules. It does not have sort parameters.
       inline
       void shift_right_application(data_expression& result, const data_expression& a1)
       {

--- a/scripts/code_generation/data_types/codegen.py
+++ b/scripts/code_generation/data_types/codegen.py
@@ -37,23 +37,26 @@
 #
 #===============================================================================
 
-import sys
-import re
+import logging
+logger = logging.getLogger(__name__)
+
 from optparse import OptionParser
 import parsing as Parsing
+import pathlib
+import re
+import sys
 
 from data import *
 
 context = None
-current_file = ""
+current_file: pathlib.Path|None = None
 
 # Verbose printing of message
-def printVerbose(string, object):
-  if verbose:
-    print(("%s: %s" % (string, str(object))))
+def printVerbose(string: str, object):
+  logging.info(f"{string}:{str(object)}")
 
 #===============================================================================
-# Tokens/precedences. 
+# Tokens/precedences.
 
 # Precedences
 # -> Associates to the right
@@ -151,8 +154,8 @@ class TokenDefinedByCode(Parsing.Token):
 # identifiers
 class TokenID(Parsing.Token):
     "%token id"
-    def __init__(self, parser, s):
-        Parsing.Token.__init__(self, parser)
+    def __init__(self, s):
+        Parsing.Token.__init__(self)
         self.data = identifier(s)
 
     def __str__(self):
@@ -162,7 +165,7 @@ class TokenID(Parsing.Token):
 # Nonterminals, with associated productions.  In traditional BNF, the following
 # productions would look something like:
 # Result ::= UsingSpec
-# UsingSpec ::= "using UsingList IncludesSpec 
+# UsingSpec ::= "using UsingList IncludesSpec
 #          | IncludesSpec
 # UsingList ::= ID
 #          | UsingSpec ID
@@ -177,7 +180,7 @@ class TokenID(Parsing.Token):
 #          | Subtypes Subtype
 # Subtype ::= "#supertypeof" ID
 # Spec ::= SortSpec FunctionSpec VarSpec EqnSpec
-# SortSpec ::= "sort" SortDecls        
+# SortSpec ::= "sort" SortDecls
 # FunctionSpec ::= MapSpec
 #                | ConsSpec MapSpec
 # ConsSpec ::= "cons" OpDecls
@@ -201,7 +204,7 @@ class TokenID(Parsing.Token):
 #           | OpDecls OpDecl ";"
 # OpDecl ::= ID Label ":" SortExpr InternalExternal DefinedBy
 # InternalExternal ::= "internal" | "external"
-# DefinedBy ::= "defined_by_rewrite_rules" | "defined_by_code" 
+# DefinedBy ::= "defined_by_rewrite_rules" | "defined_by_code"
 # EqnDecls ::= EqnDecl
 #            | EqnDecls EqnDecl
 # EqnDecl ::= DataExpr "=" DataExpr
@@ -490,7 +493,7 @@ class StructDecl(Parsing.Nonterm):
         printVerbose("StructDecl", self.data)
 
 # VarDecls ::= VarDecl
-#            | VarDecls VarDecl   
+#            | VarDecls VarDecl
 class VarDecls(Parsing.Nonterm):
     "%nonterm"
     def reduceVarDecl(self, vardecl, semicolon):
@@ -535,10 +538,10 @@ class OpDecl(Parsing.Nonterm):
         self.data = function_declaration(id.data, sortexpr.data, label.data, internal_external.data, defined_by.data)
         printVerbose("OpDecl", self.data)
 
-    # Hack for count on lists, a list cannot be internal or defined by code. 
+    # Hack for count on lists, a list cannot be internal or defined by code.
     def reduceCount(self, hash, label, colon, sortexpr, internal_external, defined_by):
         "%reduce hash Label colon SortExpr InternalExternal DefinedBy"
-        id = TokenID(parser, "#")
+        id = TokenID("#")
         self.data = function_declaration(id.data, sortexpr.data, label.data, internal_external.data, defined_by.data)
         printVerbose("OpDecl", self.data)
 
@@ -640,7 +643,7 @@ class DataExprPrimary(Parsing.Nonterm):
     # Hack for allowing application of list count
     def reduceCount(self, hash):
         "%reduce hash"
-        id = TokenID(parser, "#")
+        id = TokenID("#")
         self.data = function_symbol(id.data)
         printVerbose("DataExprPrimary", self.data)
 
@@ -761,14 +764,15 @@ class Label(Parsing.Nonterm):
 # the superclass from Parsing.Lr to Parsing.Glr, then, run this program with
 # verbosity enabled.
 class Parser(Parsing.Lr):
-    def __init__(self, spec):
+    def __init__(self, spec: Parsing.Spec):
       Parsing.Lr.__init__(self, spec)
 
     # Brain-dead scanner.  The scanner does not have to be a method of this
     # class, so for more complex parsers it is no problem to separate the
     # scanner into a separate module.
-    def scan(self, input):
-        syms = {"->"      : TokenArrow,
+    def scan(self, input: str):
+        syms: dict[str, type[Parsing.Token]] = {
+                "->"      : TokenArrow,
                 "|"       : TokenMid,
                 "#include": TokenInclude,
                 "#using"  : TokenUsing,
@@ -810,16 +814,15 @@ class Parser(Parsing.Lr):
         input = re.sub('(?<=\w)(\">)', r" \1", input)
 
         # Split the input at whitespace, producing the tokens
-        p=re.compile(r'\s+')
-        if verbose:
-          print("split input: %s" % (p.split(input)))
+        p: re.Pattern = re.compile(r'\s+')
+        logging.info(f"split input: {p.split(input)}")
 
         for word in p.split(input):
           if word != '':
              if word in syms:
-                token = syms[word](self)
+                token = syms[word]()
              else:
-                token = TokenID(parser, word)
+                token = TokenID(word)
              # Feed token to parser.
              self.token(token)
         # Tell the parser that the end of input has been reached.
@@ -887,7 +890,7 @@ def get_includes(input):
 # This parses the input file and removes comment lines from it
 # Furthermore, we use context from files that are included, therefore these
 # have to be parsed first.
-def parse_spec(infilename):
+def parse_spec(infilename: pathlib.Path):
     global outputcode
     global parser
     global includes_table
@@ -912,8 +915,6 @@ def parse_spec(infilename):
 # -------------------------------------------------------#
 def main():
     global context
-    global verbose
-    global debug
     usage = "usage: %prog [options] infile outfile"
     option_parser = OptionParser(usage)
     option_parser.add_option("-v", "--verbose", action="store_true", help="give verbose output")
@@ -921,27 +922,25 @@ def main():
     (options, args) = option_parser.parse_args()
 
     if options.verbose:
-        verbose = True
+        logger.setLevel(logging.INFO)
 
     if options.debug:
-        verbose = True
-        debug = True
+        logger.setLevel(logging.DEBUG)
         parser.verbose = True
 
     if len(args) > 0:
-        infilename = args[0]
-        outfilename = args[1]
-        try:
-            infile = open(infilename)
-            outfile = open(outfilename, "w")
-        except IOError as e:
-            print("Unable to open file ", infilename, "or", outfilename, " ", e)
-            return
+        infilename = pathlib.Path(args[0])
+        outfilename = pathlib.Path(args[1])
+        if not infilename.is_file():
+            raise RuntimeError(f"Input file {infilename} does not exist.")
+        if not outfilename.is_file():
+            raise RuntimeError(f"Output file {outfilename} does not exist.")
 
         # Parse specification in infilename and write the code to outfile
         parse_spec(infilename)
         outputcode = context.code(infilename)
-        outfile.write(outputcode)
+        with open(outfilename, 'w') as outfile:
+            outfile.write(outputcode)
 
     else:
         option_parser.print_help()
@@ -954,7 +953,7 @@ def main():
 
 # Introspect this module to generate a parser.  Enable all the bells and
 # whistles.
-spec = Parsing.Spec(sys.modules[__name__],
+spec: Parsing.Spec = Parsing.Spec(sys.modules[__name__],
                     pickleFile="codegen.pickle",
                     skinny=False,
                     logFile="codegen.log",
@@ -964,16 +963,13 @@ spec = Parsing.Spec(sys.modules[__name__],
 # Create a parser that uses the parser tables encapsulated by spec.  In this
 # program, we are only creating one parser instance, but it is possible for
 # multiple parsers to use the same Spec simultaneously.
-parser = Parser(spec)
+parser: Parser = Parser(spec)
 
 
 #
 # Global variables to collect needed information during parsing.
 #
-verbose = False       # Switch on verbose output?
-debug = False         # Switch on debug output? 
 includes_table = {}   # Maps sorts to include files
 
 if __name__ == "__main__":
     main()
-

--- a/scripts/code_generation/data_types/data.py
+++ b/scripts/code_generation/data_types/data.py
@@ -190,7 +190,7 @@ class function_declaration():
     self.original_namespace = ""
 
   def __eq__(self, other):
-    if (hasattr(other, "id") and hasattr(other, "label") and hasattr(other, "namespace") and 
+    if (hasattr(other, "id") and hasattr(other, "label") and hasattr(other, "namespace") and
             hasattr(other, "original_namespace") and hasattr(other, "internextern") and hasattr(other, "definedby")):
       return (self.id == other.id and self.label == other.label and self.namespace == other.namespace and self.original_namespace == other.original_namespace and
               self.internextern == other.internextern and self.definedby == other.definedby)
@@ -237,7 +237,7 @@ class function_declaration():
     return "        result.push_back({0}({1}));\n".format(add_namespace(self.label, self.namespace), ", ".join([s.code(spec) for s in sort_params] + extra_parameters))
 
   def mCRL2_usable_functions(self, spec, function_declarations):
-    if self.namespace != self.original_namespace or self.namespace != function_declarations.namespace or self.namespace != spec.namespace: # or self.internextern.is_internal(): Also functions declared internal are externally usable, as they can occur in lps's en pbes's that are sometimes typechecked, for instance when merging two specifications. 
+    if self.namespace != self.original_namespace or self.namespace != function_declarations.namespace or self.namespace != spec.namespace: # or self.internextern.is_internal(): Also functions declared internal are externally usable, as they can occur in lps's en pbes's that are sometimes typechecked, for instance when merging two specifications.
       return ""
 
     sort_params = self.sort_expression.sort_parameters(spec)
@@ -733,13 +733,13 @@ ${cases}
           return ""
         CODE_TEMPLATE = Template('''
       /// \\brief The data expression of an application of the function symbol ${namestring}.
-      /// \\details This function is to be implemented manually. 
+      /// \\details This function is to be implemented manually.
       ${dataparameterstring}
       /// \\return The data expression corresponding to an application of ${namestring} to a number of arguments.
       inline
       void ${functionname}_manual_implementation(data_expression& result, ${parameters});\n
 
-      /// \\brief Application of a function that is user defined instead of by rewrite rules. It does not have sort parameters. 
+      /// \\brief Application of a function that is user defined instead of by rewrite rules. It does not have sort parameters.
       inline
       void ${functionname}_application(data_expression& result, const data_expression& a1)
       {
@@ -809,7 +809,7 @@ ${cases}
 
           return self.polymorphic_function_constructor(self.id, self.label, self.sort_expression_list.sort_parameters(spec)) + \
                  self.polymorphic_function_recogniser(self.id, self.label, self.sort_expression_list.formal_parameters_code(spec)) + \
-                 self.function_application_code(self.sort_expression_list.elements[0], True) 
+                 self.function_application_code(self.sort_expression_list.elements[0], True)
 
     class multi_function_declaration_list():
       def __init__(self, elements):
@@ -2259,7 +2259,7 @@ class specification():
     if self.namespace != "undefined" and self.namespace != "":
       return self.namespace
     else:
-      return self.origin_file[:len(self.origin_file)-5]
+      return self.origin_file.stem
 
   def set_namespace(self):
     if (len(self.sort_specification.declarations.elements) == 0):
@@ -2306,8 +2306,8 @@ class specification():
     code += "/// This file was generated from the data sort specification\n"
     code += "/// mcrl2/data/build/%s.spec.\n" % (remove_underscore(self.get_namespace()))
     code += "\n"
-    code += "#ifndef MCRL2_DATA_%s_H\n" % (infilename.removesuffix(".spec").upper())
-    code += "#define MCRL2_DATA_%s_H\n\n" % (infilename.removesuffix(".spec").upper())
+    code += "#ifndef MCRL2_DATA_%s_H\n" % (infilename.stem.upper())
+    code += "#define MCRL2_DATA_%s_H\n\n" % (infilename.stem.upper())
     code += "#include \"functional\"    // std::function\n"
     code += "#include \"mcrl2/utilities/exception.h\"\n"
     code += "#include \"mcrl2/data/basic_sort.h\"\n"
@@ -2349,7 +2349,7 @@ class specification():
     code += "} // namespace mcrl2\n\n"
     code += ("#include \"mcrl2/data/detail/%s.h\" // This file contains the manual implementations of rewrite functions.\n" % (remove_underscore(self.get_namespace()))
                  if self.has_cplusplus_implementable_code() else "")
-    code += "#endif // MCRL2_DATA_%s_H\n" % (infilename.removesuffix(".spec").upper())
+    code += "#endif // MCRL2_DATA_%s_H\n" % (infilename.stem.upper())
     code = code.replace("__", "_")
     p = re.compile('sort_([A-Za-z0-9]*)_([ ]|:)')
     code = p.sub(r'sort_\1\2', code)

--- a/scripts/code_generation/data_types/fbag1.spec
+++ b/scripts/code_generation/data_types/fbag1.spec
@@ -43,7 +43,7 @@ map @fbag_cons <"cons_"> : S <"arg1"> # Pos <"arg2"> # FBag(S) <"arg3"> -> FBag(
     * <"intersection"> : FBag(S) <"left"> # FBag(S) <"right"> -> FBag(S)                   external defined_by_rewrite_rules;
     - <"difference"> : FBag(S) <"left"> # FBag(S) <"right"> -> FBag(S)                     external defined_by_rewrite_rules;
     # <"count_all"> : FBag(S) <"arg"> -> Nat                                               external defined_by_rewrite_rules;
-
+    pick <"pick">: FBag(S) <"arg"> -> S                                                    external defined_by_rewrite_rules;
 
 var d: S;
     e: S;
@@ -94,3 +94,4 @@ eqn ==(@fbag_cons(d, p, b), {:})  =  false;
     #({:}) = @c0;
     #(@fbag_cons(d,p,{:})) = @cNat(p);
     #(@fbag_cons(d,p,@fbag_cons(e,q,b))) = @cNat(@addc(false,p,Nat2Pos(#(@fbag_cons(e,q,b)))));
+    pick(@fbag_cons(d,p,b)) = d;

--- a/scripts/code_generation/data_types/fbag64.spec
+++ b/scripts/code_generation/data_types/fbag64.spec
@@ -9,7 +9,7 @@
 % Specification of the FBag data sort, denoting finite bags.
 % Note that the specification relies on the underlying data type S to have a total ordering.
 %
-% The definition of an FBag originally had the shape 
+% The definition of an FBag originally had the shape
 %
 % sort FBag(S) <"fbag"> = struct {:} <"empty"> | @fbag_cons <"cons_"> : S <"arg1"> # Pos <"arg2"> # FBag(S) <"arg3">;
 %
@@ -19,9 +19,9 @@
 %
 % Also changed @fbag_insert to become the constructor and @fbag_cons to become a map. All bags should have
 % their elements in a list with @fbag_cons as head symbol be ordered. This is not the case in lists with @fbag_insert.
-% If the @fbag_cons would be a constructor illegal lists would be constructed when evaluationg quantifications and 
-% sum operators. Now it is the case that too many bags will be generated when evaluating for instance a sum operator, 
-% but they are at least not incorrect. 
+% If the @fbag_cons would be a constructor illegal lists would be constructed when evaluationg quantifications and
+% sum operators. Now it is the case that too many bags will be generated when evaluating for instance a sum operator,
+% but they are at least not incorrect.
 
 #using S
 #include bool.spec
@@ -42,6 +42,7 @@ map  @fbag_cons <"cons_"> : S <"arg1"> # Pos <"arg2"> # FBag(S) <"arg3"> -> FBag
      * <"intersection"> : FBag(S) <"left"> # FBag(S) <"right"> -> FBag(S)                                                             external defined_by_rewrite_rules;
      - <"difference"> : FBag(S) <"left"> # FBag(S) <"right"> -> FBag(S)                                                               external defined_by_rewrite_rules;
      # <"count_all"> : FBag(S) <"arg"> -> Nat                                                                                         external defined_by_rewrite_rules;
+     pick <"pick">: FBag(S) <"arg"> -> S                                                    external defined_by_rewrite_rules;
 
 
 var  d: S;
@@ -95,3 +96,4 @@ eqn  ==(@fbag_cons(d, p, b), {:})  =  false;
      #({:}) = @c0;
      #(@fbag_cons(d,p,{:})) = Pos2Nat(p);
      #(@fbag_cons(d,p,@fbag_cons(e,q,b))) = Pos2Nat(@plus_pos(p,Nat2Pos(#(@fbag_cons(e,q,b)))));
+     pick(@fbag_cons(d,p,b)) = d;

--- a/scripts/code_generation/data_types/fset1.spec
+++ b/scripts/code_generation/data_types/fset1.spec
@@ -13,14 +13,14 @@
 %
 % sort FSet(S) <"fset"> = struct {} <"empty"> | @fset_cons <"cons_"> : S <"left"> # FSet(S) <"right">;
 %
-% But this does not work as the automatically generated relation <= is not the subset relation as 
+% But this does not work as the automatically generated relation <= is not the subset relation as
 % would be expected. The same holds for all other comparison operators. Therefore an explicit definition
-% is put into place (Jan Friso Groote, April 2017; problem reported by Tim Willemse). 
+% is put into place (Jan Friso Groote, April 2017; problem reported by Tim Willemse).
 %
 % Also changed @fset_insert and @fset_cons. @fset_insert generates unordered lists. @fset_cons is used
 % for ordered lists only. This has especially an effect when generating finite sets using quantifiers
 % and sums. When @fset_cons is a constructor unordered lists are generated, for which the rewrite rules
-% below do not work properly.  
+% below do not work properly.
 
 #using S
 #include bool.spec
@@ -40,6 +40,7 @@ map  @fset_cons <"cons_"> : S <"left"> # FSet(S) <"right"> -> FSet(S)           
      + <"union_"> : FSet(S) <"left"> # FSet(S) <"right"> -> FSet(S)                                                                      external defined_by_rewrite_rules;
      * <"intersection"> : FSet(S) <"left"> # FSet(S) <"right"> -> FSet(S)                                                                external defined_by_rewrite_rules;
      # <"count"> : FSet(S) <"arg"> -> Nat                                                                                                external defined_by_rewrite_rules;
+     pick <"pick">: FSet(S) <"arg"> -> S external defined_by_rewrite_rules;
 
 var d:S;
     e:S;
@@ -50,10 +51,10 @@ eqn ==({}, @fset_cons(d, s))  =  false;
     ==(@fset_cons(d, s), @fset_cons(e, t))  =  &&(==(d, e), ==(s, t));
     <=({}, @fset_cons(d, s))  =  true;
     <=(@fset_cons(d, s), {})  =  false;
-    <=(@fset_cons(d, s), @fset_cons(e, t))  =  if(<(d,e), false, if(==(d, e), <=(s, t), <=(@fset_cons(d, s), t))); 
+    <=(@fset_cons(d, s), @fset_cons(e, t))  =  if(<(d,e), false, if(==(d, e), <=(s, t), <=(@fset_cons(d, s), t)));
     <({}, @fset_cons(d, s))  =  true;
     <(@fset_cons(d, s), {})  =  false;
-    <(@fset_cons(d, s), @fset_cons(e, t))  =  if(<(d,e), false, if(==(d, e), <(s, t), <=(@fset_cons(d, s), t))); 
+    <(@fset_cons(d, s), @fset_cons(e, t))  =  if(<(d,e), false, if(==(d, e), <(s, t), <=(@fset_cons(d, s), t)));
     @fset_insert(d, {})  =  @fset_cons(d, {});
     @fset_insert(d, @fset_cons(d, s))  =  @fset_cons(d, s);
     <(d, e)  ->  @fset_insert(d, @fset_cons(e, s))  =  @fset_cons(d, @fset_cons(e, s));
@@ -83,3 +84,4 @@ eqn ==({}, @fset_cons(d, s))  =  false;
     #(@fset_cons(d,s)) = @cNat(succ(#(s)));
 % It is odd that the rule below has to be added separately.
     !=(s,t) = !(==(s,t));
+    pick(@fset_cons(d,s)) = d;

--- a/scripts/code_generation/data_types/fset64.spec
+++ b/scripts/code_generation/data_types/fset64.spec
@@ -13,14 +13,14 @@
 %
 % sort FSet(S) <"fset"> = struct {} <"empty"> | @fset_cons <"cons_"> : S <"left"> # FSet(S) <"right">;
 %
-% But this does not work as the automatically generated relation <= is not the subset relation as 
+% But this does not work as the automatically generated relation <= is not the subset relation as
 % would be expected. The same holds for all other comparison operators. Therefore an explicit definition
-% is put into place (Jan Friso Groote, April 2017; problem reported by Tim Willemse). 
+% is put into place (Jan Friso Groote, April 2017; problem reported by Tim Willemse).
 %
 % Also changed @fset_insert and @fset_cons. @fset_insert generates unordered lists. @fset_cons is used
 % for ordered lists only. This has especially an effect when generating finite sets using quantifiers
 % and sums. When @fset_cons is a constructor unordered lists are generated, for which the rewrite rules
-% below do not work properly.  
+% below do not work properly.
 
 #using S
 #include bool.spec
@@ -40,6 +40,7 @@ map  @fset_cons <"cons_"> : S <"left"> # FSet(S) <"right"> -> FSet(S)           
      + <"union_"> : FSet(S) <"left"> # FSet(S) <"right"> -> FSet(S)                                                                         external defined_by_rewrite_rules;
      * <"intersection"> : FSet(S) <"left"> # FSet(S) <"right"> -> FSet(S)                                                                   external defined_by_rewrite_rules;
      # <"count"> : FSet(S) <"arg"> -> Nat                                                                                                   external defined_by_rewrite_rules;
+     pick <"pick">: FSet(S) <"arg"> -> S external defined_by_rewrite_rules;
 
 var d:S;
     e:S;
@@ -52,10 +53,10 @@ eqn ==({}, @fset_cons(d, s))  =  false;
     ==(@fset_cons(d, s), @fset_cons(e, t))  =  &&(==(d, e), ==(s, t));
     <=({}, @fset_cons(d, s))  =  true;
     <=(@fset_cons(d, s), {})  =  false;
-    <=(@fset_cons(d, s), @fset_cons(e, t))  =  if(<(d,e), false, if(==(d, e), <=(s, t), <=(@fset_cons(d, s), t))); 
+    <=(@fset_cons(d, s), @fset_cons(e, t))  =  if(<(d,e), false, if(==(d, e), <=(s, t), <=(@fset_cons(d, s), t)));
     <({}, @fset_cons(d, s))  =  true;
     <(@fset_cons(d, s), {})  =  false;
-    <(@fset_cons(d, s), @fset_cons(e, t))  =  if(<(d,e), false, if(==(d, e), <(s, t), <=(@fset_cons(d, s), t))); 
+    <(@fset_cons(d, s), @fset_cons(e, t))  =  if(<(d,e), false, if(==(d, e), <(s, t), <=(@fset_cons(d, s), t)));
     @fset_insert(d, {})  =  @fset_cons(d, {});
     @fset_insert(d, @fset_cons(d, s))  =  @fset_cons(d, s);
     <(d, e)  ->  @fset_insert(d, @fset_cons(e, s))  =  @fset_cons(d, @fset_cons(e, s));
@@ -85,3 +86,4 @@ eqn ==({}, @fset_cons(d, s))  =  false;
     #(@fset_cons(d,s)) = @succ_nat(#(s));
 % It is odd that the rule below has to be added separately.
     !=(s,t) = !(==(s,t));
+    pick(@fset_cons(d,s)) = d;


### PR DESCRIPTION
Issue #1825 describes issues with defining equations on FSet and FBag. The proposed solution is to include a `pick` mapping.

This pull request implements the proposed change.

It turns out that the generator for data types was not compatible with parsing version 2.0.0 and above; as part of this PR I also update the code generator to be compatible with the new version of parsing.