### PR TITLE
Cache allow_list using unordered_set

### DIFF
--- a/libraries/lps/include/mcrl2/lps/linearise_allow_block.h
+++ b/libraries/lps/include/mcrl2/lps/linearise_allow_block.h
@@ -13,10 +13,12 @@
 #define MCRL2_LPS_LINEARISE_ALLLOW_BLOCK_H
 
 #include "mcrl2/atermpp/aterm_list.h"
+#include "mcrl2/core/identifier_string.h"
 #include "mcrl2/lps/deadlock_summand.h"
 #include "mcrl2/lps/detail/configuration.h"
 #include "mcrl2/lps/linearise_utility.h"
 #include "mcrl2/lps/stochastic_action_summand.h"
+#include "mcrl2/process/action_name_multiset.h"
 #include "mcrl2/process/process_expression.h"
 
 namespace mcrl2::lps
@@ -62,70 +64,58 @@ inline std::string log_allow_block_application(const lps_statistics_t& lps_stati
 
 /**************** allow/block *************************************/
 
-/// Determine if allow_action allows multi_action.
-///
-/// \param allow_action A sorted action_name_multiset a1|...|an
-/// \param multi_action A multiaction b1(d1)|...|bm(dm)
-/// \param termination_action The action that encodes successful termination (used only in debug mode)
-/// \returns n == m and ai == bi for 1 <= i <= n
-inline bool allow_(const process::action_name_multiset& allow_action,
-    const process::action_list& multi_action,
-    [[maybe_unused]]
-    const process::action&  termination_action)
+namespace detail
 {
-  /* The special cases where multiaction==tau and multiaction=={ Terminated } must have been
-     dealt with separately. */
-  assert(!multi_action.empty());
-  assert(multi_action != process::action_list({termination_action}));
-  assert(std::is_sorted(allow_action.names().begin(), allow_action.names().end(), process::action_name_compare()));
-  assert(std::is_sorted(multi_action.begin(), multi_action.end(), process::action_compare()));
+/// Cache for the allowed actions
+/// The cache is used to avoid linear searches in the allow list.
+using allow_list_cache = std::unordered_set<core::identifier_string_list>;
 
-  const core::identifier_string_list& names = allow_action.names();
-  // Note: names.size() and multi_action.size() are O(n) operations, so
-  // optimizing them as special case is not helpful.
-  // if (names.size() != multi_action.size())
-  // {
-  //   return false;
-  // }
-
-  core::identifier_string_list::const_iterator names_it = names.begin();
-  process::action_list::const_iterator multiaction_it = multi_action.begin();
-
-  while (names_it != names.end() && multiaction_it != multi_action.end())
+/// Calculate the allow_list_cache from the allow_list.
+/// This is used to speed up the lookups when determining is a multi-action is allowed.
+inline
+allow_list_cache make_allow_list_cache(const process::action_name_multiset_list& allowlist)
+{
+  allow_list_cache result;
+  for (const process::action_name_multiset& allow_action : allowlist)
   {
-    if (*names_it != multiaction_it->label().name())
-    {
-      return false;
-    }
-    ++names_it;
-    ++multiaction_it;
+    assert(std::is_sorted(allow_action.names().begin(), allow_action.names().end(), process::action_name_compare()));
+    result.insert(allow_action.names());
   }
+  return result;
+}
 
-  return names_it == names.end() && multiaction_it == multi_action.end();
+/// Calculate the list of action names that appear in a multi-action.
+inline
+core::identifier_string_list names(const process::action_list& multi_action)
+{
+  return core::identifier_string_list(
+    multi_action.begin(),
+    multi_action.end(),
+    [](const process::action& a)
+    {
+      return a.label().name();
+    });
+}
 }
 
 /// \brief Determine if multi_action is allowed by an allow expression in allow_list
 ///
 /// Calculates if the names of the action in multi_action match with an expression in allow_list.
 /// If multi_action is the termination action, or multi_action is the empty multiaction, the result is also true.
-inline bool allow_(const process::action_name_multiset_list& allow_list,
+inline bool allow_(const detail::allow_list_cache& allow_cache,
     const process::action_list& multi_action,
     const process::action& termination_action)
 {
+  assert(std::is_sorted(multi_action.begin(), multi_action.end(), process::action_compare()));
+
   // The empty multiaction and the termination action can never be blocked by allows.
   if (multi_action.empty() || multi_action == process::action_list({termination_action}))
   {
     return true;
   }
 
-  for (const process::action_name_multiset& allow_action : allow_list)
-  {
-    if (allow_(allow_action, multi_action, termination_action))
-    {
-      return true;
-    }
-  }
-  return false;
+  const core::identifier_string_list multi_action_names = detail::names(multi_action);
+  return allow_cache.find(multi_action_names) != allow_cache.end();
 }
 
 /// \brief Calculate if any of the actions in multiaction is blocked by encap_list.
@@ -221,6 +211,13 @@ inline void allowblockcomposition(
                                   << " delta summands";
   }
 
+  /// Cache the list of allowed actions, to avoid linear searches in the allow list.
+  detail::allow_list_cache allow_cache;
+  if (is_allow)
+  {
+    allow_cache = detail::make_allow_list_cache(allowlist);
+  }
+
   /* First add the resulting sums in two separate lists
    one for actions, and one for delta's. The delta's
    are added at the end to the actions, where for
@@ -235,7 +232,7 @@ inline void allowblockcomposition(
     const data::data_expression& condition = smmnd.condition();
 
     // Explicitly allow the termination action in any allow.
-    if ((is_allow && allow_(allowlist, multiaction, termination_action))
+    if ((is_allow && allow_(allow_cache, multiaction, termination_action))
         || (!is_allow && !encap(allowlist, multiaction)))
     {
       action_summands.push_back(smmnd);

--- a/libraries/lps/include/mcrl2/lps/linearise_communication.h
+++ b/libraries/lps/include/mcrl2/lps/linearise_communication.h
@@ -371,6 +371,7 @@ public:
         m_data_rewriter(data_rewriter),
         m_communications(sort_communications(communications)),
         m_allowlist(sort_multi_action_labels(allowlist)),
+        m_allow_cache(is_allow ? detail::make_allow_list_cache(allowlist) : detail::allow_list_cache()),
         m_blocked_actions(is_block ? get_actions(allowlist) : std::vector<core::identifier_string>()),
         m_allowed_actions(init_allowed_actions(is_allow, allowlist, termination_action)),
         m_comm_table(m_communications),
@@ -512,7 +513,7 @@ public:
       {
         const process::action_list& multiaction = multiactionconditionlist.actions[i];
 
-        if (m_is_allow && !allow_(m_allowlist, multiaction, m_terminationAction))
+        if (m_is_allow && !allow_(m_allow_cache, multiaction, m_terminationAction))
         {
           if constexpr (EnableLineariseStatistics) {
             ++disallowed_summands;
@@ -590,6 +591,7 @@ protected:
   DataRewriter& m_data_rewriter;
   const process::communication_expression_list m_communications;
   const process::action_name_multiset_list m_allowlist;         // This is a list of list of identifierstring.
+  const detail::allow_list_cache m_allow_cache; // This is a cache for allowlist, used to speed up lookups in allowlist. It contains the same information as allowlist, but in a different format that allows for faster lookups.
   const std::vector<core::identifier_string> m_blocked_actions; // used only if m_is_block is set
   const std::vector<core::identifier_string> m_allowed_actions; // used only if m_is_allow is set
   comm_entry m_comm_table;

--- a/libraries/lps/source/linearise.cpp
+++ b/libraries/lps/source/linearise.cpp
@@ -281,7 +281,7 @@ class specification_basic_type
     {
       if (objectdata.count(o)==0)
       {
-        throw mcrl2::runtime_error("Fail to recognize " + process::pp(o) + 
+        throw mcrl2::runtime_error("Fail to recognize " + process::pp(o) +
                                    ". Most likely due to unguarded recursion in a process equation. ");
       }
     }
@@ -1467,8 +1467,8 @@ class specification_basic_type
     std::set< variable > find_free_variables_process(const process_expression& p)
     {
       std::set<variable> free_variables_in_p_new;
-      free_variables_in_p_new=process::find_free_variables(p); 
-      return free_variables_in_p_new; 
+      free_variables_in_p_new=process::find_free_variables(p);
+      return free_variables_in_p_new;
     }
 
     /* Remove assignments that do not appear in the parameter list. */
@@ -1806,7 +1806,7 @@ class specification_basic_type
       }
 
       throw mcrl2::runtime_error("Internal error: expect a pCRL process (2) " + process::pp(p));
-      return process_expression(); 
+      return process_expression();
     }
 
 
