### PR TITLE
Extract the rewriter from lps::explorer

### DIFF
--- a/libraries/lps/include/mcrl2/lps/ltsmin.h
+++ b/libraries/lps/include/mcrl2/lps/ltsmin.h
@@ -329,6 +329,7 @@ class pins
     std::vector<std::vector<std::size_t> > m_update_group;
     lps::specification m_specification;
     using generator_type = lps::explorer<false, false, lps::specification>;
+    data::rewriter m_rewriter;
     generator_type m_generator;
     
     std::vector<data::variable> m_parameters_list;
@@ -342,6 +343,7 @@ class pins
     // For guard-splitting we use a different generator with a different spec.
     // This second spec has guards removed from the conditions.
     lps::specification m_specification_reduced;
+    data::rewriter m_rewriter_reduced;
     generator_type m_generator_reduced;
 
     // The type mappings
@@ -664,10 +666,12 @@ class pins
     /// \param rewriter_strategy The rewriter strategy used for generating next states
     pins(const std::string& filename, const std::string& rewriter_strategy)
       : m_specification(load_specification(filename)),
-        m_generator(m_specification, data::parse_rewrite_strategy(rewriter_strategy)),
+        m_rewriter(lps::construct_rewriter(m_specification, data::parse_rewrite_strategy(rewriter_strategy), false)),
+        m_generator(m_specification, lps::explorer_options(data::parse_rewrite_strategy(rewriter_strategy)), m_rewriter),
         m_parameters_list(process().process_parameters().begin(), process().process_parameters().end()),
         m_specification_reduced(reduce_specification(m_specification)),
