### PR TITLE
Clean up feature macro usage

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,5 @@
+---
+Checks: "clang-analyzer-*"
+WarningsAsErrors: ''
+HeaderFilterRegex: ''
+FormatStyle:     none

--- a/cmake/ConfigureCompiler.cmake
+++ b/cmake/ConfigureCompiler.cmake
@@ -83,12 +83,12 @@ add_compile_definitions(BRANCH_BIS_EXPERIMENT_JFG)
 
 # Enable all macros defined in the code used for debugging purposes.
 add_debug_compile_definitions(MCRL2_PBES_STATEGRAPH_CHECK_GUARDS)
-add_debug_compile_definitions(MCRL2_LPS_PARELM_DEBUG)
 add_debug_compile_definitions(MCRL2_ABSINTHE_CHECK_EXPRESSIONS)
 add_debug_compile_definitions(PARANOID_CHECK)
 add_compile_definitions(MCRL2_EXTENDED_TESTS)
 
 # These are defines that can be enabled for additional debug printing
+#add_compile_definitions(MCRL2_LPS_PARELM_DEBUG)
 #add_compile_definitions(MCRL2_DEBUG_EXPRESSION_BUILDER)
 #add_compile_definitions(MCRL2_PBES_EXPRESSION_BUILDER_DEBUG)
 #add_compile_definitions(MCRL2_PFNF_VISITOR_DEBUG)

--- a/cmake/ConfigureCompiler.cmake
+++ b/cmake/ConfigureCompiler.cmake
@@ -88,9 +88,6 @@ add_debug_compile_definitions(MCRL2_ABSINTHE_CHECK_EXPRESSIONS)
 add_debug_compile_definitions(PARANOID_CHECK)
 add_compile_definitions(MCRL2_EXTENDED_TESTS)
 
-# TODO: This should be MCRL2_ENABLE_MULTITHREADING
-add_compile_definitions(WITH_THREADS)
-
 # These are defines that can be enabled for additional debug printing
 #add_compile_definitions(MCRL2_DEBUG_EXPRESSION_BUILDER)
 #add_compile_definitions(MCRL2_PBES_EXPRESSION_BUILDER_DEBUG)

--- a/cmake/ConfigureCompiler.cmake
+++ b/cmake/ConfigureCompiler.cmake
@@ -77,6 +77,41 @@ if(APPLE)
   add_compile_definitions(GL_SILENCE_DEPRECATION)
 endif()
 
+# Enable the new JFG branching bisimulation algorithm.
+add_compile_definitions(BRANCH_BIS_EXPERIMENT_JFG)
+
+
+# Enable all macros defined in the code used for debugging purposes.
+add_debug_compile_definitions(MCRL2_PBES_STATEGRAPH_CHECK_GUARDS)
+add_debug_compile_definitions(MCRL2_LPS_PARELM_DEBUG)
+add_debug_compile_definitions(MCRL2_ABSINTHE_CHECK_EXPRESSIONS)
+add_debug_compile_definitions(PARANOID_CHECK)
+add_compile_definitions(MCRL2_EXTENDED_TESTS)
+
+# TODO: This should be MCRL2_ENABLE_MULTITHREADING
+add_compile_definitions(WITH_THREADS)
+
+# These are defines that can be enabled for additional debug printing
+#add_compile_definitions(MCRL2_DEBUG_EXPRESSION_BUILDER)
+#add_compile_definitions(MCRL2_PBES_EXPRESSION_BUILDER_DEBUG)
+#add_compile_definitions(MCRL2_PFNF_VISITOR_DEBUG)
+#add_compile_definitions(MCRL2_SMALL_PROGRESS_MEASURES_DEBUG)
+#add_compile_definitions(MCRL2_LOG_ENUMERATOR)
+#add_compile_definitions(MCRL2_ENUMERATOR_COUNT_REWRITE_CALLS)
+#add_compile_definitions(MCRL2_PRINT_REWRITE_STEPS)
+#add_compile_definitions(MCRL2_EQUAL_MULTI_ACTIONS_DEBUG)
+#add_compile_definitions(MCRL2_LOG_LPS_LINEARISE_STATISTICS)
+#add_compile_definitions(MCRL2_BES2PGSOLVER_PRINT_VARIABLE_NAMES)
+
+# TODO: These belong the the dnj algorithm.
+#add_compile_definitions(TEST_WORK_COUNTER_NAMES)
+#add_compile_definitions(USE_SIMPLE_LIST)
+#add_compile_definitions(USE_POOL_ALLOCATOR)
+#add_compile_definitions(INIT_WITHOUT_BLC_SETS)
+
+# TODO: Is this still needed?
+#add_compile_definitions(MCRL2_PGSOLVER_ENABLED)
+
 # Enable C++17 for all targets.
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED true)

