### PR TITLE
Add pbes substitutions to rewriters

### DIFF
--- a/libraries/pbes/include/mcrl2/pbes/pbesinst_lazy.h
+++ b/libraries/pbes/include/mcrl2/pbes/pbesinst_lazy.h
@@ -408,7 +408,7 @@ class pbesinst_lazy_algorithm
           const pbes_equation& eqn = m_pbes.equations()[index];
           const auto& phi = eqn.formula();
           data::add_assignments(sigma, eqn.variable().parameters(), X_e.parameters());
-          R(psi_e, phi, sigma);
+          R(psi_e, phi, sigma, phi_substitution(thread_index, eqn.symbol(), X_e, phi));
           R.clear_identifier_generator();
           data::remove_assignments(sigma, eqn.variable().parameters());
 

--- a/libraries/pbes/include/mcrl2/pbes/pbesinst_lazy_counter_example.h
+++ b/libraries/pbes/include/mcrl2/pbes/pbesinst_lazy_counter_example.h
@@ -66,7 +66,7 @@ static void rewrite_star(pbes_expression& result,
     const std::unordered_map<pbes_expression, structure_graph::index_type>& mapping,
     std::unordered_map<std::string, std::set<int>> R)
 {
-  bool changed = false;
+  assert(&result != &psi);
   std::smatch match;
 
 
@@ -157,8 +157,8 @@ static void rewrite_star(pbes_expression& result,
   }
 
   mCRL2log(log::debug) << "Ys := " << core::detail::print_set(Ys) << std::endl;
-
-  replace_propositional_variables(result,
+  simplify_rewriter simplify;
+  simplify(result,
       psi,
       [&](const propositional_variable_instantiation& Y) -> pbes_expression
       {
@@ -179,7 +179,6 @@ static void rewrite_star(pbes_expression& result,
           }
           else
           {
-            changed = true;
             if (alpha == 0)
             {
               // If Y is not reachable, replace it by false
@@ -196,14 +195,7 @@ static void rewrite_star(pbes_expression& result,
         }
       });
 
-  if (changed)
-  {
-    simplify_rewriter simplify;
-    const pbes_expression result1 = result;
-    simplify(result, result1);
-  }
-
-  mCRL2log(log::debug) << "result = " << psi << std::endl;
+  mCRL2log(log::debug) << "result = " << result << std::endl;
 }
 
 class pbesinst_counter_example_structure_graph_algorithm : public pbesinst_structure_graph_algorithm
@@ -232,6 +224,7 @@ public:
       const propositional_variable_instantiation& X,
       const pbes_expression& psi) override
   {
+    assert(&result != &psi); // required by super::rewrite_psi
     pbesinst_structure_graph_algorithm::rewrite_psi(thread_index, result, symbol, X, psi);
     rewrite_star(result, symbol, X, psi, G, alpha, mapping, R);
   }

--- a/libraries/pbes/include/mcrl2/pbes/pbesinst_structure_graph2.h
+++ b/libraries/pbes/include/mcrl2/pbes/pbesinst_structure_graph2.h
@@ -119,7 +119,7 @@ class pbesinst_structure_graph_algorithm2: public pbesinst_structure_graph_algor
           pbes_expression g0_,
           pbes_expression g1_
         )
-         : b(std::move(atermpp::down_cast<pbes_expression>(b_))), 
+         : b(std::move(atermpp::down_cast<pbes_expression>(b_))),
            f(std::move(atermpp::down_cast<pbes_expression>(f_))), g0(std::move(g0_)), g1(std::move(g1_))
         {}
 
@@ -345,7 +345,7 @@ class pbesinst_structure_graph_algorithm2: public pbesinst_structure_graph_algor
 
       void leave(const exists& x)
       {
-        enter(x); // Print an error message. 
+        enter(x); // Print an error message.
       }
 
       void enter(const forall& x)
@@ -355,7 +355,7 @@ class pbesinst_structure_graph_algorithm2: public pbesinst_structure_graph_algor
 
       void leave(const forall& x)
       {
-        enter(x); // Print an error. 
+        enter(x); // Print an error.
       }
     };
 
