### PR TITLE
pbessolvesymbolic: allow chaining in combination with strategy computation

### DIFF
--- a/libraries/pbes/include/mcrl2/pbes/symbolic_parity_game.h
+++ b/libraries/pbes/include/mcrl2/pbes/symbolic_parity_game.h
@@ -813,7 +813,7 @@ private:
                              << watch.seconds() << "s)\n";
 
         P = union_(P, todo1);
-        strategy = merge(minus(intersect(todo1, Vplayer[alpha]), todo), todo);
+        strategy = union_(strategy, merge(minus(intersect(todo1, Vplayer[alpha]), todo), todo));
         todo = union_(todo, intersect(todo1, W));
       }
 

--- a/libraries/pbes/include/mcrl2/pbes/symbolic_parity_game.h
+++ b/libraries/pbes/include/mcrl2/pbes/symbolic_parity_game.h
@@ -833,7 +833,7 @@ private:
       ldd P = m_chaining ? predecessors_chaining(V, U, intersect(Vplayer[alpha], W)) : predecessors(V, U);
       ldd Palpha = intersect(P, Vplayer[alpha]);
       ldd Pforced = minus(intersect(P, Vplayer[1-alpha]), I);
-      ldd strategy = m_strategy ? merge(Palpha, U) : empty_set();
+      ldd strategy = m_strategy ? merge(minus(Palpha, U), U) : empty_set();
 
       mCRL2log(log::trace) << "safe_control_predecessors_impl: initialized to\n"
         << "  P = " << print_nodes(P) << "\n"

--- a/tests/random/random_testing.py
+++ b/tests/random/random_testing.py
@@ -276,7 +276,7 @@ class LtsconvertsymbolicTest(ProcessTest):
 
         if arguments:
             self.add_command_line_options('t3', arguments)
-            
+
 
 class PbesTest(RandomTest):
     def __init__(self, name, ymlfile, settings):
@@ -439,7 +439,7 @@ class Pbes2bool_counter_exampleTest(ProcessTest):
 class Pbes2bool_counter_example_parelmTest(ProcessTest):
     def __init__(self, name, settings):
         super().__init__(name, ymlfile('pbessolve-parelm'), settings)
-        
+
 
     def create_inputfiles(self, runpath = '.'):
         super().create_inputfiles(runpath)
@@ -609,6 +609,20 @@ if os.name != 'nt':
     available_tests.update({'pbessolvesymbolic-counter-example-s3' : lambda name, settings: PbessolvesymbolicCounterexampleTest(name, ['-s3'], settings) })
     available_tests.update({'pbessolvesymbolic-counter-example-s4' : lambda name, settings: PbessolvesymbolicCounterexampleTest(name, ['-s4'], settings) })
     available_tests.update({'pbessolvesymbolic-counter-example-s7' : lambda name, settings: PbessolvesymbolicCounterexampleTest(name, ['-s7'], settings) })
+
+    available_tests.update({'pbessolvesymbolic-counter-example-saturation' : lambda name, settings: PbessolvesymbolicCounterexampleTest(name, ['--saturation'], settings) })
+    available_tests.update({'pbessolvesymbolic-counter-example-saturation-s1' : lambda name, settings: PbessolvesymbolicCounterexampleTest(name, ['--saturation', '-s1'], settings) })
+    available_tests.update({'pbessolvesymbolic-counter-example-saturation-s2' : lambda name, settings: PbessolvesymbolicCounterexampleTest(name, ['--saturation', '-s2'], settings) })
+    available_tests.update({'pbessolvesymbolic-counter-example-saturation-s3' : lambda name, settings: PbessolvesymbolicCounterexampleTest(name, ['--saturation', '-s3'], settings) })
+    available_tests.update({'pbessolvesymbolic-counter-example-saturation-s4' : lambda name, settings: PbessolvesymbolicCounterexampleTest(name, ['--saturation', '-s4'], settings) })
+    available_tests.update({'pbessolvesymbolic-counter-example-saturation-s7' : lambda name, settings: PbessolvesymbolicCounterexampleTest(name, ['--saturation', '-s7'], settings) })
+
+    available_tests.update({'pbessolvesymbolic-counter-example-chaining' : lambda name, settings: PbessolvesymbolicCounterexampleTest(name, ['--chaining'], settings) })
+    available_tests.update({'pbessolvesymbolic-counter-example-chaining-s1' : lambda name, settings: PbessolvesymbolicCounterexampleTest(name, ['--chaining', '-s1'], settings) })
+    available_tests.update({'pbessolvesymbolic-counter-example-chaining-s2' : lambda name, settings: PbessolvesymbolicCounterexampleTest(name, ['--chaining', '-s2'], settings) })
+    available_tests.update({'pbessolvesymbolic-counter-example-chaining-s3' : lambda name, settings: PbessolvesymbolicCounterexampleTest(name, ['--chaining', '-s3'], settings) })
+    available_tests.update({'pbessolvesymbolic-counter-example-chaining-s4' : lambda name, settings: PbessolvesymbolicCounterexampleTest(name, ['--chaining', '-s4'], settings) })
+    available_tests.update({'pbessolvesymbolic-counter-example-chaining-s7' : lambda name, settings: PbessolvesymbolicCounterexampleTest(name, ['--chaining', '-s7'], settings) })
     # TODO: These tests fail.
     #available_tests.update({'ltsconvertsymbolic' :  lambda name, settings: LtsconvertsymbolicTest(name, [], settings)})
     #available_tests.update({'ltsconvertsymbolic-parallel' : lambda name, settings: LtsconvertsymbolicTest(name, ['--threads=8'], settings) })

