### PR TITLE
Fix incorrect strategy check in pbessolve

### DIFF
--- a/libraries/pbes/include/mcrl2/pbes/pbesinst_lazy_counter_example.h
+++ b/libraries/pbes/include/mcrl2/pbes/pbesinst_lazy_counter_example.h
@@ -139,15 +139,15 @@ static void rewrite_star(pbes_expression& result,
         }
         else
         {
-          if (mapping.count(Y) == 0)
-          {
-            mCRL2log(log::warning) << "Cannot find vertex " << Y << " in the first structure graph.\n";
-            throw mcrl2::runtime_error("The specification cannot be consistently instantiated twice. Most likely this is an issue with the tool.");
-          }
-
           if (mcrl2::utilities::detail::contains(Ys, Y))
           {
             mCRL2log(log::debug) << "rewrite_star " << Y << " is reachable" << std::endl;
+            if (mapping.count(Y) == 0)
+            {
+              mCRL2log(log::warning) << "Cannot find vertex " << Y << " in the first structure graph.\n";
+              throw mcrl2::runtime_error("The specification cannot be consistently instantiated twice. Most likely "
+                                         "this is an issue with the tool.");
+            }
             return Y;
           }
           else


### PR DESCRIPTION
The original check was added in 38cd712 and does not correctly take into account the intended effect of rewrite_star.