@@ -375,7 +375,7 @@ class pbesinst_structure_graph_algorithm2: public pbesinst_structure_graph_algor
     // Returns true if all nodes in the todo list are undefined (i.e. have not been processed yet)
     bool todo_has_only_undefined_nodes() const
     {
-      /* for (const propositional_variable_instantiation& X: todo.all_elements())  all_elements does not seem to work. Therefore split below. 
+      /* for (const propositional_variable_instantiation& X: todo.all_elements())  all_elements does not seem to work. Therefore split below.
       {
         structure_graph::index_type u = m_graph_builder.find_vertex(X);
         const structure_graph::vertex& u_ = m_graph_builder.vertex(u);
@@ -531,6 +531,7 @@ class pbesinst_structure_graph_algorithm2: public pbesinst_structure_graph_algor
                      const pbes_expression& psi
                     ) override
     {
+      assert(&result != &psi); // required by super::rewrite_psi
       super::rewrite_psi(thread_index, result, symbol, X, psi);
       auto rplus_result = Rplus(result);
       b[thread_index] = rplus_result.b;
@@ -622,7 +623,7 @@ class pbesinst_structure_graph_algorithm2: public pbesinst_structure_graph_algor
         }
       }
       else if (m_options.optimization == partial_solve_strategy::detect_winning_loops_original && (m_options.aggressive || find_loops_guard(m_iteration_count)))
-      {        
+      {
         mCRL2log(log::verbose) << "start partial solving\n"; report = true;
 
         simple_structure_graph G(m_graph_builder.vertices());

--- a/libraries/pbes/include/mcrl2/pbes/replace.h
+++ b/libraries/pbes/include/mcrl2/pbes/replace.h
@@ -72,8 +72,6 @@ struct replace_propositional_variables_builder: public Builder<replace_propositi
   template <class T>
   void apply(T& result, const propositional_variable_instantiation& x)
   {
-    // TODO: enforce that this method is only performed when when super::apply results in a propositional_variable_instantiation
-    super::apply(result, x);
     result = sigma(atermpp::down_cast<propositional_variable_instantiation>(result));
   }
 };

--- a/libraries/pbes/include/mcrl2/pbes/replace.h
+++ b/libraries/pbes/include/mcrl2/pbes/replace.h
@@ -13,6 +13,7 @@
 #define MCRL2_PBES_REPLACE_H
 
 #include "mcrl2/data/replace.h"
+#include "mcrl2/pbes/pbes_expression.h"
 #include "mcrl2/pbes/replace_capture_avoiding.h"
 
 namespace mcrl2::pbes_system
@@ -71,7 +72,9 @@ struct replace_propositional_variables_builder: public Builder<replace_propositi
   template <class T>
   void apply(T& result, const propositional_variable_instantiation& x)
   {
-    result = sigma(x);
+    // TODO: enforce that this method is only performed when when super::apply results in a propositional_variable_instantiation
+    super::apply(result, x);
+    result = sigma(atermpp::down_cast<propositional_variable_instantiation>(result));
   }
 };
 

--- a/libraries/pbes/include/mcrl2/pbes/replace.h
+++ b/libraries/pbes/include/mcrl2/pbes/replace.h
@@ -13,7 +13,6 @@
 #define MCRL2_PBES_REPLACE_H
 
 #include "mcrl2/data/replace.h"
-#include "mcrl2/pbes/pbes_expression.h"
 #include "mcrl2/pbes/replace_capture_avoiding.h"
 
 namespace mcrl2::pbes_system
@@ -72,7 +71,7 @@ struct replace_propositional_variables_builder: public Builder<replace_propositi
   template <class T>
   void apply(T& result, const propositional_variable_instantiation& x)
   {
-    result = sigma(atermpp::down_cast<propositional_variable_instantiation>(result));
+    result = sigma(x);
   }
 };
 

--- a/libraries/pbes/include/mcrl2/pbes/rewriters/data_rewriter.h
+++ b/libraries/pbes/include/mcrl2/pbes/rewriters/data_rewriter.h
@@ -74,17 +74,17 @@ struct add_data_rewriter: public Builder<Derived>
   void apply(T& result, const propositional_variable_instantiation& x)
   {
     make_propositional_variable_instantiation(
-              result, 
-              x.name(), 
+              result,
+              x.name(),
               [this, &x](data::data_expression_list& r) -> void
                   { atermpp::make_term_list<data::data_expression>(
-                               r, 
+                               r,
                                x.parameters().begin(),
                                x.parameters().end(),
                                [this](data::data_expression& r1, const data::data_expression& arg) -> void
                                      { data_rewrite(r1, arg, R, sigma); } ) ;
-                  }); 
-  } 
+                  });
+  }
 };
 
 template <typename Derived, typename DataRewriter, typename SubstitutionFunction>

--- a/libraries/pbes/include/mcrl2/pbes/rewriters/enumerate_quantifiers_rewriter.h
+++ b/libraries/pbes/include/mcrl2/pbes/rewriters/enumerate_quantifiers_rewriter.h
@@ -347,7 +347,7 @@ struct enumerate_quantifiers_rewriter
     template <typename MutableSubstitution>
     void operator()(pbes_expression& result, const pbes_expression& x, MutableSubstitution& sigma) const
     {
-      detail::apply_enumerate_builder<detail::enumerate_quantifiers_builder, data::rewriter, MutableSubstitution>(m_rewriter, sigma, m_dataspec, m_id_generator, m_enumerate_infinite_sorts).apply(result, x);
+      detail::apply_enumerate_builder<detail::enumerate_quantifiers_builder, data::rewriter, MutableSubstitution>(m_rewriter, sigma, no_substitution(), m_dataspec, m_id_generator, m_enumerate_infinite_sorts).apply(result, x);
     }
 
     template<typename MutableSubstitution, typename PbesSubstitution>

--- a/libraries/pbes/include/mcrl2/pbes/rewriters/enumerate_quantifiers_rewriter.h
+++ b/libraries/pbes/include/mcrl2/pbes/rewriters/enumerate_quantifiers_rewriter.h
@@ -263,19 +263,19 @@ struct apply_enumerate_builder: public Builder<apply_enumerate_builder<Builder, 
     bool enumerate_infinite_sorts)
     : super(R, sigma, sigma_pbes, dataspec, id_generator, enumerate_infinite_sorts)
   {}
-
-  apply_enumerate_builder(const DataRewriter& R,
-    MutableSubstitution& sigma,
-    const data::data_specification& dataspec,
-    data::enumerator_identifier_generator& id_generator,
-    bool enumerate_infinite_sorts)
-    : super(R, sigma, no_substitution(), dataspec, id_generator, enumerate_infinite_sorts)
-  {}
 };
 
-template <template <class, class, class, class> class Builder, class DataRewriter, class MutableSubstitution, class PbesSubstitution = no_substitution>
-apply_enumerate_builder<Builder, DataRewriter, MutableSubstitution, PbesSubstitution>
-make_apply_enumerate_builder(const DataRewriter& R, MutableSubstitution& sigma, const data::data_specification& dataspec, data::enumerator_identifier_generator& id_generator, const PbesSubstitution& sigma_pbes, bool enumerate_infinite_sorts)
+template<template<class, class, class, class> class Builder,
+  class DataRewriter,
+  class MutableSubstitution,
+  class PbesSubstitution>
+apply_enumerate_builder<Builder, DataRewriter, MutableSubstitution, PbesSubstitution> make_apply_enumerate_builder(
+  const DataRewriter& R,
+  MutableSubstitution& sigma,
+  const PbesSubstitution& sigma_pbes,
+  const data::data_specification& dataspec,
+  data::enumerator_identifier_generator& id_generator,
+  bool enumerate_infinite_sorts)
 {
   return apply_enumerate_builder<Builder, DataRewriter, MutableSubstitution, PbesSubstitution>(R,
     sigma,
@@ -332,7 +332,7 @@ struct enumerate_quantifiers_rewriter
     {
       data::rewriter::substitution_type sigma;
       pbes_expression result;
-      detail::apply_enumerate_builder<detail::enumerate_quantifiers_builder, data::rewriter, data::rewriter::substitution_type>(m_rewriter, sigma, m_dataspec, m_id_generator, m_enumerate_infinite_sorts).apply(result, x);
+      detail::apply_enumerate_builder<detail::enumerate_quantifiers_builder, data::rewriter, data::rewriter::substitution_type>(m_rewriter, sigma, no_substitution(), m_dataspec, m_id_generator, m_enumerate_infinite_sorts).apply(result, x);
       return result;
     }
 
@@ -340,7 +340,7 @@ struct enumerate_quantifiers_rewriter
     pbes_expression operator()(const pbes_expression& x, MutableSubstitution& sigma) const
     {
       pbes_expression result;
-      detail::apply_enumerate_builder<detail::enumerate_quantifiers_builder, data::rewriter, MutableSubstitution>(m_rewriter, sigma, m_dataspec, m_id_generator, m_enumerate_infinite_sorts).apply(result, x);
+      detail::apply_enumerate_builder<detail::enumerate_quantifiers_builder, data::rewriter, MutableSubstitution>(m_rewriter, sigma, no_substitution(), m_dataspec, m_id_generator, m_enumerate_infinite_sorts).apply(result, x);
       return result;
     }
 
@@ -370,7 +370,7 @@ struct enumerate_quantifiers_rewriter
     template<typename MutableSubstitution, typename PbesSubstitution>
     void operator()(pbes_expression& result, const pbes_expression& x, MutableSubstitution& sigma, const PbesSubstitution& sigma_pbes) const
     {
-      detail::apply_enumerate_builder<detail::enumerate_quantifiers_builder, data::rewriter, MutableSubstitution>(
+      detail::apply_enumerate_builder<detail::enumerate_quantifiers_builder, data::rewriter, MutableSubstitution, PbesSubstitution>(
         m_rewriter,
         sigma,
         sigma_pbes,

--- a/libraries/pbes/include/mcrl2/pbes/rewriters/enumerate_quantifiers_rewriter.h
+++ b/libraries/pbes/include/mcrl2/pbes/rewriters/enumerate_quantifiers_rewriter.h
@@ -86,7 +86,7 @@ struct enumerate_quantifiers_builder: public simplify_data_rewriter_builder<Deri
     }
   }
 
-  // We assume that phi is already rewritten. 
+  // We assume that phi is already rewritten.
   void enumerate_forall(pbes_expression& result, const data::variable_list& v, const pbes_expression& phi)
   {
     assert(!v.empty());
@@ -139,7 +139,7 @@ struct enumerate_quantifiers_builder: public simplify_data_rewriter_builder<Deri
       data::variable_list enumerable;
       data::variable_list non_enumerable;
       data::variable_list unused;
-      data::detail::split_enumerable_variables(x.variables(), m_dataspec, super::R, 
+      data::detail::split_enumerable_variables(x.variables(), m_dataspec, super::R,
                                                enumerable, non_enumerable, unused,
                                                [&free_variables](const data::variable& v){ return free_variables.count(v)>0; });
       if (enumerable.empty())
@@ -158,8 +158,8 @@ struct enumerate_quantifiers_builder: public simplify_data_rewriter_builder<Deri
       data::variable_list finite;
       data::variable_list infinite;
       data::variable_list unused;
-      data::detail::split_finite_variables(x.variables(), m_dataspec, 
-                                           finite, infinite, unused, 
+      data::detail::split_finite_variables(x.variables(), m_dataspec,
+                                           finite, infinite, unused,
                                            [&free_variables](const data::variable& v){ return free_variables.count(v)>0; });
       if (finite.empty())
       {
@@ -187,7 +187,7 @@ struct enumerate_quantifiers_builder: public simplify_data_rewriter_builder<Deri
       data::variable_list enumerable;
       data::variable_list non_enumerable;
       data::variable_list unused;
-      data::detail::split_enumerable_variables(x.variables(), m_dataspec, super::R, 
+      data::detail::split_enumerable_variables(x.variables(), m_dataspec, super::R,
                                                enumerable, non_enumerable, unused,
                                                [&free_variables](const data::variable& v){ return free_variables.count(v)>0; });
       if (enumerable.empty())
@@ -195,7 +195,7 @@ struct enumerate_quantifiers_builder: public simplify_data_rewriter_builder<Deri
         data::optimized_exists_no_empty_domain(result, non_enumerable, result, remove_unused_variables);
       }
       else
-      { 
+      {
         pbes_expression phi_;
         enumerate_exists(phi_, enumerable, result);
         data::optimized_exists_no_empty_domain(result, non_enumerable, phi_, remove_unused_variables);
@@ -206,8 +206,8 @@ struct enumerate_quantifiers_builder: public simplify_data_rewriter_builder<Deri
       data::variable_list finite;
       data::variable_list infinite;
       data::variable_list unused;
-      data::detail::split_finite_variables(x.variables(), m_dataspec, 
-                                           finite, infinite, unused, 
+      data::detail::split_finite_variables(x.variables(), m_dataspec,
+                                           finite, infinite, unused,
                                            [&free_variables](const data::variable& v){ return free_variables.count(v)>0; });
       if (finite.empty())
       {
@@ -232,7 +232,7 @@ struct enumerate_quantifiers_builder: public simplify_data_rewriter_builder<Deri
   }
 
   // N.B. This function has been added to make this class operate well with the enumerator.
-  //      that employs the "make_rewrite" variant with an explicit result. 
+  //      that employs the "make_rewrite" variant with an explicit result.
   void operator()(pbes_expression& result, const pbes_expression& x, MutableSubstitution&)
   {
     derived().apply(result, x);
@@ -310,19 +310,19 @@ struct enumerate_quantifiers_rewriter
       m_id_generator.clear();
     }
 
-    /// \brief Create a clone of the rewriter in which the underlying rewriter is copied, and not passed as a shared pointer. 
-    /// \details This is useful when the rewriter is used in different parallel processes. One rewriter can only be used sequentially. 
-    /// \return A rewriter, with a copy of the underlying jitty, jittyc or jittyp rewriting engine. 
+    /// \brief Create a clone of the rewriter in which the underlying rewriter is copied, and not passed as a shared pointer.
+    /// \details This is useful when the rewriter is used in different parallel processes. One rewriter can only be used sequentially.
+    /// \return A rewriter, with a copy of the underlying jitty, jittyc or jittyp rewriting engine.
     enumerate_quantifiers_rewriter clone()
     {
       return enumerate_quantifiers_rewriter(m_rewriter.clone(), m_dataspec, m_enumerate_infinite_sorts);
     }
 
-    /// \brief Initialises this rewriter with thread dependent information. 
+    /// \brief Initialises this rewriter with thread dependent information.
     /// \details This function sets a pointer to the m_busy_flag and m_forbidden_flag of this.
     ///          process, such that rewriter can access these faster than via the general thread.
     ///          local mechanism. It is expected that this is not needed when compilers become.
-    ///          faster, and should be removed in due time. 
+    ///          faster, and should be removed in due time.
     void thread_initialise()
     {
       m_rewriter.thread_initialise();

--- a/libraries/pbes/include/mcrl2/pbes/rewriters/simplify_rewriter.h
+++ b/libraries/pbes/include/mcrl2/pbes/rewriters/simplify_rewriter.h
@@ -193,7 +193,7 @@ template <typename Derived>
 struct simplify_builder: public add_simplify<pbes_system::pbes_expression_builder, Derived>
 { };
 
-template <typename Derived, typename DataRewriter, typename MutableSubstitution, typename PbesSubstitution = pbes_system::no_substitution>
+template <typename Derived, typename DataRewriter, typename MutableSubstitution, typename PbesSubstitution>
 struct simplify_data_rewriter_builder : public add_data_rewriter<pbes_system::detail::simplify_builder, Derived, DataRewriter, MutableSubstitution>
 {
   using super = add_data_rewriter<pbes_system::detail::simplify_builder, Derived, DataRewriter, MutableSubstitution>;
@@ -204,7 +204,7 @@ struct simplify_data_rewriter_builder : public add_data_rewriter<pbes_system::de
   using substitution_administration_type = data::detail::substitution_updater_with_an_identifier_generator<MutableSubstitution,
                                                                   data::enumerator_identifier_generator>;
   substitution_administration_type substitution_administration;
-  const PbesSubstitution m_sigma_pbes = no_substitution();
+  const PbesSubstitution& m_sigma_pbes;
 
   simplify_data_rewriter_builder(const DataRewriter& R, MutableSubstitution& sigma)
     : super(R, sigma),
@@ -288,7 +288,7 @@ struct apply_data_rewriter_with_pbes_substitution_builder
 
   apply_data_rewriter_with_pbes_substitution_builder(const DataRewriter& R,
     MutableSubstitution& sigma)
-    : super(R, sigma)
+    : super(R, sigma, no_substitution())
   {}
 };
 

--- a/libraries/pbes/include/mcrl2/pbes/substitutions.h
+++ b/libraries/pbes/include/mcrl2/pbes/substitutions.h
@@ -196,6 +196,24 @@ class propositional_variable_substitution
     }
 };
 
+// Compose two substitution functions.
+// Fist, we attempt to apply sigma1; if that does not change X, we apply sigma 2.
+inline
+std::function<pbes_expression(const propositional_variable_instantiation&)> compose_substitutions(
+  const std::function<pbes_expression(const propositional_variable_instantiation&)> sigma1,
+  const std::function<pbes_expression(const propositional_variable_instantiation&)> sigma2)
+  {
+    return [sigma1, sigma2](const propositional_variable_instantiation& X)
+    {
+      pbes_expression result = sigma1(X);
+      if (result != X)
+      {
+        return result;
+      }
+      return sigma2(X);
+    };
+  }
+
 } // namespace mcrl2::pbes_system
 
 

--- a/libraries/pbes/include/mcrl2/pbes/substitutions.h
+++ b/libraries/pbes/include/mcrl2/pbes/substitutions.h
@@ -13,9 +13,17 @@
 #define MCRL2_PBES_SUBSTITUTIONS_H
 
 #include "mcrl2/data/substitutions/mutable_map_substitution.h"
+#include "mcrl2/pbes/pbes_expression.h"
 #include "mcrl2/pbes/replace.h"
 
 namespace mcrl2::pbes_system {
+
+/// \brief An empty struct that can be used to indicate that there
+///        is no substitution that should be applied to propositional variables
+struct no_substitution
+{
+  const propositional_variable_instantiation& operator()(const propositional_variable_instantiation& v) { return v; }
+};
 
 /** \brief Substitution function for propositional variables
  *

--- a/tools/release/pbessolvesymbolic/pbessolvesymbolic.cpp
+++ b/tools/release/pbessolvesymbolic/pbessolvesymbolic.cpp
@@ -73,6 +73,7 @@ public:
     const propositional_variable_instantiation& X,
     const pbes_expression& psi) override
   {
+    assert(&result != &psi); // precondition for simplify
     std::vector<std::uint32_t> singleton;
     bool changed = false;
     std::smatch match;
@@ -80,7 +81,8 @@ public:
     mCRL2log(log::debug) << "X = " << X << ", psi = " << psi << std::endl;
     if (!std::regex_match(static_cast<const std::string&>(X.name()), match, mcrl2::pbes_system::detail::positive_or_negative))
     {
-      replace_propositional_variables(
+      simplify_rewriter simplify;
+      simplify(
           result,
           psi,
           [&](const propositional_variable_instantiation& Y) -> pbes_expression
@@ -159,14 +161,8 @@ public:
 
     }
 
-    if (changed)
-    {
-        simplify_rewriter simplify;
-        const pbes_expression result1 = result;
-        simplify(result, result1);
-    }
-
-    mCRL2log(log::debug) << "result = " << psi << std::endl;
+    mCRL2log(log::trace) << "rewrite_star: right hand side changed to " << result << "\n" << std::endl;
+    mCRL2log(log::debug) << "result = " << result << std::endl;
     const pbes_expression result2 = result;
     pbesinst_structure_graph_algorithm::rewrite_psi(thread_index, result, symbol, X, result2);
   }


### PR DESCRIPTION
Equip simplifying pbes rewriters and the enumerate quantifiers rewriter with a PBES substitution (mapping a propositional variable instantiation onto a pbes expression).

This enables more simplifications during rewriting, and hence may avoid exploring parts of the expressions.

This is a preparation for combining some of the steps in pbessolve.