-        m_generator_reduced(m_specification_reduced, data::parse_rewrite_strategy(rewriter_strategy))
+        m_rewriter_reduced(lps::construct_rewriter(m_specification_reduced, data::parse_rewrite_strategy(rewriter_strategy), false)),
+        m_generator_reduced(m_specification_reduced, lps::explorer_options(data::parse_rewrite_strategy(rewriter_strategy)), m_rewriter_reduced)
     {
       initialize_read_write_groups();
 

--- a/libraries/lts/include/mcrl2/lts/simulation.h
+++ b/libraries/lts/include/mcrl2/lts/simulation.h
@@ -80,6 +80,7 @@ class simulation
 
   protected:
     stochastic_specification m_specification;
+    data::rewriter m_rewriter;
     explorer_type m_explorer;
     bool m_auto_select_probabilistic_state=false;
     std::mt19937 m_gen; // mersenne_twister_engine seeded with rd().

--- a/libraries/lts/include/mcrl2/lts/state_space_generator.h
+++ b/libraries/lts/include/mcrl2/lts/state_space_generator.h
@@ -653,7 +653,7 @@ struct state_space_generator
   using state_type = typename explorer_type::state_type;
 
   const lps::explorer_options& options;
-  lps::explorer<Stochastic, Timed, Specification> explorer;
+  explorer_type& explorer;
   detail::trace_constructor<explorer_type> m_trace_constructor;
 
   detail::action_detector<explorer_type> m_action_detector;
@@ -662,9 +662,9 @@ struct state_space_generator
   std::unique_ptr<detail::divergence_detector<explorer_type>> m_divergence_detector;
   detail::progress_monitor m_progress_monitor;
 
-  state_space_generator(const Specification& lpsspec, const lps::explorer_options& options_)
+  state_space_generator(const Specification& lpsspec, const lps::explorer_options& options_, explorer_type& explorer_)
     : options(options_),
-      explorer(lpsspec, options_),
+      explorer(explorer_),
       m_trace_constructor(explorer),
       m_action_detector(lpsspec, m_trace_constructor, options.trace_actions, options.trace_multiactions, options.trace_prefix, options.max_traces),
       m_deadlock_detector(m_trace_constructor, options.trace_prefix, options.max_traces),

--- a/libraries/lts/source/simulation.cpp
+++ b/libraries/lts/source/simulation.cpp
@@ -32,7 +32,8 @@ std::vector<simulation::transition_type> simulation::transitions(const state& so
 simulation::simulation(const stochastic_specification& specification, data::rewrite_strategy strategy)
   :
     m_specification(specification),
-    m_explorer(specification, explorer_options(strategy)),
+    m_rewriter(construct_rewriter(specification, strategy, false)),
+    m_explorer(specification, explorer_options(strategy), m_rewriter),
     m_gen(),
     m_distrib(0,std::numeric_limits<std::size_t>::max())
 {

--- a/libraries/lts/test/linearization_instantiation_compare_probabilistic_test.cpp
+++ b/libraries/lts/test/linearization_instantiation_compare_probabilistic_test.cpp
@@ -39,7 +39,9 @@ LTS_TYPE translate_lps_to_lts(const lps::stochastic_specification& specification
   const std::string& output_filename = utilities::temporary_filename("linearization_instantiation_probabilistic_compare_test_file");
 
   LTS_TYPE result;
-  lts::state_space_generator<true, false, lps::stochastic_specification> generator(specification, options);
+  data::rewriter rewr = lps::construct_rewriter(specification, options.rewrite_strategy, options.remove_unused_rewrite_rules);
+  lps::explorer<true, false, lps::stochastic_specification> explorer(specification, options, rewr);
+  lts::state_space_generator<true, false, lps::stochastic_specification> generator(specification, options, explorer);
   auto builder = create_stochastic_lts_builder(specification, options, result.type());
   generator.explore(*builder);
   builder->save(output_filename);

--- a/libraries/lts/test/linearization_instantiation_compare_test.cpp
+++ b/libraries/lts/test/linearization_instantiation_compare_test.cpp
@@ -39,7 +39,9 @@ LTS_TYPE translate_lps_to_lts(const lps::stochastic_specification& specification
   const std::string& output_filename = utilities::temporary_filename("linearization_instantiation_compare_test_file");
 
   LTS_TYPE result;
-  lts::state_space_generator<false, false, lps::stochastic_specification> generator(specification, options);
+  data::rewriter rewr = lps::construct_rewriter(specification, options.rewrite_strategy, options.remove_unused_rewrite_rules);
+  lps::explorer<false, false, lps::stochastic_specification> explorer(specification, options, rewr);
+  lts::state_space_generator<false, false, lps::stochastic_specification> generator(specification, options, explorer);
   lps::specification lpsspec = lps::remove_stochastic_operators(specification);
   auto builder = create_lts_builder(lpsspec, options, result.type());
   generator.explore(*builder);

--- a/libraries/lts/test/lps2lts_test.cpp
+++ b/libraries/lts/test/lps2lts_test.cpp
@@ -28,7 +28,9 @@ using namespace mcrl2::lps;
 template <bool Stochastic, bool Timed, typename Specification, typename LTSBuilder>
 void generate_state_space(const Specification& lpsspec, LTSBuilder& builder, const std::string& output_filename, const lps::explorer_options& options)
 {
-  lts::state_space_generator<Stochastic, Timed, Specification> generator(lpsspec, options);
+  data::rewriter rewr = lps::construct_rewriter(lpsspec, options.rewrite_strategy, options.remove_unused_rewrite_rules);
+  lps::explorer<Stochastic, Timed, Specification> explorer(lpsspec, options, rewr);
+  lts::state_space_generator<Stochastic, Timed, Specification> generator(lpsspec, options, explorer);
   generator.explore(builder);
   builder.save(output_filename);
 }

--- a/tools/release/lps2lts/lps2lts.cpp
+++ b/tools/release/lps2lts/lps2lts.cpp
@@ -343,7 +343,9 @@ class lps2lts_tool: public parallel_tool<rewriter_tool<input_output_tool>>
     template <bool Stochastic, bool Timed, typename Specification, typename LTSBuilder>
     bool generate_state_space(const Specification& lpsspec, LTSBuilder& builder)
     {
-      lts::state_space_generator<Stochastic, Timed, Specification> generator(lpsspec, options);
+      data::rewriter rewr = lps::construct_rewriter(lpsspec, options.rewrite_strategy, options.remove_unused_rewrite_rules);
+      lps::explorer<Stochastic, Timed, Specification> explorer(lpsspec, options, rewr);
+      lts::state_space_generator<Stochastic, Timed, Specification> generator(lpsspec, options, explorer);
       current_explorer = &generator.explorer;
       
       bool result = generator.explore(builder);


### PR DESCRIPTION
- The rewriter is now constructed outside of the lps::explorer class.

- Similarly the explorer is constructed outside of the lts::state_space_generator class.

This is done to allow an existing rewriter to be reused for state space generation. This will be used to improve the efficiency of Dezyne workflows.