--- a/cmake/ConfigureMSVC.cmake
+++ b/cmake/ConfigureMSVC.cmake
@@ -33,7 +33,9 @@ add_compile_definitions(_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES) # Enables templ
 add_compile_definitions(_CRT_SECURE_NO_WARNINGS)                 # Prevents many CRT deprecation warnings, especially in dparser.
 add_compile_definitions(BOOST_ALL_NO_LIB=1) # Tells the config system not to automatically select which libraries to link against. Normally if a compiler supports #pragma lib, 
                                             # then the correct library build variant will be automatically selected and linked against, simply by the act of including one of 
-                                            # that library's headers. This macro turns that feature off. 
+                                            # that library's headers. This macro turns that feature off.
+add_debug_compile_definitions(_MSVC_STL_HARDENING=1) # Checks for some instances of undefined behavior at runtime and reports them to the user.
+add_debug_compile_definitions(_MSVC_STL_DESTRUCTOR_TOMBSTONES=1) # Another new safety feature we have added is destructor tombstones, which help mitigate use-after-free mistakes. 
 
 if(MCRL2_ENABLE_ADDRESS_SANITIZER)
   mcrl2_add_c_flag(/fsanitize=address)

--- a/cmake/ConfigureUNIX.cmake
+++ b/cmake/ConfigureUNIX.cmake
@@ -83,6 +83,9 @@ if(NOT ${MCRL2_IS_CLANG})
   endif()
 endif()
 
+# Enable clang-tidy static analysis.
+#set(CMAKE_CXX_CLANG_TIDY clang-tidy)
+
 # This prevents warnings in the dnj bisimulation algorithm.
 mcrl2_add_cxx_flag(-Wno-switch)
 

--- a/cmake/MCRL2AddFlag.cmake
+++ b/cmake/MCRL2AddFlag.cmake
@@ -39,6 +39,7 @@ function(mcrl2_add_c_debug_flag FLAG)
   endif()
 endfunction()
 
+# Adds linker flags whenever they are supported by the compiler.
 function(mcrl2_add_link_options FLAGS)
   check_cxx_compiler_flag(${FLAGS} LINKER_${FLAGS}_ACCEPTED)
 
@@ -47,10 +48,16 @@ function(mcrl2_add_link_options FLAGS)
   endif()
 endfunction()
 
+# Adds linker options for the Debug configuration.
 function(mcrl2_add_debug_link_options FLAGS)
   check_cxx_compiler_flag(${FLAGS} LINKER_${FLAGS}_ACCEPTED)
 
   if(LINKER_${FLAGS}_ACCEPTED)
     add_compile_options($<$<CONFIG:Debug>:${FLAGS}>)
   endif()
+endfunction()
+
+# Adds compile definitions for the Debug configuration.
+function(add_debug_compile_definitions FLAGS)
+  add_compile_definitions($<$<CONFIG:Debug>:${FLAGS}>)
 endfunction()

--- a/doc/sphinx/developer_manual/guidelines.rst
+++ b/doc/sphinx/developer_manual/guidelines.rst
@@ -164,6 +164,26 @@ Platform independence
 The source code must compile on the actively supported platforms
 and supported build tools on those platforms.
 
+Feature macros
+^^^^^^^^^^^^^^
+
+Mmacros should be avoided whenever possible and replaced by global `constexpr`
+boolean variables. However, in the cases that macros are unavoidable (i.e.,
+require introducing templates) they should be used as follows. The macro should
+be named ``MCRL2_`` as explained above and in the code we are allowed to check
+for them with ``#ifdef`` blocks, where the corresponding ``#endif`` has a
+comment stating which macro is being tested. However, we do not allow macros to
+be defined in the code itself, but only by the build system. This can be done by
+adding a ``add_compile_definitions`` command to the ``ConfigureCompiler.cmake``
+file.
+
+Formatting
+^^^^^^^^^^^
+
+The code should be formatted according to the mCRL2 coding style, this can be
+(partially) enforced by running `clang-format
+<https://clang.llvm.org/docs/ClangFormat.html>`_ on the code.
+
 Committing changes
 ------------------
 When committing changes, the following guidelines should be adhered to:
@@ -171,7 +191,7 @@ When committing changes, the following guidelines should be adhered to:
 * Make sure the updated code successfully compiles, installs, and passes all
   tests.
 * Enter a clear commit message.
-* Whenever a commit solves a Trac ticket, the commit message must refer to the
+* Whenever a commit solves a Github ticket, the commit message must refer to the
   ticket by its number, formatted as `fixes #n`, where `n` represents the ticket
   number. This automatically closes the ticket with a reference to the commit
   number and message.

