### PR TITLE
Consistently compute strategies in different solvers.

### DIFF
--- a/libraries/pbes/include/mcrl2/pbes/pbesreach.h
+++ b/libraries/pbes/include/mcrl2/pbes/pbesreach.h
@@ -53,7 +53,8 @@ data::data_specification construct_propositional_variable_data_specification(con
 
 struct symbolic_reachability_options: public symbolic::symbolic_reachability_options
 {
-  bool check_strategy = false;
+  bool compute_strategy = false; // compute strategy during solving and/or symbolic reachability
+  bool check_strategy = false;   // check strategy after solving
   bool make_total = false;
   bool reset_parameters = false;
   bool aggressive = false;

--- a/libraries/pbes/include/mcrl2/pbes/pbesreach_partial.h
+++ b/libraries/pbes/include/mcrl2/pbes/pbesreach_partial.h
@@ -48,7 +48,7 @@ public:
         V,
         m_options.no_relprod,
         m_options.chaining,
-        m_options.check_strategy);
+        m_options.compute_strategy);
       G.print_information();
       symbolic_pbessolve_algorithm solver(G);
 


### PR DESCRIPTION
Due to the incompatibility between chaining, used in safe_predecessors_impl, and the computation of strategies in that same function, we need to ensure that chaining is disabled when computing strategies.
The class symbolic_parity_game has a flag m_strategy that controls whether the strategy needs to be computed in safe_predecessors_impl, and if so, chaining is not used.
When applying partial solvers, this option was not consistently passed between all solvers, leading to incomplete strategies. This in turn resulted in incorrect simplified right hand sides being generated in the second pass of pbessolvesymbolic when generating counterexamples.

The majority of changes in this commit is detailed trace-level debug output that is useful in debugging the problem.

TODO:
- [ ] add a testcase for the symbolic solver with counterexamples that reproduces the issue.