### PR TITLE
Make the explorer an attribute of the class simulation

### DIFF
--- a/libraries/lps/include/mcrl2/lps/explorer.h
+++ b/libraries/lps/include/mcrl2/lps/explorer.h
@@ -541,7 +541,7 @@ class explorer: public abortable
     void compute_state(state& result,
                        const DataExpressionSequence& v,
                        data::mutable_indexed_substitution<>& sigma,
-                       data::rewriter& rewr) const
+                       const data::rewriter& rewr) const
     {
       lps::make_state(result, 
                       v.begin(), 
@@ -554,8 +554,8 @@ class explorer: public abortable
                                   const stochastic_distribution& distribution, 
                                   const DataExpressionSequence& next_state,
                                   data::mutable_indexed_substitution<>& sigma,
-                                  data::rewriter& rewr, 
-                                  data::enumerator_algorithm<>& enumerator) const
+                                  const data::rewriter& rewr,
+                                  const data::enumerator_algorithm<>& enumerator) const
     {                                              
       result.clear();
       if (distribution.is_defined())
@@ -588,7 +588,7 @@ class explorer: public abortable
       }
     }
 
-    /// Rewrite action a, and put it back in place. 
+    /// Rewrite action a, and put it back in place.
     lps::multi_action rewrite_action(
                              const lps::multi_action& a,
                              data::mutable_indexed_substitution<>& sigma,
@@ -1030,6 +1030,21 @@ class explorer: public abortable
       return m_global_rewr;
     }
 
+    // Compute the initial stochastic state
+    void compute_initial_stochastic_state(stochastic_state& result) const
+    {
+      compute_stochastic_state(result, m_initial_distribution, m_initial_state, m_global_sigma, m_global_rewr, m_global_enumerator);
+    }
+
+    // Convenience overload: use internal sigma/rewriter/enumerator
+    template <typename DataExpressionSequence>
+    void compute_stochastic_state(stochastic_state& result,
+                                  const stochastic_distribution& distribution,
+                                  const DataExpressionSequence& next_state) const
+    {
+      compute_stochastic_state(result, distribution, next_state, m_global_sigma, m_global_rewr, m_global_enumerator);
+    }
+
     // Utility function to obtain the outgoing transitions of the current state.
     // Should not be used concurrently. 
     std::list<transition> out_edges(const state& s)
@@ -1410,7 +1425,7 @@ class explorer: public abortable
       state_type s0;
       if constexpr (Stochastic)
       {
-        compute_stochastic_state(s0, m_initial_distribution, m_initial_state, m_global_sigma, m_global_rewr, m_global_enumerator);
+        compute_initial_stochastic_state(s0);
       }
       else
       {

--- a/libraries/lts/include/mcrl2/lts/simulation.h
+++ b/libraries/lts/include/mcrl2/lts/simulation.h
@@ -18,18 +18,19 @@ namespace mcrl2::lps  // TODO: This should become lts. We should not declare obj
 /// \brief Simulation process.
 // A simulation is effectively a trace annotated with outgoing transition information
 // and an operation to extend the trace with an outgoing transition from the last state.
-class simulation : protected explorer<true, false, stochastic_specification>
+class simulation
 {
   public:
-
-    using transition_t = transition;
+    using explorer_type = explorer<true, false, stochastic_specification>;
+    using transition_type = explorer_type::transition;
+    using state_type = explorer_type::state_type;
 
     struct simulator_state_t
     {
       lps::stochastic_state source_state;
       std::size_t state_number = 0UL; // This represents the number of the selected probabilistic state, or a number out
                                       // of range if not source state is chosen.
-      std::vector<transition_t> transitions;
+      std::vector<transition_type> transitions;
       std::size_t transition_number
           = 0UL; // This indicates the chosen transition, or a number out of range if no transition is chosen.
     };
@@ -79,7 +80,7 @@ class simulation : protected explorer<true, false, stochastic_specification>
 
   protected:
     stochastic_specification m_specification;
-
+    explorer_type m_explorer;
     bool m_auto_select_probabilistic_state=false;
     std::mt19937 m_gen; // mersenne_twister_engine seeded with rd().
     std::uniform_int_distribution<std::size_t> m_distrib; // A random generator with a uniform distribution. 
@@ -87,7 +88,7 @@ class simulation : protected explorer<true, false, stochastic_specification>
     // The complete trace.
     std::deque<simulator_state_t> m_full_trace;
 
-    std::vector<transition_t> transitions(const lps::state& source_state);
+    std::vector<transition_type> transitions(const lps::state& source_state);
 
     bool match_trace_probabilistic_state(lts::trace& trace);
     bool match_trace_transition(lts::trace& trace);


### PR DESCRIPTION
- This is a much cleaner interface, and it is needed as a preparation for changes in the interface of the explorer and state_space_generator classes.