### PR TITLE
Removed option to set CMAKE_APPLE_SILICON_PROCESSOR.

### DIFF
--- a/cmake/ConfigureUNIX.cmake
+++ b/cmake/ConfigureUNIX.cmake
@@ -116,14 +116,6 @@ if(APPLE)
 
   set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-stack_size,${MCRL2_OSX_STACK_SIZE}")
   set(CMAKE_EXE_LINKER_FLAGS_DEBUG "")
-
-  if (NOT DEFINED CMAKE_APPLE_SILICON_PROCESSOR) 
-    set(CMAKE_APPLE_SILICON_PROCESSOR "x86_64" CACHE STRING "Select whether the generated code is x86_64 or arm64" FORCE) 
-  else()
-    set(CMAKE_APPLE_SILICON_PROCESSOR "arm64" CACHE STRING "Select whether the generated code is x86_64 or arm64" FORCE)
-  endif()
-  set_property(CACHE CMAKE_APPLE_SILICON_PROCESSOR PROPERTY STRINGS "x86_64" "arm64")
-  set(CMAKE_OSX_ARCHITECTURES ${CMAKE_APPLE_SILICON_PROCESSOR} CACHE INTERNAL "" FORCE)
 elseif(NOT ${MCRL2_IS_CLANG})
   mcrl2_add_link_options(-Wl,--as-needed)
 

--- a/cmake/PrintBuildInfo.cmake
+++ b/cmake/PrintBuildInfo.cmake
@@ -35,6 +35,7 @@ message(STATUS "** Installing to:   ${CMAKE_INSTALL_PREFIX}")
 message(STATUS "** CMake version:   ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION}.${CMAKE_PATCH_VERSION}")
 message(STATUS "** C++ compiler:    ${CMAKE_CXX_COMPILER_ID} ${CMAKE_CXX_COMPILER_VERSION}")
 message(STATUS "** C compiler:      ${CMAKE_C_COMPILER_ID} ${CMAKE_C_COMPILER_VERSION}")
+message(STATUS "** Architecture:    ${CMAKE_HOST_SYSTEM_PROCESSOR}")
 message(STATUS "**")
 message(STATUS "** Boost:  ${Boost_MAJOR_VERSION}.${Boost_MINOR_VERSION}.")
 


### PR DESCRIPTION
The option will be automatically set by CMake.
It can be manually configured by adding the option `-DCMAKE_APPLE_SILICON_PROCESSOR=...`