### PR TITLE
Fix enumerate_quantifiers rewriter when using pbes substitutions

### DIFF
--- a/libraries/pbes/include/mcrl2/pbes/pbesinst_lazy_counter_example.h
+++ b/libraries/pbes/include/mcrl2/pbes/pbesinst_lazy_counter_example.h
@@ -84,6 +84,12 @@ struct rewrite_star_substitution
   {}
 
   pbes_expression operator()(const propositional_variable_instantiation& Y) const {
+    // the rewrite_star substitution is only applicable to closed PVIs.
+    if(!find_free_variables(Y).empty())
+    {
+      return Y;
+    }
+
     std::smatch match;
 
     // Now we need to find all reachable X --> Y, following vertices that are not ranked.

--- a/libraries/pbes/include/mcrl2/pbes/rewriters/data_rewriter.h
+++ b/libraries/pbes/include/mcrl2/pbes/rewriters/data_rewriter.h
@@ -73,17 +73,16 @@ struct add_data_rewriter: public Builder<Derived>
   template <class T>
   void apply(T& result, const propositional_variable_instantiation& x)
   {
-    make_propositional_variable_instantiation(
-              result,
-              x.name(),
-              [this, &x](data::data_expression_list& r) -> void
-                  { atermpp::make_term_list<data::data_expression>(
-                               r,
-                               x.parameters().begin(),
-                               x.parameters().end(),
-                               [this](data::data_expression& r1, const data::data_expression& arg) -> void
-                                     { data_rewrite(r1, arg, R, sigma); } ) ;
-                  });
+    make_propositional_variable_instantiation(result,
+                              x.name(),
+                              [this, &x](data::data_expression_list& r) -> void
+                              {
+                                atermpp::make_term_list<data::data_expression>(r,
+                                  x.parameters().begin(),
+                                  x.parameters().end(),
+                                  [this](data::data_expression& r1, const data::data_expression& arg) -> void
+                                  { data_rewrite(r1, arg, R, sigma); });
+                              });
   }
 };
 

--- a/libraries/pbes/include/mcrl2/pbes/rewriters/enumerate_quantifiers_rewriter.h
+++ b/libraries/pbes/include/mcrl2/pbes/rewriters/enumerate_quantifiers_rewriter.h
@@ -156,7 +156,13 @@ struct enumerate_quantifiers_builder: public simplify_data_rewriter_builder<Deri
       {
         pbes_expression phi_;
         enumerate_forall(phi_, enumerable, result);
-        data::optimized_forall_no_empty_domain(result, non_enumerable, phi_, remove_unused_variables);
+        if constexpr (!std::is_same_v<PbesSubstitution, no_substitution>)
+        {
+          // we need to rewrite the new body again to deal properly with PBES substitutions
+          // TODO: update enumerate_forall such that it uses the rewriter in derived() during enumeration
+          derived().apply(result, phi_);
+        }
+        data::optimized_forall_no_empty_domain(result, non_enumerable, result, remove_unused_variables);
       }
     }
     else
@@ -175,7 +181,13 @@ struct enumerate_quantifiers_builder: public simplify_data_rewriter_builder<Deri
       {
         pbes_expression phi_;
         enumerate_forall(phi_, finite, result);
-        data::optimized_forall_no_empty_domain(result, infinite, phi_, remove_unused_variables);
+        if constexpr (!std::is_same_v<PbesSubstitution, no_substitution>)
+        {
+          // we need to rewrite the new body again to deal properly with PBES substitutions
+          // TODO: update enumerate_forall such that it uses the rewriter in derived() during enumeration
+          derived().apply(result, phi_);
+        }
+        data::optimized_forall_no_empty_domain(result, infinite, result, remove_unused_variables);
       }
     }
     redo_substitution(x.variables(), undo);