--- a/libraries/data/test/data_specification_test.cpp
+++ b/libraries/data/test/data_specification_test.cpp
@@ -868,7 +868,8 @@ BOOST_AUTO_TEST_CASE(test_bke)
     const sort_expression& s = a.reference();
     if (is_structured_sort(s))
     {
-      for (const structured_sort_constructor& constructor: structured_sort(s).constructors())
+      structured_sort sort(s);
+      for (const structured_sort_constructor& constructor: sort.constructors())
       {
         for (const structured_sort_constructor_argument& argument: constructor.arguments())
         {

--- a/libraries/data/test/typecheck_test.cpp
+++ b/libraries/data/test/typecheck_test.cpp
@@ -9,9 +9,6 @@
 
 #define BOOST_TEST_MODULE typecheck_test
 
-// Some tests rely on type check failures, so we have to set this flag.
-#define MCRL2_DISABLE_TYPECHECK_ASSERTIONS
-
 #include <boost/test/included/unit_test.hpp>
 
 #include "mcrl2/data/data_io.h"

--- a/libraries/lps/source/linearise.cpp
+++ b/libraries/lps/source/linearise.cpp
@@ -33,6 +33,7 @@
 //#define MCRL2_LOG_LPS_LINEARISE_STATISTICS 1
 
 //mCRL2 data
+#include "mcrl2/atermpp/aterm.h"
 #include "mcrl2/data/substitutions/maintain_variables_in_rhs.h"
 #include "mcrl2/data/fourier_motzkin.h"
 #include "mcrl2/data/enumerator.h"
@@ -4890,8 +4891,8 @@ class specification_basic_type
 
       if (is_process_instance_assignment(t))
       {
-        const process_identifier& procId=process_instance_assignment(t).identifier();
-        const assignment_list& t1=process_instance_assignment(t).assignments();
+        const process_identifier& procId=atermpp::down_cast<process_instance_assignment>(t).identifier();
+        const assignment_list& t1=atermpp::down_cast<process_instance_assignment>(t).assignments();
         return push_regular(procId,
                             t1,
                             stack,
@@ -9778,7 +9779,8 @@ class specification_basic_type
                                                  visited_processes);
 
         maintain_variables_in_rhs<mutable_map_substitution<> > sigma;
-        for (const assignment& a: process_instance_assignment(t).assignments())
+        process_instance_assignment assign(t);
+        for (const assignment& a: assign.assignments())
         {
           sigma[a.lhs()]=a.rhs();
         }

--- a/libraries/lps/test/constelm_test.cpp
+++ b/libraries/lps/test/constelm_test.cpp
@@ -9,8 +9,6 @@
 /// \file constelm_test.cpp
 /// \brief Add your file description here.
 
-//#define MCRL2_LPSCONSTELM_DEBUG
-
 #define BOOST_TEST_MODULE constelm_test
 #include <boost/algorithm/string.hpp>
 #include <boost/test/included/unit_test.hpp>

--- a/libraries/lps/test/invelm_test.cpp
+++ b/libraries/lps/test/invelm_test.cpp
@@ -9,8 +9,6 @@
 /// \file invelm_test.cpp
 /// \brief Add your file description here.
 
-//#define MCRL2_LPS_PARELM_DEBUG
-
 #define BOOST_TEST_MODULE invelm_test
 #include <boost/test/included/unit_test.hpp>
 

--- a/libraries/lps/test/multi_action_test.cpp
+++ b/libraries/lps/test/multi_action_test.cpp
@@ -9,8 +9,6 @@
 /// \file multi_action_test.cpp
 /// \brief Add your file description here.
 
-//#define MCRL2_LPS_PARELM_DEBUG
-
 #define BOOST_TEST_MODULE multi_action_test
 #include <boost/test/included/unit_test.hpp>
 

--- a/libraries/lps/test/parelm_test.cpp
+++ b/libraries/lps/test/parelm_test.cpp
@@ -9,8 +9,6 @@
 /// \file parelm_test.cpp
 /// \brief Add your file description here.
 
-//#define MCRL2_LPS_PARELM_DEBUG
-
 #define BOOST_TEST_MODULE parelm_test
 #include <boost/algorithm/string.hpp>
 #include <boost/test/included/unit_test.hpp>

--- a/libraries/lps/test/print_test.cpp
+++ b/libraries/lps/test/print_test.cpp
@@ -73,35 +73,6 @@ BOOST_AUTO_TEST_CASE(no_summands)
   BOOST_CHECK(s.find("delta @ 0") != std::string::npos);
 }
 
-#ifdef MCRL2_PRINT_PROBLEM_CASES
-void test_specification(const std::string& spec_text)
-{
-  specification x = parse_linear_process_specification(spec_text);
-
-  std::string s1 = lps::pp(x);
-  std::string s2 = lps::print(x);
-  if (s1 != s2)
-  {
-    std::clog << "--- testing spec ---" << std::endl;
-    std::clog << "<pp>   " << s1 << std::endl;
-    std::clog << "<print>" << s2 << std::endl;
-    BOOST_CHECK(s1 == s2);
-  }
-}
-
-BOOST_AUTO_TEST_CASE(problem_cases)
-{
-  std::string SPEC;
-
-  SPEC =
-    "act  a: Bool;         \n"
-    "proc P =  a(true) . P;\n"
-    "init P;               \n"
-    ;
-  test_specification(SPEC);
-}
-#endif
-
 BOOST_AUTO_TEST_CASE(ticket_1208)
 {
   std::string text =

--- a/libraries/lts/include/mcrl2/lts/detail/liblts_bisim_gj.h
+++ b/libraries/lts/include/mcrl2/lts/detail/liblts_bisim_gj.h
@@ -5821,7 +5821,7 @@ class bisim_partitioner_gj
           const transition& t=m_aut.get_transitions()[ti];
           const label_index label = label_or_divergence(t,
                                                     m_aut.num_action_labels());
-          transition_index& c=count_transitions_per_action[label];              assert(0 <= c); assert(c < m_transitions.size());
+          transition_index& c=count_transitions_per_action[label];              assert(c < m_transitions.size());
           m_BLC_transitions[c]=ti;
           c++;
         }

--- a/libraries/lts/include/mcrl2/lts/lts_algorithm.h
+++ b/libraries/lts/include/mcrl2/lts/lts_algorithm.h
@@ -16,8 +16,6 @@
  * \author Jan Friso Groote, Bas Ploeger, Muck van Weerdenburg
  */
 
-#define BRANCH_BIS_EXPERIMENT_JFG
-
 #ifndef MCRL2_LTS_LTS_ALGORITHM_H
 #define MCRL2_LTS_LTS_ALGORITHM_H
 

--- a/libraries/lts/include/mcrl2/lts/lts_equivalence.h
+++ b/libraries/lts/include/mcrl2/lts/lts_equivalence.h
@@ -13,8 +13,6 @@
  * \author Jan Friso Groote, Bas Ploeger, Muck van Weerdenburg, Jeroen Keiren
  */
 
-#define BRANCH_BIS_EXPERIMENT_JFG
-
 #ifndef MCRL2_LTS_LTS_EQUIVALENCE_H
 #define MCRL2_LTS_LTS_EQUIVALENCE_H
 

--- a/libraries/lts/source/liblts_bisim_gjkw.cpp
+++ b/libraries/lts/source/liblts_bisim_gjkw.cpp
@@ -26,8 +26,6 @@
 #include "mcrl2/lts/lts_fsm.h"
 #include "mcrl2/lts/lts_utilities.h"
 
-#define PARANOID_CHECK
-
 namespace mcrl2
 {
 namespace lts

--- a/libraries/pbes/include/mcrl2/pbes/absinthe.h
+++ b/libraries/pbes/include/mcrl2/pbes/absinthe.h
@@ -12,8 +12,6 @@
 #ifndef MCRL2_PBES_ABSINTHE_H
 #define MCRL2_PBES_ABSINTHE_H
 
-#define MCRL2_ABSINTHE_CHECK_EXPRESSIONS
-
 #include "mcrl2/data/consistency.h"
 #include "mcrl2/data/detail/data_construction.h"
 #include "mcrl2/pbes/builder.h"

--- a/libraries/pbes/test/bes_test.cpp
+++ b/libraries/pbes/test/bes_test.cpp
@@ -23,7 +23,6 @@ typedef core::term_traits<pbes_expression> tr;
 void test_join()
 {
   propositional_variable X("X");
-  const pbes_expression& Z1 = propositional_variable_instantiation(X.name());
   const pbes_expression& Z2(propositional_variable_instantiation(X.name()));
   pbes_expression Z3;
   Z3 = propositional_variable_instantiation(X.name());
@@ -34,24 +33,6 @@ void test_join()
   s.insert(propositional_variable_instantiation("X2"));
   pbes_expression x = join_or(s.begin(), s.end());
   std::cout << "x = " << pbes_system::pp(x) << std::endl;
-
-#ifdef MCRL2_JOIN_TEST
-// The gcc compiler gives the following error:
-//
-// D:\mcrl2\libraries\core\include/mcrl2/utilities/detail/join.h:54:22: error: call
-// of overloaded 'pbes_expression(const mcrl2::pbes_system::propositional_variable&)' is
-// ambiguous
-//
-// This seems to be triggered by an incorrect optimization, in which the return
-// type of the function false_() is discarded.
-//
-  std::set<propositional_variable> sv;
-  sv.insert(propositional_variable("X1"));
-  sv.insert(propositional_variable("X2"));
-  x = join_or(sv.begin(), sv.end());
-  std::cout << "x = " << pbes_system::pp(x) << std::endl;
-#endif
-
 }
 
 void test_expressions()

--- a/libraries/pbes/test/pbesinst_test.cpp
+++ b/libraries/pbes/test/pbesinst_test.cpp
@@ -19,7 +19,6 @@
 #include "mcrl2/pbes/lps2pbes.h"
 #include "mcrl2/pbes/pbesinst_finite_algorithm.h"
 #include "mcrl2/pbes/pbesinst_symbolic.h"
-#include "mcrl2/pbes/rewriter.h"
 #include "mcrl2/pbes/txt2pbes.h"
 
 using namespace mcrl2;
@@ -303,117 +302,6 @@ BOOST_AUTO_TEST_CASE(test_pbesinst_slow)
 {
   test_pbes(random1, false, true);
   test_pbes(random2, false, true);
-}
-
-// Note: this test takes a lot of time!
-BOOST_AUTO_TEST_CASE(test_cabp)
-{
-    std::string CABP_SPECIFICATION =
-            "% This file contains the cabp protocol as described in section 3.5 of         \n"
-            "% S. Mauw and G.J. Veltink, editors, Algebraic Specification of Communication \n"
-            "% Protocols, Cambridge tracts in theoretical computer science 36, Cambridge   \n"
-            "% University Press, Cambridge 1993.                                           \n"
-            "%                                                                             \n"
-            "% With two data elements, the generated transition system has 464 states.     \n"
-            "%                                                                             \n"
-            "% It is interesting to see the clustering of this statespace in ltsgraph.     \n"
-            "% The statespace after branching bisimulation contains 3 states and is        \n"
-            "% exactly the same as the reduced statespace of the alternating bit protocol. \n"
-            "%                                                                             \n"
-            "% Note that it is interesting to compare the differences of the alternating   \n"
-            "% bit protocol (abp), concurrent alternating bit protocol (cabp), one bit     \n"
-            "% sliding window protocol (onebit) and the alternating bit protocol with      \n"
-            "% independent acknowledgements (par), regarding the implementation, the       \n"
-            "% the number of states and the external behaviour.                            \n"
-            "                                                                              \n"
-            "%-------------------------------  DATA  ----------------------------------    \n"
-            "                                                                              \n"
-            "sort DATA = struct d1 | d2;                                                   \n"
-            "                                                                              \n"
-            "%-------------------------------  error  ----------------------------------   \n"
-            "                                                                              \n"
-            "sort  error = struct ce | ae;                                                 \n"
-            "                                                                              \n"
-            "%-------------------------------  bit ------------------------------------    \n"
-            "                                                                              \n"
-            "sort  bit = struct bit0 | bit1;                                               \n"
-            "                                                                              \n"
-            "map   invert:bit -> bit;                                                      \n"
-            "eqn   invert(bit1)=bit0;                                                      \n"
-            "      invert(bit0)=bit1;                                                      \n"
-            "                                                                              \n"
-            "%-------------------------------  Frame ----------------------------------    \n"
-            "                                                                              \n"
-            "sort Frame = struct frame(getd : DATA, getb: bit);                            \n"
-            "                                                                              \n"
-            "%------------------------------  ACK   -----------------------------------    \n"
-            "                                                                              \n"
-            "sort ACK = struct ac;                                                         \n"
-            "                                                                              \n"
-            "%------------------------------  act   -----------------------------------    \n"
-            "                                                                              \n"
-            "act   r1,s2 : DATA;                                                           \n"
-            "      c3,r3,s3,c4,r4,s4 : Frame;                                              \n"
-            "      c4,r4,s4,c7,r7,s7 : error;                                              \n"
-            "      c5,r5,s5,c8,r8,s8 : ACK;                                                \n"
-            "      c6,r6,s6,c7,r7,s7 : bit;                                                \n"
-            "      skip;                                                                   \n"
-            "                                                                              \n"
-            "%------------------------------  proc  -----------------------------------    \n"
-            "                                                                              \n"
-            "                                                                              \n"
-            "proc  S = RM(bit0);                                                           \n"
-            "      RM(b:bit) = sum d:DATA.r1(d).SF(frame(d,b));                            \n"
-            "      SF(f:Frame) = s3(f).SF(f) + r8(ac).RM(invert(getb(f)));                 \n"
-            "                                                                              \n"
-            "      K  = sum f:Frame.r3(f).K(f);                                            \n"
-            "      K(f:Frame) = (skip.s4(f)+skip.s4(ce)+skip).K;                           \n"
-            "                                                                              \n"
-            "      R = RF(bit0);                                                           \n"
-            "      RF(b:bit) = sum d:DATA.r4(frame(d,b)).s2(d).s5(ac).RF(invert(b))        \n"
-            "                     + sum d:DATA. r4(frame(d,invert(b))).RF(b)               \n"
-            "                     + r4(ce).RF(b);                                          \n"
-            "                                                                              \n"
-            "      AS = AS(bit1);                                                          \n"
-            "      AS(b:bit) = r5(ac).AS(invert(b)) + s6(b).AS(b);                         \n"
-            "                                                                              \n"
-            "      L = sum b:bit.r6(b) . L(b);                                             \n"
-            "      L(b:bit) = ( skip.s7(b) + skip.s7(ae) + skip ).L;                       \n"
-            "                                                                              \n"
-            "      AR = AR(bit0);                                                          \n"
-            "      AR(b:bit) = ( r7(ae) + r7(invert(b))) . AR(b)                           \n"
-            "                   + r7(b).s8(ac).AR(invert(b));                              \n"
-            "                                                                              \n"
-            "init                                                                          \n"
-            "   hide({c3,c4,c5,c6,c7,c8,skip},                                             \n"
-            "     allow({c3,c4,c5,c6,c7,c8,skip,r1,s2},                                    \n"
-            "       comm({r3|s3->c3, r4|s4->c4, r5|s5->c5, r6|s6->c6,                      \n"
-            "                r7|s7->c7, r8|s8->c8},                                        \n"
-            "               S || K || R || AS || L || AR )));                              \n"
-    ;
-
-    std::string INFINITELY_OFTEN_SEND = "nu X. mu Y. (<r1(d1)>X || <!r1(d1)>Y)";
-
-    // create a pbes p
-    lps::specification spec = remove_stochastic_operators(lps::linearise(CABP_SPECIFICATION));
-    state_formulas::state_formula formula = state_formulas::parse_state_formula(INFINITELY_OFTEN_SEND, spec, false);
-    bool timed = false;
-    pbes p = lps2pbes(spec, formula, timed);
-    pbes_system::detail::instantiate_global_variables(p);
-
-    std::string expr = "(exists d_RM_00: DATA. (val(d_RM_00 == d1) && val(s31_RM == 1)) && X(2, bit0, frame(d_RM_00, b_RM), s32_K, f_K, s33_RF1, d_RF1, b_RF1, b_AS1, s35_L, b_L, s36_AR1, b_AR1)) || (((((((((((exists d_RM_00: DATA. (val(!(d_RM_00 == d1)) && val(s31_RM == 1)) && Y(2, bit0, frame(d_RM_00, b_RM), s32_K, f_K, s33_RF1, d_RF1, b_RF1, b_AS1, s35_L, b_L, s36_AR1, b_AR1)) || (exists e4_RF1_00: Bool, d4_RF1_00: DATA. val((s32_K == 3 && s33_RF1 == 1) && if(e4_RF1_00, frame(d4_RF1_00, invert(b_RF1)), frame(d4_RF1_00, b_RF1)) == f_K) && Y(s31_RM, b_RM, f_RM, 1, frame(d1, bit0), if(e4_RF1_00, 1, 2), if(e4_RF1_00, d1, d4_RF1_00), b_RF1, b_AS1, s35_L, b_L, s36_AR1, b_AR1))) || val(s32_K == 4 && s33_RF1 == 1) && Y(s31_RM, b_RM, f_RM, 1, frame(d1, bit0), 1, d1, b_RF1, b_AS1, s35_L, b_L, s36_AR1, b_AR1)) || val(s33_RF1 == 2) && Y(s31_RM, b_RM, f_RM, s32_K, f_K, 3, d1, b_RF1, b_AS1, s35_L, b_L, s36_AR1, b_AR1)) || val(s35_L == 1) && Y(s31_RM, b_RM, f_RM, s32_K, f_K, s33_RF1, d_RF1, b_RF1, b_AS1, 2, b_AS1, s36_AR1, b_AR1)) || (exists e5_L_00: Enum3. val(C3_fun2(e5_L_00, true, true, true) && s35_L == 2) && Y(s31_RM, b_RM, f_RM, s32_K, f_K, s33_RF1, d_RF1, b_RF1, b_AS1, C3_fun(e5_L_00, 1, 3, 4), C3_fun3(e5_L_00, bit0, b_L, bit0), s36_AR1, b_AR1))) || val(s35_L == 4 && s36_AR1 == 1) && Y(s31_RM, b_RM, f_RM, s32_K, f_K, s33_RF1, d_RF1, b_RF1, b_AS1, 1, bit0, 1, b_AR1)) || (exists e7_AR1_00: Bool. val((s35_L == 3 && s36_AR1 == 1) && if(e7_AR1_00, b_AR1, invert(b_AR1)) == b_L) && Y(s31_RM, b_RM, f_RM, s32_K, f_K, s33_RF1, d_RF1, b_RF1, b_AS1, 1, bit0, if(e7_AR1_00, 2, 1), b_AR1))) || val(s33_RF1 == 3) && Y(s31_RM, b_RM, f_RM, s32_K, f_K, 1, d1, invert(b_RF1), invert(b_AS1), s35_L, b_L, s36_AR1, b_AR1)) || (exists e_K_00: Enum3. val(C3_fun2(e_K_00, true, true, true) && s32_K == 2) && Y(s31_RM, b_RM, f_RM, C3_fun(e_K_00, 1, 3, 4), C3_fun1(e_K_00, frame(d1, bit0), f_K, frame(d1, bit0)), s33_RF1, d_RF1, b_RF1, b_AS1, s35_L, b_L, s36_AR1, b_AR1))) || val(s31_RM == 2 && s32_K == 1) && Y(2, bit0, f_RM, 2, f_RM, s33_RF1, d_RF1, b_RF1, b_AS1, s35_L, b_L, s36_AR1, b_AR1)) || val(s31_RM == 2 && s36_AR1 == 2) && Y(1, invert(getb(f_RM)), frame(d1, bit0), s32_K, f_K, s33_RF1, d_RF1, b_RF1, b_AS1, s35_L, b_L, 1, invert(b_AR1))";
-    std::string subst = "s31_RM:Pos := 2; b_RM:bit := bit0; f_RM:Frame := frame(d2, bit0); s32_K:Pos := 3; f_K:Frame := frame(d2, bit0); s33_RF1:Pos := 1; d_RF1:DATA := d1; b_RF1:bit := bit0; b_AS1:bit := bit1; s35_L:Pos := 1; b_L:bit := bit0; s36_AR1:Pos := 1; b_AR1:bit := bit0";
-
-    data::mutable_map_substitution<> sigma;
-    pbes_expression t = parse_pbes_expression(expr, subst, p, sigma);
-    pbesinst_algorithm algorithm(p.data());
-    enumerate_quantifiers_rewriter& R = algorithm.rewriter();
-    data::mutable_indexed_substitution<> sigma1;
-    for (const auto& i: sigma)
-    {
-        sigma1[i.first] = i.second;
-    }
-    pbes_expression z = R(t, sigma1);
 }
 
 // Note: this test takes a lot of time!

--- a/libraries/pbes/test/stategraph_test.cpp
+++ b/libraries/pbes/test/stategraph_test.cpp
@@ -12,9 +12,6 @@
 #define BOOST_TEST_MODULE stategraph_test
 #include <boost/test/included/unit_test.hpp>
 
-// Without this check_guards() simply returns true.
-#define MCRL2_PBES_STATEGRAPH_CHECK_GUARDS
-
 #include "mcrl2/pbes/detail/stategraph_local_reset_variables.h"
 #include "mcrl2/pbes/significant_variables.h"
 #include "mcrl2/pbes/txt2pbes.h"

--- a/libraries/pbes/test/stategraph_test.cpp
+++ b/libraries/pbes/test/stategraph_test.cpp
@@ -12,7 +12,9 @@
 #define BOOST_TEST_MODULE stategraph_test
 #include <boost/test/included/unit_test.hpp>
 
-#include "mcrl2/pbes/detail/stategraph_global_reset_variables.h"
+// Without this check_guards() simply returns true.
+#define MCRL2_PBES_STATEGRAPH_CHECK_GUARDS
+
 #include "mcrl2/pbes/detail/stategraph_local_reset_variables.h"
 #include "mcrl2/pbes/significant_variables.h"
 #include "mcrl2/pbes/txt2pbes.h"
@@ -145,9 +147,9 @@ void test_guard(const std::string& pbesspec, const std::string& X, const std::st
   f.apply(x1);
   BOOST_CHECK(f.expression_stack.back().check_guards(x1, R));
 
-//  pbes_expression g = detail::guard(X1, x1);
-//  std::string result = pbes_system::pp(g);
-//  check_result(X, result, expected_result, "");
+  pbes_expression g = detail::guard(X1, x1);
+  std::string result = pbes_system::pp(g);
+  check_result(X, result, expected_result, "");
 }
 
 BOOST_AUTO_TEST_CASE(test_guard1)

--- a/libraries/pg/include/mcrl2/pg/ParityGame.h
+++ b/libraries/pg/include/mcrl2/pg/ParityGame.h
@@ -153,14 +153,14 @@ public:
                        StaticGraph::EdgeDirection edge_dir
                             = StaticGraph::EDGE_NONE );
 
-#ifdef WITH_THREADS
+#ifdef MCRL2_ENABLE_MULTITHREADING
     void make_subgame_threads( const ParityGame &game,
                                const verti *verts,
                                const verti nvert,
                                bool proper,
                                StaticGraph::EdgeDirection edge_dir
                                     = StaticGraph::EDGE_NONE );
-#endif
+#endif // MCRL2_ENABLE_MULTITHREADING
 
     //!@}
 

--- a/libraries/pg/source/Graph.cpp
+++ b/libraries/pg/source/Graph.cpp
@@ -507,7 +507,7 @@ void StaticGraph::swap(StaticGraph &g)
     std::swap(edge_dir_, g.edge_dir_);
 }
 
-#ifdef WITH_THREADS
+#ifdef MCRL2_ENABLE_MULTITHREADING
 void StaticGraph::make_subgraph_threads( const StaticGraph &graph,
                                          const verti *verts,
                                          const verti num_vertices,
@@ -600,4 +600,4 @@ void StaticGraph::make_subgraph_threads( const StaticGraph &graph,
         predecessor_index_[v] = e;
     }
 }
-#endif
+#endif // MCRL2_ENABLE_MULTITHREADING

--- a/libraries/pg/source/ParityGame.cpp
+++ b/libraries/pg/source/ParityGame.cpp
@@ -292,7 +292,7 @@ void ParityGame::swap(ParityGame &pg)
     swap(cardinality_, pg.cardinality_);
 }
 
-#ifdef WITH_THREADS
+#ifdef MCRL2_ENABLE_MULTITHREADING
 void ParityGame::make_subgame_threads( const ParityGame &game,
                                        const verti *verts,
                                        const verti nvert,
@@ -313,4 +313,4 @@ void ParityGame::make_subgame_threads( const ParityGame &game,
     // FIXME: parallellize this?
     recalculate_cardinalities(nvert);
 }
-#endif
+#endif // MCRL2_ENABLE_MULTITHREADING

--- a/libraries/symbolic/include/mcrl2/symbolic/symbolic_reachability.h
+++ b/libraries/symbolic/include/mcrl2/symbolic/symbolic_reachability.h
@@ -101,7 +101,7 @@ data::rewriter construct_rewriter(const data::data_specification& dataspec, data
 }
 
 template <typename EnumeratorElement>
-void check_enumerator_solution(const EnumeratorElement& p, const summand_group& summand)
+void check_enumerator_solution(const EnumeratorElement& p, const summand_group&)
 {
   if (p.expression() != data::sort_bool::true_())
   {    

--- a/tools/experimental/ltscombine/lts_combine.cpp
+++ b/tools/experimental/ltscombine/lts_combine.cpp
@@ -256,8 +256,7 @@ public:
       std::mutex& progress_mutex,
       std::mutex& states_mutex,
       std::condition_variable& queue_cond,
-      std::size_t& busy,
-      std::size_t thread_nr)
+      std::size_t& busy)
   {
     while (true)
     {
@@ -582,8 +581,7 @@ void mcrl2::combine_lts(std::vector<lts::lts_lts_t>& lts,
             progress_mutex,
             states_mutex,
             queue_cond,
-            busy,
-            i);
+            busy);
         }));
   }
 

