### PR TITLE
Constelm and parelm show warning when PBES has evidence

### DIFF
--- a/libraries/pbes/include/mcrl2/pbes/constelm.h
+++ b/libraries/pbes/include/mcrl2/pbes/constelm.h
@@ -1045,7 +1045,7 @@ void constelm(pbes& p,
               bool check_quantifiers = true
              )
 {
-  bool has_counter_example = pbes_system::detail::has_counter_example_information(p);
+  const bool has_counter_example = pbes_system::detail::has_counter_example_information(p);
   if (has_counter_example)
   {
     mCRL2log(log::warning) << "Warning: the PBES has counter example information, which may not be preserved by constant elimination." << std::endl;

--- a/libraries/pbes/include/mcrl2/pbes/constelm.h
+++ b/libraries/pbes/include/mcrl2/pbes/constelm.h
@@ -15,6 +15,7 @@
 #include "mcrl2/pbes/print.h"
 #include "mcrl2/pbes/replace.h"
 #include "mcrl2/pbes/rewriters/enumerate_quantifiers_rewriter.h"
+#include "mcrl2/pbes/detail/pbes_remove_counterexample_info.h"
 
 namespace mcrl2
 {
@@ -1044,6 +1045,11 @@ void constelm(pbes& p,
               bool check_quantifiers = true
              )
 {
+  bool has_counter_example = pbes_system::detail::has_counter_example_information(p);
+  if (has_counter_example)
+  {
+    mCRL2log(log::warning) << "Warning: the PBES has counter example information, which may not be preserved by constant elimination." << std::endl;
+  }
   // data rewriter
   data::rewriter datar(p.data(), rewrite_strategy);
 

--- a/libraries/pbes/include/mcrl2/pbes/parelm.h
+++ b/libraries/pbes/include/mcrl2/pbes/parelm.h
@@ -309,11 +309,10 @@ class pbes_parelm_algorithm
 inline
 void parelm(pbes& p)
 {
-  bool has_counter_example = pbes_system::detail::has_counter_example_information(p);
+  const bool has_counter_example = pbes_system::detail::has_counter_example_information(p);
   if (has_counter_example)
   {
     mCRL2log(log::warning) << "Warning: the PBES has counter example information, which may not be preserved by parameter elimination." << std::endl;
-
   }
   pbes_parelm_algorithm algorithm;
   algorithm.run(p);

--- a/libraries/pbes/include/mcrl2/pbes/parelm.h
+++ b/libraries/pbes/include/mcrl2/pbes/parelm.h
@@ -14,6 +14,7 @@
 #include "mcrl2/pbes/detail/find_free_variables.h"
 #include "mcrl2/utilities/detail/iota.h"
 #include "mcrl2/utilities/reachable_nodes.h"
+#include "mcrl2/pbes/detail/pbes_remove_counterexample_info.h"
 
 namespace mcrl2::pbes_system {
 
@@ -308,6 +309,12 @@ class pbes_parelm_algorithm
 inline
 void parelm(pbes& p)
 {
+  bool has_counter_example = pbes_system::detail::has_counter_example_information(p);
+  if (has_counter_example)
+  {
+    mCRL2log(log::warning) << "Warning: the PBES has counter example information, which may not be preserved by parameter elimination." << std::endl;
+
+  }
   pbes_parelm_algorithm algorithm;
   algorithm.run(p);
 }


### PR DESCRIPTION
Related to #1850, although it doesn't prevent the segfault. The tool pbessolve could detect when the counter example information is malformed and throw an error in that case.