@@ -3989,7 +3989,7 @@ class specification_basic_type
     /**************** Collectparameterlist ******************************/
 
     bool alreadypresent(variable& var,
-                        const variable_list& vl, 
+                        const variable_list& vl,
                         mutable_indexed_substitution<>& parameter_renaming)
     {
       /* Note: variables can be different, although they have the
@@ -4004,9 +4004,9 @@ class specification_basic_type
         {
           if (v.sort()==var.sort())
           {
-            return true; // The variable is present. 
+            return true; // The variable is present.
           }
-          else 
+          else
           {
             if (parameter_renaming(v)==v)
             {
@@ -4017,14 +4017,14 @@ class specification_basic_type
             }
             else
             {
-              // The variable var is renamed, and the renaming was already present. 
-              var=atermpp::down_cast<variable>(parameter_renaming(v)); 
+              // The variable var is renamed, and the renaming was already present.
+              var=atermpp::down_cast<variable>(parameter_renaming(v));
               return true;
             }
           }
         }
       }
-      return false; // The variable var is not present. 
+      return false; // The variable var is not present.
     }
 
     variable_list joinparameters(const variable_list& par1,
@@ -4049,9 +4049,9 @@ class specification_basic_type
       return result;
     }
 
-    // While collecting the parameter list the process parameters that are part of the process identifiers may change. 
-    // This means the list pCRLprocs may change. 
-    variable_list collectparameterlist(std::set<process_identifier>& pCRLprocs) 
+    // While collecting the parameter list the process parameters that are part of the process identifiers may change.
+    // This means the list pCRLprocs may change.
+    variable_list collectparameterlist(std::set<process_identifier>& pCRLprocs)
                                        // mutable_indexed_substitution<>& parameter_renaming)
     {
       mutable_indexed_substitution<> parameter_renaming;  // Used to rename variables with the same name but different sorts.
@@ -4061,7 +4061,7 @@ class specification_basic_type
         const objectdatatype& object=objectIndex(p);
         parameters=joinparameters(parameters,object.parameters, parameter_renaming);
       }
-      // Apply the parameter renaming. 
+      // Apply the parameter renaming.
       std::set<process_identifier> new_pCRLprocs;
       for (const process_identifier& p: pCRLprocs)
       {
@@ -5078,7 +5078,7 @@ class specification_basic_type
       const bool regular,
       const bool singlestate,
       const variable_list& process_parameters)
-      
+
     {
       data_expression atTime;
       action_list multiAction;
@@ -7595,6 +7595,11 @@ class specification_basic_type
       const bool is_block,
       stochastic_action_summand_vector& action_summands)
     {
+      lps::detail::allow_list_cache allow_cache;
+      if(is_allow)
+      {
+        allow_cache = lps::detail::make_allow_list_cache(allowlist);
+      }
       for (const stochastic_action_summand& summand1: action_summands1)
       {
         variable_list sumvars=ultimate_delay_condition.variables();
@@ -7612,7 +7617,7 @@ class specification_basic_type
 
         if (multiaction1 != action_list({ terminationAction }))
         {
-          if (is_allow && !allow_(allowlist,multiaction1,terminationAction))
+          if (is_allow && !allow_(allow_cache,multiaction1,terminationAction))
           {
             continue;
           }
@@ -7801,6 +7806,12 @@ class specification_basic_type
           const bool is_block,
           stochastic_action_summand_vector& action_summands)
     {
+      lps::detail::allow_list_cache allow_cache;
+      if(is_allow)
+      {
+        allow_cache = lps::detail::make_allow_list_cache(allowlist);
+      }
+
       // First combine the action summands.
       for (const stochastic_action_summand& summand1: action_summands1)
       {
@@ -7832,7 +7843,7 @@ class specification_basic_type
               multiaction3=linMergeMultiActionList(multiaction1,multiaction2);
             }
 
-            if (is_allow && !allow_(allowlist,multiaction3,terminationAction))
+            if (is_allow && !allow_(allow_cache,multiaction3,terminationAction))
             {
               continue;
             }

--- a/libraries/lps/test/linearise_allow_block_test.cpp
+++ b/libraries/lps/test/linearise_allow_block_test.cpp
@@ -44,41 +44,63 @@ process::action make_action(const std::string& name, const data::data_expression
 }
 
 inline
-action_name_multiset allow_ab()
+detail::allow_list_cache allow_ab()
 {
   core::identifier_string_list result;
   result.push_front(core::identifier_string("b"));
   result.push_front(core::identifier_string("a"));
-  return action_name_multiset(result);
+  process::action_name_multiset_list multiset_list;
+  multiset_list.push_front(process::action_name_multiset(result));
+  return detail::make_allow_list_cache(multiset_list);
 }
 
 inline
-action_name_multiset allow_abb()
+detail::allow_list_cache allow_abb()
 {
   core::identifier_string_list result;
   result.push_front(core::identifier_string("b"));
   result.push_front(core::identifier_string("b"));
   result.push_front(core::identifier_string("a"));
-  return action_name_multiset(result);
+  process::action_name_multiset_list multiset_list;
+  multiset_list.push_front(process::action_name_multiset(result));
+  return detail::make_allow_list_cache(multiset_list);
 }
 
 inline
-action_name_multiset allow_cd()
+detail::allow_list_cache allow_cd()
 {
   core::identifier_string_list result;
   result.push_front(core::identifier_string("d"));
   result.push_front(core::identifier_string("c"));
-  return action_name_multiset(result);
+  process::action_name_multiset_list multiset_list;
+  multiset_list.push_front(process::action_name_multiset(result));
+  return detail::make_allow_list_cache(multiset_list);
 }
 
 inline
-action_name_multiset_list allow_ab_abb_cd()
+detail::allow_list_cache allow_ab_abb_cd()
 {
-  action_name_multiset_list result;
-  result.push_front(allow_cd());
-  result.push_front(allow_abb());
-  result.push_front(allow_ab());
-  return result;
+  process::action_name_multiset_list result;
+
+  // Create multisets for each allowed action
+  core::identifier_string_list ab;
+  ab.push_front(core::identifier_string("b"));
+  ab.push_front(core::identifier_string("a"));
+
+  core::identifier_string_list abb;
+  abb.push_front(core::identifier_string("b"));
+  abb.push_front(core::identifier_string("b"));
+  abb.push_front(core::identifier_string("a"));
+
+  core::identifier_string_list cd;
+  cd.push_front(core::identifier_string("d"));
+  cd.push_front(core::identifier_string("c"));
+
+  result.push_front(process::action_name_multiset(cd));
+  result.push_front(process::action_name_multiset(abb));
+  result.push_front(process::action_name_multiset(ab));
+
+  return detail::make_allow_list_cache(result);
 }
 
 BOOST_AUTO_TEST_CASE(test_single_allow)

--- a/libraries/lps/test/linearise_communication_test.cpp
+++ b/libraries/lps/test/linearise_communication_test.cpp
@@ -9,6 +9,7 @@
 /// \file linearise_communication_test.cpp
 /// \brief Test for applying communication operator
 
+#include "mcrl2/lps/linearise_allow_block.h"
 #define BOOST_TEST_MODULE linearise_communication_test
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/test/included/unit_test.hpp>
@@ -34,10 +35,11 @@ BOOST_GLOBAL_FIXTURE(LogDebug);
 inline
 lps::detail::tuple_list filter_allow(const lps::detail::tuple_list& l, const action_name_multiset_list& allowed)
 {
+  lps::detail::allow_list_cache allow_cache = lps::detail::make_allow_list_cache(allowed);
   lps::detail::tuple_list result;
   for (std::size_t i = 0; i < l.size(); ++i)
   {
-    if (allow_(allowed, l.actions[i], action(action_label("Terminate", data::sort_expression_list()), data::data_expression_list())))
+    if (allow_(allow_cache, l.actions[i], action(action_label("Terminate", data::sort_expression_list()), data::data_expression_list())))
     {
       result.conditions.push_back(l.conditions[i]);
       result.actions.push_back(l.actions[i]);


### PR DESCRIPTION
Instead of performing a linear search through the allow_list for every multi-action (and thus for every summand), cache the multi-action names in the allow_list using an unordered set once (outside the loops over all summands), and use this cache to determine if a multiaction is allowed or not.

For the Cordis Cylinder model, this further reduces a run of `mcrl22lps` from +/-200s to +/- 37s.

The usefulness of introducing the cache was very quicly observed by github copilot, but the code is my own.