--- a/tools/release/ltspbisim/ltspbisim.cpp
+++ b/tools/release/ltspbisim/ltspbisim.cpp
@@ -178,6 +178,7 @@ class ltsconvert_tool : public input_output_tool
         {
           mCRL2log(warning) << "Cannot determine type of output. Assuming .aut.\n";
         }
+        [[fallthrough]];
         case lts_aut:
         case lts_aut_probabilistic:
         {


### PR DESCRIPTION
In the toolset we use quite a few macros for conditionally enabling code: to enable new algorithms, enabling expensive debug checks and additional logging. This comes with a few disadvantages. It is often unclear what macros there are, in which header they should be defined and sometimes the code in macros is never compiled at all and as such breaks over time. This pull request proposes some changes to how we deal with feature macros.

In general, macros that only conditionally enable some pieces of code should be replaced by global `constexpr` booleans. Then it is clear where they are defined (if one uses an IDE), and I propose to define them in a single `configuration.h` per library whenever they are used in multiple headers, where there should also be an explanation of what they do. Furthermore, code that is discarded by a `if constexpr` must still be valid and as such is checked even if the condition does not hold for it (unless it is within a template statement). Functions that are now conditionally compiled away can simply be defined, but unused.

Now, we can also introduce new members conditionally using the methods described in this blog [post](https://brevzin.github.io/c++/2021/11/21/conditional-members/), where some solutions require `C++20` features. This does look like absolute template hell with compilation error. So I do not propose to use this for the main features like `MCRL2_ENABLE_JITTYC`, but perhaps some smaller debugging uses can be replaced by it.

For all the features that really require macros I propose to only check them in the code using `ifdef` blocks, but to define them globally in the `ConfigureCompiler.cmake`, together with all the other macros,

TODO:
 - [ ] Check which macros can be replaced by constexpr booleans
 - [ ] Remove the MCRL2_ENABLE_MULTITHREADING and commit to a parallel toolset, the single threaded toolset is now untested.


