### PR TITLE
Ensure rewrite_star substiutution is only applies to closed PVI

### DIFF
--- a/libraries/pbes/include/mcrl2/pbes/pbesinst_lazy_counter_example.h
+++ b/libraries/pbes/include/mcrl2/pbes/pbesinst_lazy_counter_example.h
@@ -87,6 +87,7 @@ struct rewrite_star_substitution
     // the rewrite_star substitution is only applicable to closed PVIs.
     if(!find_free_variables(Y).empty())
     {
+      mCRL2log(log::trace) << "rewrite_star " << Y << " contains free variables, not applying substitution\n";
       return Y;
     }
 

--- a/tools/release/pbessolvesymbolic/pbessolvesymbolic.cpp
+++ b/tools/release/pbessolvesymbolic/pbessolvesymbolic.cpp
@@ -149,6 +149,13 @@ public:
 
       pbes_expression operator()(const propositional_variable_instantiation& Y) const
       {
+        // the rewrite_star substitution is only applicable to closed PVIs.
+        if (!find_free_variables(Y).empty())
+        {
+          mCRL2log(log::trace) << "rewrite_star " << Y << " contains free variables, not applying substitution\n";
+          return Y;
+        }
+
         if (std::regex_match(static_cast<const std::string&>(Y.name()),
               match,
               mcrl2::pbes_system::detail::positive_or_negative))


### PR DESCRIPTION
This was already applied in the rewrite_star substitution used for the explicit solver in pbessolve, but not in the symbolic solver in pbessolvesymbolic.

This was uncovered by the random tests as pointed out by @mlaveaux.