--- a/tools/release/pbessolvesymbolic/pbessolvesymbolic.cpp
+++ b/tools/release/pbessolvesymbolic/pbessolvesymbolic.cpp
@@ -481,21 +481,15 @@ class pbessolvesymbolic_tool: public parallel_tool<rewriter_tool<input_output_to
           {
             if (options_.max_iterations == 0)
             {
-              if (options_.check_strategy && options_.chaining)
-              {
-                mCRL2log(log::info) << "Solving will not use chaining since it cannot be used while checking the strategy" << std::endl;
-                options_.chaining = false;
-              }
-
               pbes_system::symbolic_parity_game G(reach.pbes(),
                 reach.summand_groups(),
                 reach.data_index(),
                 reach.V(),
                 options_.no_relprod,
                 options_.chaining,
-                options_.check_strategy);
+                options_.compute_strategy);
               G.print_information();
-              pbes_system::symbolic_pbessolve_algorithm solver(G);
+              pbes_system::symbolic_pbessolve_algorithm solver(G, options_.check_strategy);
 
               mCRL2log(log::debug) << pbes_system::detail::print_pbes_info(reach.pbes()) << std::endl;
               timer().start("solving");
@@ -516,12 +510,6 @@ class pbessolvesymbolic_tool: public parallel_tool<rewriter_tool<input_output_to
           // We are generating a counterexample, so the strategy must be computed, irregardless of
           // whether we check the strategy afterwards.
           options_.compute_strategy = true;
-
-          if (options_.chaining)
-          {
-            mCRL2log(log::info) << "(Partial) solving will not use chaining since it cannot be used while computing the strategy" << std::endl;
-            options_.chaining = false;
-          }
 
           PbesReachAlgorithm reach(srf_pbes, options_);
 
@@ -599,6 +587,7 @@ class pbessolvesymbolic_tool: public parallel_tool<rewriter_tool<input_output_to
             //pbessolve_options.optimization = std::min(partial_solve_strategy::remove_self_loops, options_.solve_strategy);
             pbessolve_options.rewrite_strategy = options_.rewrite_strategy;
             pbessolve_options.remove_unused_rewrite_rules = options_.remove_unused_rewrite_rules;
+            pbessolve_options.check_strategy = options_.check_strategy;
             pbessolve_options.number_of_threads = 1; // If we spawn multiple threads here, the threads of Sylvan and the explicit exploration will interfere
 
             PbesInstAlgorithm second_instantiate(SG, pbessolve_options, pbesspec_simplified, !result, reach.propvar_map(), reach.data_index(), G.players(V)[result ? 0 : 1], V, result ? solution.strategy[0] : solution.strategy[1], reach.rewriter());


### PR DESCRIPTION
So far, pbessolvesymbolic could not use chaining during solving when a strategy had to be computed. To enable this combination, this pull request does the following:

- Extend the computation of predecessors with chaining to calculate a strategy for player alpha.
- Use this strategy in the computation of safe control predecessors.
- Remove the restrictions on the combination of chaining and strategy computation from pbessolvesymbolic and the library.
- Enabled random tests for chaining/saturation in combination with the different solving optimizations.

I attach a PDF that documents the algorithms; once Anna Stramaglia's changes to the documentation of the symbolic solver are completed, I will make sure to add the documentation to the website as well.

[Safe control predecessor.pdf](https://github.com/user-attachments/files/23962161/Safe.control.predecessor.pdf)