@@ -204,6 +216,12 @@ struct enumerate_quantifiers_builder: public simplify_data_rewriter_builder<Deri
       {
         pbes_expression phi_;
         enumerate_exists(phi_, enumerable, result);
+        if constexpr (!std::is_same_v<PbesSubstitution, no_substitution>)
+        {
+          // we need to rewrite the new body again to deal properly with PBES substitutions
+          // TODO: update enumerate_exists such that it uses the rewriter in derived() during enumeration
+          derived().apply(result, phi_);
+        }
         data::optimized_exists_no_empty_domain(result, non_enumerable, phi_, remove_unused_variables);
       }
     }
@@ -223,6 +241,12 @@ struct enumerate_quantifiers_builder: public simplify_data_rewriter_builder<Deri
       {
         pbes_expression phi_;
         enumerate_exists(phi_, finite, result);
+        if constexpr (!std::is_same_v<PbesSubstitution, no_substitution>)
+        {
+          // we need to rewrite the new body again to deal properly with PBES substitutions
+          // TODO: update enumerate_exists such that it uses the rewriter in derived() during enumeration
+          derived().apply(result, phi_);
+        }
         data::optimized_exists_no_empty_domain(result, infinite, phi_, remove_unused_variables);
       }
     }

--- a/libraries/pbes/include/mcrl2/pbes/rewriters/simplify_rewriter.h
+++ b/libraries/pbes/include/mcrl2/pbes/rewriters/simplify_rewriter.h
@@ -219,7 +219,7 @@ struct simplify_data_rewriter_builder : public add_data_rewriter<pbes_system::de
 
   MutableSubstitution& substitution()
   {
-    substitution_administration.substitution();
+    return substitution_administration.substitution();
   }
 
 

--- a/libraries/pbes/test/rewriter_test.cpp
+++ b/libraries/pbes/test/rewriter_test.cpp
@@ -381,6 +381,7 @@ BOOST_AUTO_TEST_CASE(test_simplifying_data_rewriter_with_pbes_substitution)
   test_simplify(R_substitution, r, "forall n: Nat. val(b) && Y(n)", "forall n: Nat. val(b) && Y(n)", "simplify_with_data_and_pbes_substitution");
   test_simplify(R_substitution, r, "forall n: Nat. val(b)", "val(b)", "simplify_with_data_and_pbes_substitution");
   test_simplify(R_substitution, r, "forall m: Nat. val(m > 2) && X", "(forall m: Nat. val(m > 2))", "simplify_with_data_and_pbes_substitution");
+  test_simplify(R_substitution, r, "forall m: Nat. val(m == 1) => !Y(m)", "forall m: Nat. val(m == 1) => !Y(m)", "simplify_with_data_and_pbes_substitution");
 }
 
 BOOST_AUTO_TEST_CASE(test_enumerate_quantifiers_rewriter)
@@ -512,6 +513,9 @@ BOOST_AUTO_TEST_CASE(test_enumerate_quantifiers_rewriter_with_pbes_substitution)
   test_rewriters(N(R_substitution), N(r), "forall n: Nat . val(n > 1)", "false");
   test_rewriters(N(R_substitution), N(r), "forall n: Nat . val(n > 0)", "false");
   test_rewriters(N(R_substitution), N(r), "forall p: Pos . val(p > 0)", "true");
+  test_rewriters(N(R_substitution), N(r), "forall m: Nat. val(m == 1) => !Y(m)", "true");
+  test_rewriters(N(R_substitution), N(r), "forall m: Nat. val(m < 5) => Y(m)", "false");
+  test_rewriters(N(R_substitution), N(r), "exists m: Nat. val(m < 5) && Y(m)", "Y(0) || Y(2) || Y(3) || Y(4)");
 }
 
 template <typename Rewriter1, typename Rewriter2>


### PR DESCRIPTION
When enumerating quantifiers, the body is only rewritten a priori, at which point the PBES substitutions may not yet be applicable. The substitution also needs to be applied to the body that results from enumeration.

A more elegant solution than rewriting the body twice would be to rewrite during enumeration.

This fixes an issue with the example_test reported by @jgroote.