### PR TITLE
Chore: Bump lace to version 1.6.3

### DIFF
--- a/3rd-party/lace/CMakeLists.txt
+++ b/3rd-party/lace/CMakeLists.txt
@@ -1,39 +1,39 @@
-cmake_minimum_required(VERSION 3.15)
+﻿cmake_minimum_required(VERSION 3.23...3.31)
 cmake_policy(SET CMP0092 NEW) # do not automatically add /W3 for MSVC
 
 project(lace
-    VERSION 1.6.0
+    VERSION 1.6.3
     DESCRIPTION "Lace, a work-stealing framework for multi-core fork-join parallelism"
     HOMEPAGE_URL "https://github.com/trolando/lace"
     LANGUAGES C
 )
 
-# if we ever go to 3.21, use PROJECT_IS_TOP_LEVEL
-string(COMPARE EQUAL "${CMAKE_SOURCE_DIR}" "${CMAKE_CURRENT_SOURCE_DIR}" lace_is_top_level)
+# ── Build defaults ───────────────────────────────────────────────────────────
 
-set(lace_VERSION ${PROJECT_VERSION} CACHE INTERNAL "Lace version")
-
-if(lace_is_top_level AND NOT CMAKE_CONFIGURATION_TYPES)
-    # Default to Release when building as top project
-    if(NOT CMAKE_BUILD_TYPE)
-        set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Build type" FORCE)
-    endif()
-    set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release" "RelWithDebInfo" "MinSizeRel")
+if(lace_IS_TOP_LEVEL AND NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+    set(CMAKE_BUILD_TYPE Release CACHE STRING "Build type" FORCE)
+    set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS Debug Release RelWithDebInfo MinSizeRel)
 endif()
 
-list(INSERT CMAKE_MODULE_PATH 0 "${CMAKE_CURRENT_LIST_DIR}/cmake")
+if(lace_IS_TOP_LEVEL)
+    set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+endif()
 
+list(PREPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
+
+# ── Options ──────────────────────────────────────────────────────────────────
+
+option(BUILD_SHARED_LIBS "Build shared libraries instead of static"                  OFF)
+option(LACE_ENABLE_PIC   "Build Lace with -fPIC (e.g. for linking into shared libs)" OFF)
+option(LACE_NATIVE_OPT   "Enable -march=native for compiler optimizations"           ON)
+option(LACE_BACKOFF      "Let idle threads sleep if there is no work"                ON)
+option(LACE_USE_HWLOC    "Let Lace pin threads/memory using libhwloc"                OFF)
 option(LACE_PIE_TIMES    "Let Lace record Pie times"                                 OFF)
 option(LACE_COUNT_TASKS  "Let Lace record the number of tasks"                       OFF)
 option(LACE_COUNT_STEALS "Let Lace count #steals and #leaps"                         OFF)
 option(LACE_COUNT_SPLITS "Let Lace count #splits"                                    OFF)
-option(LACE_USE_HWLOC    "Let Lace pin threads/memory using libhwloc"                OFF)
-option(LACE_BACKOFF      "Let idle threads sleep if there is no work"                ON)
-option(LACE_NATIVE_OPT   "Enable -march=native for compiler optimizations"           OFF)
-option(LACE_ENABLE_PIC   "Build Lace with -fPIC (e.g. for linking into shared libs)" OFF)
-option(BUILD_SHARED_LIBS "Build shared libraries instead of static"                  OFF)
 
-if(lace_is_top_level)
+if(lace_IS_TOP_LEVEL)
     option(LACE_BUILD_TESTS      "Build and run Lace tests"                          ON)
     option(LACE_BUILD_BENCHMARKS "Build Lace benchmark programs"                     ON)
     option(LACE_SANITIZE_ADDRESS "Enable AddressSanitizer"                           OFF)
@@ -41,40 +41,26 @@ if(lace_is_top_level)
     option(LACE_SANITIZE_UB      "Enable UndefinedBehaviorSanitizer"                 OFF)
 endif()
 
+if(BUILD_SHARED_LIBS)
+    message(WARNING
+        "Building Lace as a shared library is not recommended. PLT indirection "
+        "on hot paths hurts performance, and Lace must be instantiated exactly "
+        "once per process. Instead, build Lace as a static library with LACE_ENABLE_PIC "
+        "and link it into your shared library or executable."
+    )
+endif()
+
+# ── Platform feature detection ───────────────────────────────────────────────
+
 include(CheckSymbolExists)
 check_symbol_exists(sched_getaffinity "sched.h" HAVE_SCHED_GETAFFINITY)
 check_symbol_exists(mmap "sys/mman.h" HAVE_MMAP)
 
 if(NOT WIN32 AND NOT HAVE_MMAP)
-    # Note: in WIN32, we can always use VirtualAlloc so we do not check then
-    message(ERROR " mmap not found?!")
+    message(FATAL_ERROR "mmap not found (required on non-Windows platforms)")
 endif()
 
-if(LACE_SANITIZE_ADDRESS AND LACE_SANITIZE_THREAD)
-   message(FATAL_ERROR "AddressSanitizer and ThreadSanitizer cannot be used together")
-endif()
-
-set(lace_sanitizer_flags "")
-if(lace_is_top_level)
-    if(LACE_SANITIZE_ADDRESS)
-        list(APPEND lace_sanitizer_flags -fsanitize=address -fno-omit-frame-pointer)
-    endif()
-    if(LACE_SANITIZE_THREAD)
-        list(APPEND lace_sanitizer_flags -fsanitize=thread)
-    endif()
-    if(LACE_SANITIZE_UB)
-        list(APPEND lace_sanitizer_flags -fsanitize=undefined)
-    endif()
-endif()
-
-if(lace_sanitizer_flags)
-    if(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang")
-        add_compile_options(${lace_sanitizer_flags})
-        add_link_options(${lace_sanitizer_flags})
-    else()
-        message(WARNING "Sanitizers requested but not supported by compiler '${CMAKE_C_COMPILER_ID}' -- ignoring")
-    endif()
-endif()
+# ── Dependencies ─────────────────────────────────────────────────────────────
 
 if(NOT MSVC)
     find_package(Threads REQUIRED)
@@ -84,32 +70,79 @@ if(LACE_USE_HWLOC)
     find_package(HWLOC REQUIRED)
 endif()
 
-if(BUILD_SHARED_LIBS)
-    set(LACE_ENABLE_PIC ON)
-endif()
+# ── Sanitizer support (top-level builds only) ────────────────────────────────
 
-foreach(_target lace lace14)
-    if(_target STREQUAL "lace")
-        set(_src ${CMAKE_CURRENT_SOURCE_DIR}/src/lace.c ${CMAKE_CURRENT_SOURCE_DIR}/src/lace.h)
-    else()
-        set(_src ${CMAKE_CURRENT_SOURCE_DIR}/src/lace14.c ${CMAKE_CURRENT_SOURCE_DIR}/src/lace14.h)
+if(lace_IS_TOP_LEVEL)
+    if(LACE_SANITIZE_ADDRESS AND LACE_SANITIZE_THREAD)
+        message(FATAL_ERROR "AddressSanitizer and ThreadSanitizer cannot be combined")
     endif()
 
-    add_library(${_target} ${_src})
+    set(_san "")
+    if(LACE_SANITIZE_ADDRESS)
+        list(APPEND _san "address")
+    endif()
+    if(LACE_SANITIZE_THREAD)
+        list(APPEND _san "thread")
+    endif()
+    if(LACE_SANITIZE_UB)
+        list(APPEND _san "undefined")
+    endif()
+
+    if(_san)
+        if(NOT CMAKE_C_COMPILER_ID MATCHES "GNU|Clang")
+            message(FATAL_ERROR "Sanitizers are not supported with compiler '${CMAKE_C_COMPILER_ID}'")
+        endif()
+        string(REPLACE ";" "," _san_list "${_san}")
+        set(_san_flags "-fsanitize=${_san_list} -fno-omit-frame-pointer")
+        string(APPEND CMAKE_C_FLAGS             " ${_san_flags}")
+        string(APPEND CMAKE_CXX_FLAGS           " ${_san_flags}")
+        string(APPEND CMAKE_EXE_LINKER_FLAGS    " ${_san_flags}")
+        string(APPEND CMAKE_SHARED_LINKER_FLAGS " ${_san_flags}")
+        string(APPEND CMAKE_MODULE_LINKER_FLAGS " ${_san_flags}")
+        message(STATUS "Sanitizers enabled: ${_san_list}")
+    endif()
+    unset(_san)
+endif()
+
+# ── Generated header (before targets, so FILE_SET can reference it) ──────────
+
+configure_file(src/lace_config.h.in ${CMAKE_CURRENT_BINARY_DIR}/lace_config.h @ONLY)
+
+# ── Library targets ──────────────────────────────────────────────────────────
+
+foreach(_target lace lace14)
+
+    # ── Sources and public headers ───────────────────────────────────────
+    add_library(${_target})
     add_library(lace::${_target} ALIAS ${_target})
 
+    if(_target STREQUAL "lace")
+        target_sources(${_target}
+          PRIVATE src/lace.c
+          PUBLIC  FILE_SET HEADERS
+                  BASE_DIRS src ${CMAKE_CURRENT_BINARY_DIR}
+                  FILES src/lace.h ${CMAKE_CURRENT_BINARY_DIR}/lace_config.h
+        )
+    else()
+        target_sources(${_target}
+          PRIVATE src/lace14.c
+          PUBLIC  FILE_SET HEADERS
+                  BASE_DIRS src ${CMAKE_CURRENT_BINARY_DIR}
+                  FILES src/lace14.h ${CMAKE_CURRENT_BINARY_DIR}/lace_config.h
+        )
+    endif()
+
+    # ── Compile features ─────────────────────────────────────────────────
     target_compile_features(${_target} PUBLIC c_std_11)
 
-    target_include_directories(${_target}
-        PUBLIC
-            $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/src>
-            $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
-            $<INSTALL_INTERFACE:include>
-    )
+    # ── PIC ──────────────────────────────────────────────────────────────
+    if(BUILD_SHARED_LIBS OR LACE_ENABLE_PIC)
+        set_target_properties(${_target} PROPERTIES POSITION_INDEPENDENT_CODE ON)
+    endif()
 
-    set_target_properties(${_target} PROPERTIES POSITION_INDEPENDENT_CODE ${LACE_ENABLE_PIC})
+    # ── Compiler flags ───────────────────────────────────────────────────
 
-    # we're adding quite a few extra warnings, to ensure Lace as a library is compliant with the 
+    # we're adding quite a few extra warnings, to ensure Lace as a library is compliant with the
     # C standard and won't trigger warnings or errors when included in a stricter project
 
     if(CMAKE_C_COMPILER_ID MATCHES "GNU")
@@ -154,27 +187,33 @@ foreach(_target lace lace14)
         )
     endif()
 
+    # ── Link dependencies ────────────────────────────────────────────────
     if(NOT MSVC)
         target_link_libraries(${_target} PUBLIC Threads::Threads)
+    endif()
+
+    if(WIN32)
+        target_link_libraries(${_target} PUBLIC synchronization)
     endif()
 
     if(LACE_USE_HWLOC)
         target_link_libraries(${_target} PUBLIC HWLOC::hwloc)
     endif()
 
-    set_target_properties(${_target} PROPERTIES
-        VERSION ${PROJECT_VERSION}
-        SOVERSION ${PROJECT_VERSION_MAJOR}
-        ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lib
-        LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lib
-        RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/bin
-        WINDOWS_EXPORT_ALL_SYMBOLS ${BUILD_SHARED_LIBS}
-    )
+    # ── Shared library versioning ────────────────────────────────────────
+    if(BUILD_SHARED_LIBS)
+        set_target_properties(${_target} PROPERTIES
+            VERSION   ${PROJECT_VERSION}
+            SOVERSION ${PROJECT_VERSION_MAJOR}
+            WINDOWS_EXPORT_ALL_SYMBOLS ON
+        )
+    endif()
+
 endforeach()
 
-configure_file(src/lace_config.h.in ${CMAKE_CURRENT_BINARY_DIR}/lace_config.h @ONLY)
+# ── Tests and benchmarks (top-level only) ────────────────────────────────────
 
-if(lace_is_top_level)
+if(lace_IS_TOP_LEVEL)
     enable_language(CXX)
 
     if(LACE_BUILD_BENCHMARKS)
@@ -188,26 +227,41 @@ if(lace_is_top_level)
     endif()
 endif()
 
+# ── Hide options when consumed as a subproject ───────────────────────────────
+
+if(NOT lace_IS_TOP_LEVEL)
+    mark_as_advanced(
+        BUILD_SHARED_LIBS
+        LACE_ENABLE_PIC
+        LACE_NATIVE_OPT
+        LACE_BACKOFF
+        LACE_USE_HWLOC
+        LACE_PIE_TIMES
+        LACE_COUNT_TASKS
+        LACE_COUNT_STEALS
+        LACE_COUNT_SPLITS
+    )
+endif()
+
+# ── Installation ─────────────────────────────────────────────────────────────
+
 include(GNUInstallDirs)
 
 install(TARGETS lace lace14
     EXPORT lace-targets
-    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-    INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    ARCHIVE       DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    LIBRARY       DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    RUNTIME       DESTINATION ${CMAKE_INSTALL_BINDIR}
+    FILE_SET HEADERS DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
-install(FILES 
-    "${CMAKE_CURRENT_SOURCE_DIR}/src/lace.h"
-    "${CMAKE_CURRENT_SOURCE_DIR}/src/lace14.h"
-    "${CMAKE_CURRENT_BINARY_DIR}/lace_config.h"
-    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-)
+
 install(EXPORT lace-targets
-    FILE lace-targets.cmake
+    FILE      lace-targets.cmake
     NAMESPACE lace::
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/lace
 )
+
+# ── CMake package config ─────────────────────────────────────────────────────
 
 include(CMakePackageConfigHelpers)
 
@@ -227,8 +281,11 @@ install(
     FILES
         ${CMAKE_CURRENT_BINARY_DIR}/cmake/lace-config.cmake
         ${CMAKE_CURRENT_BINARY_DIR}/cmake/lace-config-version.cmake
+        ${CMAKE_CURRENT_SOURCE_DIR}/cmake/FindHWLOC.cmake
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/lace
 )
+
+# ── pkg-config ───────────────────────────────────────────────────────────────
 
 set(_PC_EXTRA_CFLAGS "")
 set(_PC_EXTRA_LIBS "")
@@ -245,30 +302,34 @@ if(LACE_USE_HWLOC)
     endforeach()
 endif()
 
-# Join lists into space-separated strings
+if(MINGW)
+    list(APPEND _PC_EXTRA_LIBS "-lsynchronization")
+endif()
+
 string(JOIN " " PC_EXTRA_CFLAGS ${_PC_EXTRA_CFLAGS})
 string(JOIN " " PC_EXTRA_LIBS ${_PC_EXTRA_LIBS})
 
 if(NOT MSVC)
-    configure_file("${CMAKE_CURRENT_SOURCE_DIR}/src/lace.pc.in" "${CMAKE_CURRENT_BINARY_DIR}/lace.pc" @ONLY)
-    configure_file("${CMAKE_CURRENT_SOURCE_DIR}/src/lace14.pc.in" "${CMAKE_CURRENT_BINARY_DIR}/lace14.pc" @ONLY)
-
-    # message(STATUS "Generated EXTRA_LIBS for .pc = \"${PC_EXTRA_LIBS}\"")
-
+    configure_file("${CMAKE_CURRENT_SOURCE_DIR}/src/lace.pc.in"
+                   "${CMAKE_CURRENT_BINARY_DIR}/lace.pc" @ONLY)
+    configure_file("${CMAKE_CURRENT_SOURCE_DIR}/src/lace14.pc.in"
+                   "${CMAKE_CURRENT_BINARY_DIR}/lace14.pc" @ONLY)
     install(
         FILES
-        ${CMAKE_CURRENT_BINARY_DIR}/lace.pc
-        ${CMAKE_CURRENT_BINARY_DIR}/lace14.pc
+            ${CMAKE_CURRENT_BINARY_DIR}/lace.pc
+            ${CMAKE_CURRENT_BINARY_DIR}/lace14.pc
         DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
-    )   
+    )
 endif()
 
-# Summary
+# ── Summary ──────────────────────────────────────────────────────────────────
+
+# # Summary
 # message(STATUS "")
 # message(STATUS "Lace ${PROJECT_VERSION} configuration summary:")
 # message(STATUS "  Build type        : ${CMAKE_BUILD_TYPE}")
 # message(STATUS "  Shared libraries  : ${BUILD_SHARED_LIBS}")
-# message(STATUS "  Top-level project : ${lace_is_top_level}")
+# message(STATUS "  Top-level project : ${lace_IS_TOP_LEVEL}")
 # message(STATUS "  Use HWLOC         : ${LACE_USE_HWLOC}")
 # message(STATUS "  Use -march=native : ${LACE_NATIVE_OPT}")
 # message(STATUS "  Use -fPIC         : ${LACE_ENABLE_PIC}")
@@ -285,13 +346,3 @@ endif()
 #     message(STATUS "  Sanitize UB       : ${LACE_SANITIZE_UB}")
 # endif()
 # message(STATUS "")
-
-# JFG: Avoid showing lace options in ccmake.
-mark_as_advanced(
-  LACE_PIE_TIMES
-  LACE_COUNT_TASKS
-  LACE_COUNT_STEALS
-  LACE_COUNT_SPLITS
-  LACE_USE_HWLOC
-  LACE_USE_MMAP
-)

--- a/3rd-party/lace/cmake/lace-config.cmake.in
+++ b/3rd-party/lace/cmake/lace-config.cmake.in
@@ -1,5 +1,17 @@
 @PACKAGE_INIT@
 
-if(NOT TARGET lace::lace)
-    include(${CMAKE_CURRENT_LIST_DIR}/lace-targets.cmake)
+include(CMakeFindDependencyMacro)
+
+if(NOT MSVC)
+    find_dependency(Threads)
 endif()
+
+if(@LACE_USE_HWLOC@)
+    find_dependency(HWLOC)
+endif()
+
+if(NOT TARGET lace::lace)
+    include("${CMAKE_CURRENT_LIST_DIR}/lace-targets.cmake")
+endif()
+
+check_required_components(lace)

--- a/3rd-party/lace/src/lace.c
+++ b/3rd-party/lace/src/lace.c
@@ -26,6 +26,7 @@
 
 #include <errno.h> // for errno
 #include <inttypes.h> // for PRIu64
+#include <limits.h> // for INT_MAX etc
 #include <stddef.h> // for size_t
 #include <stdio.h>  // for fprintf
 #include <stdlib.h> // for memalign, malloc
@@ -148,6 +149,212 @@ static size_t get_cache_line_size(void)
 static size_t cache_line_size;
 
 /**
+ * Portable futex support
+ */
+
+#if defined(__linux__)
+#include <linux/futex.h>
+#include <sys/syscall.h>
+
+LACE_UNUSED
+static int lace_futex_wait(atomic_int *addr, int expected, int64_t timeout_us)
+{
+    if (timeout_us < 0) {
+        return (int)syscall(SYS_futex, addr, FUTEX_WAIT_PRIVATE, expected, NULL, NULL, 0);
+    }
+    struct timespec ts;
+    ts.tv_sec = (time_t)(timeout_us / 1000000);
+    ts.tv_nsec = (long)((timeout_us % 1000000) * 1000);
+    return (int)syscall(SYS_futex, addr, FUTEX_WAIT_PRIVATE, expected, &ts, NULL, 0);
+}
+
+LACE_UNUSED
+static int lace_futex_wake_one(atomic_int *addr)
+{
+    return (int)syscall(SYS_futex, addr, FUTEX_WAKE_PRIVATE, 1, NULL, NULL, 0);
+}
+
+LACE_UNUSED
+static int lace_futex_wake_all(atomic_int *addr)
+{
+    return (int)syscall(SYS_futex, addr, FUTEX_WAKE_PRIVATE, INT_MAX, NULL, NULL, 0);
+}
+
+#elif defined(__FreeBSD__)
+#include <sys/umtx.h>
+
+LACE_UNUSED
+static int lace_futex_wait(atomic_int *addr, int expected, int64_t timeout_us)
+{
+    struct _umtx_time ut;
+    if (timeout_us < 0) {
+        return _umtx_op(addr, UMTX_OP_WAIT_UINT_PRIVATE, (unsigned long)expected, NULL, NULL);
+    }
+    ut._flags = UMTX_ABSTIME;  /* we want relative, but FreeBSD wants this struct */
+    ut._clockid = CLOCK_MONOTONIC;
+    ut._timeout.tv_sec = (time_t)(timeout_us / 1000000);
+    ut._timeout.tv_nsec = (timeout_us % 1000000) * 1000;
+    /* Actually for relative timeout, don't set UMTX_ABSTIME */
+    ut._flags = 0;
+    return _umtx_op(addr, UMTX_OP_WAIT_UINT_PRIVATE, (unsigned long)expected,
+                    (void *)(uintptr_t)sizeof(ut), &ut);
+}
+
+LACE_UNUSED
+static int lace_futex_wake_one(atomic_int *addr)
+{
+    return _umtx_op(addr, UMTX_OP_WAKE_PRIVATE, 1, NULL, NULL);
+}
+
+LACE_UNUSED
+static int lace_futex_wake_all(atomic_int *addr)
+{
+    return _umtx_op(addr, UMTX_OP_WAKE_PRIVATE, INT_MAX, NULL, NULL);
+}
+
+#elif defined(__APPLE__)
+#include <Availability.h>
+
+#if defined(__MAC_OS_X_VERSION_MIN_REQUIRED) && __MAC_OS_X_VERSION_MIN_REQUIRED >= 140400
+/* macOS 14.4+: public os_sync API */
+#include <os/os_sync_wait_on_address.h>
+
+LACE_UNUSED
+static int lace_futex_wait(atomic_int *addr, int expected, int64_t timeout_us)
+{
+    if (timeout_us < 0) {
+        return os_sync_wait_on_address(addr, (uint64_t)(unsigned int)expected,
+            sizeof(int), OS_SYNC_WAIT_ON_ADDRESS_NONE);
+    }
+    uint64_t timeout_ns = (uint64_t)timeout_us * 1000;
+    return os_sync_wait_on_address_with_timeout(addr, (uint64_t)(unsigned int)expected,
+        sizeof(int), OS_SYNC_WAIT_ON_ADDRESS_NONE,
+        OS_CLOCK_MACH_ABSOLUTE_TIME, timeout_ns);
+}
+
+LACE_UNUSED
+static int lace_futex_wake_one(atomic_int *addr)
+{
+    return os_sync_wake_by_address_any(addr, sizeof(int), OS_SYNC_WAKE_BY_ADDRESS_NONE);
+}
+
+LACE_UNUSED
+static int lace_futex_wake_all(atomic_int *addr)
+{
+    return os_sync_wake_by_address_all(addr, sizeof(int), OS_SYNC_WAKE_BY_ADDRESS_NONE);
+}
+
+#else
+/* macOS < 14.4: private __ulock API (used by Rust stdlib, Go runtime, libc++) */
+extern int __ulock_wait(uint32_t op, void *addr, uint64_t val, uint32_t timeout_us);
+extern int __ulock_wake(uint32_t op, void *addr, uint64_t val);
+#define UL_COMPARE_AND_WAIT 1
+#define ULF_WAKE_ALL        0x00000100
+
+LACE_UNUSED
+static int lace_futex_wait(atomic_int *addr, int expected, int64_t timeout_us)
+{
+    uint32_t tus = (timeout_us < 0) ? 0 : (uint32_t)timeout_us;
+    return __ulock_wait(UL_COMPARE_AND_WAIT, addr, (uint64_t)(unsigned int)expected, tus);
+}
+
+LACE_UNUSED
+static int lace_futex_wake_one(atomic_int *addr)
+{
+    return __ulock_wake(UL_COMPARE_AND_WAIT, addr, 0);
+}
+
+LACE_UNUSED
+static int lace_futex_wake_all(atomic_int *addr)
+{
+    return __ulock_wake(UL_COMPARE_AND_WAIT | ULF_WAKE_ALL, addr, 0);
+}
+#endif /* macOS version check */
+
+#elif defined(_WIN32)
+/* WaitOnAddress / WakeByAddress* — available since Windows 8 */
+/* synchapi.h is already included above for LACE_MSVC; link with Synchronization.lib */
+
+LACE_UNUSED
+static int lace_futex_wait(atomic_int *addr, int expected, int64_t timeout_us)
+{
+    DWORD ms;
+    if (timeout_us < 0) {
+        ms = INFINITE;
+    } else {
+        ms = (DWORD)((timeout_us + 999) / 1000);
+        if (ms == 0) ms = 1;
+    }
+    return WaitOnAddress((volatile void*)addr, &expected, sizeof(int), ms) ? 0 : -1;
+}
+
+LACE_UNUSED
+static int lace_futex_wake_one(atomic_int *addr)
+{
+    WakeByAddressSingle((void*)addr);
+    return 0;
+}
+
+LACE_UNUSED
+static int lace_futex_wake_all(atomic_int *addr)
+{
+    WakeByAddressAll((void*)addr);
+    return 0;
+}
+
+#else
+#error "No futex implementation available for this platform"
+#endif
+
+/**
+ * CPU pause/yield helpers
+ */
+
+#if defined(_MSC_VER)
+# include <intrin.h>
+#endif
+
+#if defined(__i386__) || defined(__x86_64__)
+# if !defined(_MSC_VER)
+#  include <emmintrin.h>   /* _mm_pause on Clang/GCC */
+# endif
+#endif
+
+LACE_UNUSED
+static inline void lace_cpu_pause(void)
+{
+#if defined(__i386__) || defined(__x86_64__) || defined(_M_IX86) || defined(_M_X64)
+    /* x86/x64: use intrinsics/builtins, no inline asm needed */
+# if defined(_MSC_VER)
+    _mm_pause();
+# elif defined(__clang__) || defined(__GNUC__)
+    _mm_pause();
+# else
+    __asm__ __volatile__("pause");
+# endif
+#elif defined(__arm__) || defined(__aarch64__) || defined(_M_ARM) || defined(_M_ARM64)
+    /* ARM/AArch64 */
+# if defined(_MSC_VER)
+    __yield();
+# else
+    __asm__ __volatile__("yield");
+# endif
+#else
+    /* no-op on other architectures */
+#endif
+}
+
+LACE_UNUSED
+static inline void lace_cpu_yield(void)
+{
+#if defined(_WIN32)
+    SwitchToThread();
+#else
+    sched_yield();
+#endif
+}
+
+/**
  * Thread handles
  */
 #if !LACE_MSVC
@@ -159,7 +366,7 @@ static HANDLE* handles = NULL;
 /**
  * Worker thread program stacks
  */
-#if LACE_USE_HWLOC || !defined(_WIN32)
+#if LACE_USE_HWLOC || (!defined(_WIN32) && !defined(__FreeBSD__))
 static void** worker_stacks = NULL;
 static size_t worker_stack_size = 0;
 static size_t worker_stack_page_size = 0;
@@ -235,6 +442,17 @@ static atomic_int lace_quits = 0;
  * Flag whether lace is running
  */
 static int is_running = 0;
+
+/**
+ * Futex-based idle system for progressive worker sleeping
+ */
+static atomic_int wake_futex = 0;   /* futex word: incremented to wake sleeping workers */
+static atomic_int n_sleeping = 0;   /* count of workers currently in futex_wait */
+
+/* Progressive idle thresholds (failed steal iterations before transitioning) */
+#define LACE_IDLE_STAGE1_LIMIT  256   /* yield */
+#define LACE_IDLE_FUTEX_TIMEOUT_MIN 100
+#define LACE_IDLE_FUTEX_TIMEOUT_MAX 1000
 
 /**
  * Thread-specific mechanism to access current worker data
@@ -581,7 +799,7 @@ lace_init_worker(unsigned int worker)
   */
 typedef struct ext_lace_task {
     Task* task;
-    lace_sem_t sem;
+    atomic_int done;
 } ExtTask;
 
 #define LACE_EXT_SLOTS 64
@@ -601,10 +819,7 @@ lace_run_task(Task* task)
     ExtTask et;
     et.task = task;
     atomic_store_explicit(&et.task->thief, 0, memory_order_relaxed);
-    if (lace_sem_init(&et.sem, 0) != 0) {
-        fprintf(stderr, "Lace error: unable to create semaphore for external task!\n");
-        exit(1);
-    }
+    atomic_store_explicit(&et.done, 0, memory_order_relaxed);
 
     // Push into any empty slot
     while (1) {
@@ -620,14 +835,25 @@ lace_run_task(Task* task)
     }
 pushed:
 
-    lace_sem_wait(&et.sem);
-    lace_sem_destroy(&et.sem);
+    /* Wake a sleeping worker to pick up the external task */
+    atomic_fetch_add_explicit(&wake_futex, 1, memory_order_release);
+    lace_futex_wake_one(&wake_futex);
+
+    for (int spin = 0; spin < 256; spin++) {
+        if (atomic_load_explicit(&et.done, memory_order_acquire)) return;
+        lace_cpu_pause();
+    }
+
+    while (!atomic_load_explicit(&et.done, memory_order_acquire)) {
+        lace_futex_wait(&et.done, 0, LACE_IDLE_FUTEX_TIMEOUT_MIN);
+    }
 }
 
 static inline void
 lace_steal_external(WorkerP* self, Task* head)
 {
     for (int i = 0; i < LACE_EXT_SLOTS; i++) {
+        if (atomic_load_explicit(&external_tasks[i], memory_order_relaxed) == NULL) continue;
         ExtTask* stolen = atomic_exchange_explicit(&external_tasks[i], NULL, memory_order_acquire);
         if (stolen != NULL) {
             // execute task
@@ -637,7 +863,8 @@ lace_steal_external(WorkerP* self, Task* head)
             stolen->task->f(self, head, stolen->task);
             lace_time_event(self, 2);
             atomic_store_explicit(&stolen->task->thief, THIEF_COMPLETED, memory_order_relaxed);
-            lace_sem_post(&stolen->sem);
+            atomic_store_explicit(&stolen->done, 1, memory_order_release);
+            lace_futex_wake_one(&stolen->done);
             lace_time_event(self, 8);
             return;
         }
@@ -658,7 +885,7 @@ TASK(void, lace_steal_random)
 
         PR_COUNTSTEALS(__lace_worker, CTR_steal_tries);
         Worker *res = lace_steal(__lace_worker, __lace_dq_head, victim);
-        if (res == LACE_STOLEN) {
+        if (res == LACE_STOLEN || res == LACE_STOLEN_LAST) {
             PR_COUNTSTEALS(__lace_worker, CTR_steals);
         } else if (res == LACE_BUSY) {
             PR_COUNTSTEALS(__lace_worker, CTR_steal_busy);
@@ -674,7 +901,7 @@ LACE_NO_SANITIZE_THREAD
 TASK(void, lace_steal_loop, atomic_int*, quit)
 {
     // Determine who I am
-    const int worker_id = __lace_worker->worker;
+    const unsigned int worker_id =(unsigned int) __lace_worker->worker;
 
     // Prepare self, victim
     Worker ** const self = &workers[worker_id];
@@ -685,56 +912,76 @@ TASK(void, lace_steal_loop, atomic_int*, quit)
 #endif
 
     unsigned int n = n_workers;
-#if LACE_BACKOFF
-    unsigned int backoff = 0;
-#endif
+    unsigned int last_victim = worker_id; // means no last victim
+    unsigned int idle_count = 0;
 
     while (1) {
-#if LACE_BACKOFF
-        backoff++;
-#endif
         if (n > 1) {
-            victim = workers + ((lace_rng(__lace_worker) % (n - 1)) + (uint64_t)worker_id + 1) % n;
+            // Victim selection: try last successful victim first, then random
+            if ((idle_count&1) == 0 && last_victim != worker_id) {
+                victim = workers + last_victim;
+            } else {
+                victim = workers + ((lace_rng(__lace_worker) % (n - 1)) + (uint64_t)worker_id + 1) % n;
+            }
 
             PR_COUNTSTEALS(__lace_worker, CTR_steal_tries);
             Worker* res = lace_steal(__lace_worker, __lace_dq_head , *victim);
-            if (res == LACE_STOLEN) {
+            if (res == LACE_STOLEN || res == LACE_STOLEN_LAST) {
                 PR_COUNTSTEALS(__lace_worker, CTR_steals);
-#if LACE_BACKOFF
-                backoff = 0;
-#endif
+                last_victim = (unsigned int)(victim - workers);
+                idle_count = 0;
+                // If workers are sleeping, wake one to help
+                if (res == LACE_STOLEN &&
+                    atomic_load_explicit(&n_sleeping, memory_order_relaxed) > 0) {
+                    atomic_fetch_add_explicit(&wake_futex, 1, memory_order_release);
+                    lace_futex_wake_one(&wake_futex);
+                }
             }
             else if (res == LACE_BUSY) {
                 PR_COUNTSTEALS(__lace_worker, CTR_steal_busy);
-#if LACE_BACKOFF
-                backoff = 0;
-#endif
+                idle_count = 0;
             }
             else { // LACE_NOWORK
+                idle_count++;
             }
         }
 
         YIELD_NEWFRAME();
 
-        if (LACE_UNLIKELY(atomic_load_explicit(&external_task_count, memory_order_acquire) > 0)) {
+        if (LACE_UNLIKELY(idle_count % 4 == 0 &&
+            atomic_load_explicit(&external_task_count, memory_order_acquire) > 0)) {
             lace_steal_external(__lace_worker, __lace_dq_head);
-#if LACE_BACKOFF
-            backoff = 0;
-#endif
+            idle_count = 0;
             continue;
         }
 
 #if LACE_BACKOFF
-        if (backoff > 1000) { // only back off after 1000 attempts
-            int64_t delay_us = ((int64_t)1) << ((backoff - 1000) / 50);
-            if (delay_us > 1000) delay_us = 1000; // cap at 1ms
+        // Progressive idle: pause → yield → futex sleep
+        if (idle_count > LACE_IDLE_STAGE1_LIMIT) {
+            /* Stage 2: futex wait with bounded timeout */
 #if LACE_PIE_TIMES
             uint64_t prev = lace_gethrtime();
 #endif
-            lace_sleep_us(delay_us);
+            unsigned int futex_iters = idle_count - LACE_IDLE_STAGE1_LIMIT;
+            int64_t timeout_us = LACE_IDLE_FUTEX_TIMEOUT_MIN * (1 + (int64_t)futex_iters);
+            if (timeout_us > LACE_IDLE_FUTEX_TIMEOUT_MAX) timeout_us = LACE_IDLE_FUTEX_TIMEOUT_MAX;
+
+            atomic_fetch_add_explicit(&n_sleeping, 1, memory_order_relaxed);
+            int val = atomic_load_explicit(&wake_futex, memory_order_acquire);
+            lace_futex_wait(&wake_futex, val, timeout_us);
+            atomic_fetch_sub_explicit(&n_sleeping, 1, memory_order_relaxed);
 #if LACE_PIE_TIMES
             PR_ADD(__lace_worker, CTR_backoff, lace_gethrtime() - prev);
 #endif
+
+            if (atomic_load_explicit(&external_task_count, memory_order_acquire) > 0) {
+                lace_steal_external(__lace_worker, __lace_dq_head);
+                idle_count = 0;
+                continue;
+            }
+        } else {
+            /* Stage 1: yield the CPU briefly */
+            lace_cpu_yield();
         }
 #endif
 
@@ -855,7 +1102,7 @@ lace_start(unsigned int _n_workers, size_t dequesize)
     else {
         n_pus = (unsigned)hwloc_get_nbobjs_by_type(topo, HWLOC_OBJ_PU);
     }
-    if (allowed) hwloc_bitmap_free(allowed); 
+    if (allowed) hwloc_bitmap_free(allowed);
 #else
     n_pus = lace_get_pu_count();
 #endif
@@ -1025,7 +1272,7 @@ lace_start(unsigned int _n_workers, size_t dequesize)
             worker_stacks[i] = stack;
             }
         }
-#elif !defined(_WIN32)
+#elif !defined(_WIN32) && !defined(__FreeBSD__)
     // Use mmap so first-touch places pages on the right NUMA node after pinning
     {
         long ps = sysconf(_SC_PAGESIZE);
@@ -1059,7 +1306,7 @@ lace_start(unsigned int _n_workers, size_t dequesize)
         }
     }
 #else
-    // _WIN32 without HWLOC: just set stack size, let the OS handle it
+    // _WIN32 or FreeBSD without HWLOC: just set stack size, let the OS handle it
     if (pthread_attr_setstacksize(&worker_attr, stacksize) != 0) {
         fprintf(stderr, "Lace error: unable to set stack size to %zu bytes!\n", stacksize);
         exit(1);
@@ -1112,7 +1359,7 @@ lace_start(unsigned int _n_workers, size_t dequesize)
     /* Spawn all workers */
     for (unsigned int i = 0; i < n_workers; i++) {
 #if !LACE_MSVC
-#if LACE_USE_HWLOC || !defined(_WIN32)
+#if LACE_USE_HWLOC || (!defined(_WIN32) && !defined(__FreeBSD__))
         if (pthread_attr_setstack(&worker_attr,
             (char*)worker_stacks[i] + worker_stack_page_size,
             worker_stack_size - worker_stack_page_size) != 0) {
@@ -1298,6 +1545,10 @@ void lace_stop(void)
 {
     atomic_store_explicit(&lace_quits, 1, memory_order_relaxed);
 
+    /* Wake all sleeping workers so they observe the quit flag */
+    atomic_fetch_add_explicit(&wake_futex, 1, memory_order_release);
+    lace_futex_wake_all(&wake_futex);
+
     for (unsigned int i = 0; i < n_workers; i++) {
 #if !LACE_MSVC
         pthread_join(handles[i], NULL);
@@ -1317,7 +1568,7 @@ void lace_stop(void)
         free(worker_stacks);
         worker_stacks = NULL;
     }
-#elif !defined(_WIN32)
+#elif !defined(_WIN32) && !defined(__FreeBSD__)
     if (worker_stacks != NULL) {
         for (unsigned int i = 0; i < n_workers; i++) {
             munmap(worker_stacks[i], worker_stack_size);

--- a/3rd-party/lace/src/lace.h
+++ b/3rd-party/lace/src/lace.h
@@ -21,7 +21,7 @@
 // Lace version
 #define LACE_VERSION_MAJOR 1
 #define LACE_VERSION_MINOR 6
-#define LACE_VERSION_PATCH 0
+#define LACE_VERSION_PATCH 3
 
 #if defined(_MSC_VER) && !defined(__clang__)
     #define LACE_MSVC 1
@@ -886,9 +886,10 @@ typedef struct _WorkerP {
 #endif
 } WorkerP;
 
-#define LACE_STOLEN   ((Worker*)0)
-#define LACE_BUSY     ((Worker*)1)
-#define LACE_NOWORK   ((Worker*)2)
+#define LACE_STOLEN      ((Worker*)0)
+#define LACE_BUSY        ((Worker*)1)
+#define LACE_NOWORK      ((Worker*)2)
+#define LACE_STOLEN_LAST ((Worker*)3)
 
 LACE_NORETURN void lace_abort_stack_overflow(void);
 
@@ -1036,7 +1037,7 @@ Worker* lace_steal(WorkerP *self, Task *__dq_head, Worker *victim)
                 lace_time_event(self, 2);
                 atomic_store_explicit(&t->thief, THIEF_COMPLETED, memory_order_release);
                 lace_time_event(self, 8);
-                return LACE_STOLEN;
+                return ts_new.ts.tail < ts_new.ts.split ? LACE_STOLEN : LACE_STOLEN_LAST;
             }
  
             lace_time_event(self, 7);

--- a/3rd-party/lace/src/lace.pc.in
+++ b/3rd-party/lace/src/lace.pc.in
@@ -7,3 +7,4 @@ URL: @PROJECT_HOMEPAGE_URL@
 Version: @PROJECT_VERSION@
 Cflags: -I${includedir}
 Libs: -L${libdir} -lpthread -llace
+Libs.private: @PC_EXTRA_LIBS@

--- a/3rd-party/lace/src/lace.sh
+++ b/3rd-party/lace/src/lace.sh
@@ -902,9 +902,10 @@ typedef struct _WorkerP {
 #endif
 } WorkerP;
 
-#define LACE_STOLEN   ((Worker*)0)
-#define LACE_BUSY     ((Worker*)1)
-#define LACE_NOWORK   ((Worker*)2)
+#define LACE_STOLEN      ((Worker*)0)
+#define LACE_BUSY        ((Worker*)1)
+#define LACE_NOWORK      ((Worker*)2)
+#define LACE_STOLEN_LAST ((Worker*)3)
 
 LACE_NORETURN void lace_abort_stack_overflow(void);
 
@@ -1052,7 +1053,7 @@ Worker* lace_steal(WorkerP *self, Task *__dq_head, Worker *victim)
                 lace_time_event(self, 2);
                 atomic_store_explicit(&t->thief, THIEF_COMPLETED, memory_order_release);
                 lace_time_event(self, 8);
-                return LACE_STOLEN;
+                return ts_new.ts.tail < ts_new.ts.split ? LACE_STOLEN : LACE_STOLEN_LAST;
             }
  
             lace_time_event(self, 7);

--- a/3rd-party/lace/src/lace14.c
+++ b/3rd-party/lace/src/lace14.c
@@ -26,6 +26,7 @@
 
 #include <errno.h> // for errno
 #include <inttypes.h> // for PRIu64
+#include <limits.h> // for INT_MAX etc
 #include <stddef.h> // for size_t
 #include <stdio.h>  // for fprintf
 #include <stdlib.h> // for memalign, malloc
@@ -148,6 +149,212 @@ static size_t get_cache_line_size(void)
 static size_t cache_line_size;
 
 /**
+ * Portable futex support
+ */
+
+#if defined(__linux__)
+#include <linux/futex.h>
+#include <sys/syscall.h>
+
+LACE_UNUSED
+static int lace_futex_wait(atomic_int *addr, int expected, int64_t timeout_us)
+{
+    if (timeout_us < 0) {
+        return (int)syscall(SYS_futex, addr, FUTEX_WAIT_PRIVATE, expected, NULL, NULL, 0);
+    }
+    struct timespec ts;
+    ts.tv_sec = (time_t)(timeout_us / 1000000);
+    ts.tv_nsec = (long)((timeout_us % 1000000) * 1000);
+    return (int)syscall(SYS_futex, addr, FUTEX_WAIT_PRIVATE, expected, &ts, NULL, 0);
+}
+
+LACE_UNUSED
+static int lace_futex_wake_one(atomic_int *addr)
+{
+    return (int)syscall(SYS_futex, addr, FUTEX_WAKE_PRIVATE, 1, NULL, NULL, 0);
+}
+
+LACE_UNUSED
+static int lace_futex_wake_all(atomic_int *addr)
+{
+    return (int)syscall(SYS_futex, addr, FUTEX_WAKE_PRIVATE, INT_MAX, NULL, NULL, 0);
+}
+
+#elif defined(__FreeBSD__)
+#include <sys/umtx.h>
+
+LACE_UNUSED
+static int lace_futex_wait(atomic_int *addr, int expected, int64_t timeout_us)
+{
+    struct _umtx_time ut;
+    if (timeout_us < 0) {
+        return _umtx_op(addr, UMTX_OP_WAIT_UINT_PRIVATE, (unsigned long)expected, NULL, NULL);
+    }
+    ut._flags = UMTX_ABSTIME;  /* we want relative, but FreeBSD wants this struct */
+    ut._clockid = CLOCK_MONOTONIC;
+    ut._timeout.tv_sec = (time_t)(timeout_us / 1000000);
+    ut._timeout.tv_nsec = (timeout_us % 1000000) * 1000;
+    /* Actually for relative timeout, don't set UMTX_ABSTIME */
+    ut._flags = 0;
+    return _umtx_op(addr, UMTX_OP_WAIT_UINT_PRIVATE, (unsigned long)expected,
+                    (void *)(uintptr_t)sizeof(ut), &ut);
+}
+
+LACE_UNUSED
+static int lace_futex_wake_one(atomic_int *addr)
+{
+    return _umtx_op(addr, UMTX_OP_WAKE_PRIVATE, 1, NULL, NULL);
+}
+
+LACE_UNUSED
+static int lace_futex_wake_all(atomic_int *addr)
+{
+    return _umtx_op(addr, UMTX_OP_WAKE_PRIVATE, INT_MAX, NULL, NULL);
+}
+
+#elif defined(__APPLE__)
+#include <Availability.h>
+
+#if defined(__MAC_OS_X_VERSION_MIN_REQUIRED) && __MAC_OS_X_VERSION_MIN_REQUIRED >= 140400
+/* macOS 14.4+: public os_sync API */
+#include <os/os_sync_wait_on_address.h>
+
+LACE_UNUSED
+static int lace_futex_wait(atomic_int *addr, int expected, int64_t timeout_us)
+{
+    if (timeout_us < 0) {
+        return os_sync_wait_on_address(addr, (uint64_t)(unsigned int)expected,
+            sizeof(int), OS_SYNC_WAIT_ON_ADDRESS_NONE);
+    }
+    uint64_t timeout_ns = (uint64_t)timeout_us * 1000;
+    return os_sync_wait_on_address_with_timeout(addr, (uint64_t)(unsigned int)expected,
+        sizeof(int), OS_SYNC_WAIT_ON_ADDRESS_NONE,
+        OS_CLOCK_MACH_ABSOLUTE_TIME, timeout_ns);
+}
+
+LACE_UNUSED
+static int lace_futex_wake_one(atomic_int *addr)
+{
+    return os_sync_wake_by_address_any(addr, sizeof(int), OS_SYNC_WAKE_BY_ADDRESS_NONE);
+}
+
+LACE_UNUSED
+static int lace_futex_wake_all(atomic_int *addr)
+{
+    return os_sync_wake_by_address_all(addr, sizeof(int), OS_SYNC_WAKE_BY_ADDRESS_NONE);
+}
+
+#else
+/* macOS < 14.4: private __ulock API (used by Rust stdlib, Go runtime, libc++) */
+extern int __ulock_wait(uint32_t op, void *addr, uint64_t val, uint32_t timeout_us);
+extern int __ulock_wake(uint32_t op, void *addr, uint64_t val);
+#define UL_COMPARE_AND_WAIT 1
+#define ULF_WAKE_ALL        0x00000100
+
+LACE_UNUSED
+static int lace_futex_wait(atomic_int *addr, int expected, int64_t timeout_us)
+{
+    uint32_t tus = (timeout_us < 0) ? 0 : (uint32_t)timeout_us;
+    return __ulock_wait(UL_COMPARE_AND_WAIT, addr, (uint64_t)(unsigned int)expected, tus);
+}
+
+LACE_UNUSED
+static int lace_futex_wake_one(atomic_int *addr)
+{
+    return __ulock_wake(UL_COMPARE_AND_WAIT, addr, 0);
+}
+
+LACE_UNUSED
+static int lace_futex_wake_all(atomic_int *addr)
+{
+    return __ulock_wake(UL_COMPARE_AND_WAIT | ULF_WAKE_ALL, addr, 0);
+}
+#endif /* macOS version check */
+
+#elif defined(_WIN32)
+/* WaitOnAddress / WakeByAddress* — available since Windows 8 */
+/* synchapi.h is already included above for LACE_MSVC; link with Synchronization.lib */
+
+LACE_UNUSED
+static int lace_futex_wait(atomic_int *addr, int expected, int64_t timeout_us)
+{
+    DWORD ms;
+    if (timeout_us < 0) {
+        ms = INFINITE;
+    } else {
+        ms = (DWORD)((timeout_us + 999) / 1000);
+        if (ms == 0) ms = 1;
+    }
+    return WaitOnAddress((volatile void*)addr, &expected, sizeof(int), ms) ? 0 : -1;
+}
+
+LACE_UNUSED
+static int lace_futex_wake_one(atomic_int *addr)
+{
+    WakeByAddressSingle((void*)addr);
+    return 0;
+}
+
+LACE_UNUSED
+static int lace_futex_wake_all(atomic_int *addr)
+{
+    WakeByAddressAll((void*)addr);
+    return 0;
+}
+
+#else
+#error "No futex implementation available for this platform"
+#endif
+
+/**
+ * CPU pause/yield helpers
+ */
+
+#if defined(_MSC_VER)
+# include <intrin.h>
+#endif
+
+#if defined(__i386__) || defined(__x86_64__)
+# if !defined(_MSC_VER)
+#  include <emmintrin.h>   /* _mm_pause on Clang/GCC */
+# endif
+#endif
+
+LACE_UNUSED
+static inline void lace_cpu_pause(void)
+{
+#if defined(__i386__) || defined(__x86_64__) || defined(_M_IX86) || defined(_M_X64)
+    /* x86/x64: use intrinsics/builtins, no inline asm needed */
+# if defined(_MSC_VER)
+    _mm_pause();
+# elif defined(__clang__) || defined(__GNUC__)
+    _mm_pause();
+# else
+    __asm__ __volatile__("pause");
+# endif
+#elif defined(__arm__) || defined(__aarch64__) || defined(_M_ARM) || defined(_M_ARM64)
+    /* ARM/AArch64 */
+# if defined(_MSC_VER)
+    __yield();
+# else
+    __asm__ __volatile__("yield");
+# endif
+#else
+    /* no-op on other architectures */
+#endif
+}
+
+LACE_UNUSED
+static inline void lace_cpu_yield(void)
+{
+#if defined(_WIN32)
+    SwitchToThread();
+#else
+    sched_yield();
+#endif
+}
+
+/**
  * Thread handles
  */
 #if !LACE_MSVC
@@ -159,7 +366,7 @@ static HANDLE* handles = NULL;
 /**
  * Worker thread program stacks
  */
-#if LACE_USE_HWLOC || !defined(_WIN32)
+#if LACE_USE_HWLOC || (!defined(_WIN32) && !defined(__FreeBSD__))
 static void** worker_stacks = NULL;
 static size_t worker_stack_size = 0;
 static size_t worker_stack_page_size = 0;
@@ -235,6 +442,17 @@ static atomic_int lace_quits = 0;
  * Flag whether lace is running
  */
 static int is_running = 0;
+
+/**
+ * Futex-based idle system for progressive worker sleeping
+ */
+static atomic_int wake_futex = 0;   /* futex word: incremented to wake sleeping workers */
+static atomic_int n_sleeping = 0;   /* count of workers currently in futex_wait */
+
+/* Progressive idle thresholds (failed steal iterations before transitioning) */
+#define LACE_IDLE_STAGE1_LIMIT  256   /* yield */
+#define LACE_IDLE_FUTEX_TIMEOUT_MIN 100
+#define LACE_IDLE_FUTEX_TIMEOUT_MAX 1000
 
 /**
  * Thread-specific mechanism to access current worker data
@@ -581,7 +799,7 @@ lace_init_worker(unsigned int worker)
   */
 typedef struct ext_lace_task {
     Task* task;
-    lace_sem_t sem;
+    atomic_int done;
 } ExtTask;
 
 #define LACE_EXT_SLOTS 64
@@ -601,10 +819,7 @@ lace_run_task(Task* task)
     ExtTask et;
     et.task = task;
     atomic_store_explicit(&et.task->thief, 0, memory_order_relaxed);
-    if (lace_sem_init(&et.sem, 0) != 0) {
-        fprintf(stderr, "Lace error: unable to create semaphore for external task!\n");
-        exit(1);
-    }
+    atomic_store_explicit(&et.done, 0, memory_order_relaxed);
 
     // Push into any empty slot
     while (1) {
@@ -620,14 +835,25 @@ lace_run_task(Task* task)
     }
 pushed:
 
-    lace_sem_wait(&et.sem);
-    lace_sem_destroy(&et.sem);
+    /* Wake a sleeping worker to pick up the external task */
+    atomic_fetch_add_explicit(&wake_futex, 1, memory_order_release);
+    lace_futex_wake_one(&wake_futex);
+
+    for (int spin = 0; spin < 256; spin++) {
+        if (atomic_load_explicit(&et.done, memory_order_acquire)) return;
+        lace_cpu_pause();
+    }
+
+    while (!atomic_load_explicit(&et.done, memory_order_acquire)) {
+        lace_futex_wait(&et.done, 0, LACE_IDLE_FUTEX_TIMEOUT_MIN);
+    }
 }
 
 static inline void
 lace_steal_external(WorkerP* self, Task* head)
 {
     for (int i = 0; i < LACE_EXT_SLOTS; i++) {
+        if (atomic_load_explicit(&external_tasks[i], memory_order_relaxed) == NULL) continue;
         ExtTask* stolen = atomic_exchange_explicit(&external_tasks[i], NULL, memory_order_acquire);
         if (stolen != NULL) {
             // execute task
@@ -637,7 +863,8 @@ lace_steal_external(WorkerP* self, Task* head)
             stolen->task->f(self, head, stolen->task);
             lace_time_event(self, 2);
             atomic_store_explicit(&stolen->task->thief, THIEF_COMPLETED, memory_order_relaxed);
-            lace_sem_post(&stolen->sem);
+            atomic_store_explicit(&stolen->done, 1, memory_order_release);
+            lace_futex_wake_one(&stolen->done);
             lace_time_event(self, 8);
             return;
         }
@@ -658,7 +885,7 @@ TASK(void, lace_steal_random)
 
         PR_COUNTSTEALS(__lace_worker, CTR_steal_tries);
         Worker *res = lace_steal(__lace_worker, __lace_dq_head, victim);
-        if (res == LACE_STOLEN) {
+        if (res == LACE_STOLEN || res == LACE_STOLEN_LAST) {
             PR_COUNTSTEALS(__lace_worker, CTR_steals);
         } else if (res == LACE_BUSY) {
             PR_COUNTSTEALS(__lace_worker, CTR_steal_busy);
@@ -674,7 +901,7 @@ LACE_NO_SANITIZE_THREAD
 TASK(void, lace_steal_loop, atomic_int*, quit)
 {
     // Determine who I am
-    const int worker_id = __lace_worker->worker;
+    const unsigned int worker_id =(unsigned int) __lace_worker->worker;
 
     // Prepare self, victim
     Worker ** const self = &workers[worker_id];
@@ -685,56 +912,76 @@ TASK(void, lace_steal_loop, atomic_int*, quit)
 #endif
 
     unsigned int n = n_workers;
-#if LACE_BACKOFF
-    unsigned int backoff = 0;
-#endif
+    unsigned int last_victim = worker_id; // means no last victim
+    unsigned int idle_count = 0;
 
     while (1) {
-#if LACE_BACKOFF
-        backoff++;
-#endif
         if (n > 1) {
-            victim = workers + ((lace_rng(__lace_worker) % (n - 1)) + (uint64_t)worker_id + 1) % n;
+            // Victim selection: try last successful victim first, then random
+            if ((idle_count&1) == 0 && last_victim != worker_id) {
+                victim = workers + last_victim;
+            } else {
+                victim = workers + ((lace_rng(__lace_worker) % (n - 1)) + (uint64_t)worker_id + 1) % n;
+            }
 
             PR_COUNTSTEALS(__lace_worker, CTR_steal_tries);
             Worker* res = lace_steal(__lace_worker, __lace_dq_head , *victim);
-            if (res == LACE_STOLEN) {
+            if (res == LACE_STOLEN || res == LACE_STOLEN_LAST) {
                 PR_COUNTSTEALS(__lace_worker, CTR_steals);
-#if LACE_BACKOFF
-                backoff = 0;
-#endif
+                last_victim = (unsigned int)(victim - workers);
+                idle_count = 0;
+                // If workers are sleeping, wake one to help
+                if (res == LACE_STOLEN &&
+                    atomic_load_explicit(&n_sleeping, memory_order_relaxed) > 0) {
+                    atomic_fetch_add_explicit(&wake_futex, 1, memory_order_release);
+                    lace_futex_wake_one(&wake_futex);
+                }
             }
             else if (res == LACE_BUSY) {
                 PR_COUNTSTEALS(__lace_worker, CTR_steal_busy);
-#if LACE_BACKOFF
-                backoff = 0;
-#endif
+                idle_count = 0;
             }
             else { // LACE_NOWORK
+                idle_count++;
             }
         }
 
         YIELD_NEWFRAME();
 
-        if (LACE_UNLIKELY(atomic_load_explicit(&external_task_count, memory_order_acquire) > 0)) {
+        if (LACE_UNLIKELY(idle_count % 4 == 0 &&
+            atomic_load_explicit(&external_task_count, memory_order_acquire) > 0)) {
             lace_steal_external(__lace_worker, __lace_dq_head);
-#if LACE_BACKOFF
-            backoff = 0;
-#endif
+            idle_count = 0;
             continue;
         }
 
 #if LACE_BACKOFF
-        if (backoff > 1000) { // only back off after 1000 attempts
-            int64_t delay_us = ((int64_t)1) << ((backoff - 1000) / 50);
-            if (delay_us > 1000) delay_us = 1000; // cap at 1ms
+        // Progressive idle: pause → yield → futex sleep
+        if (idle_count > LACE_IDLE_STAGE1_LIMIT) {
+            /* Stage 2: futex wait with bounded timeout */
 #if LACE_PIE_TIMES
             uint64_t prev = lace_gethrtime();
 #endif
-            lace_sleep_us(delay_us);
+            unsigned int futex_iters = idle_count - LACE_IDLE_STAGE1_LIMIT;
+            int64_t timeout_us = LACE_IDLE_FUTEX_TIMEOUT_MIN * (1 + (int64_t)futex_iters);
+            if (timeout_us > LACE_IDLE_FUTEX_TIMEOUT_MAX) timeout_us = LACE_IDLE_FUTEX_TIMEOUT_MAX;
+
+            atomic_fetch_add_explicit(&n_sleeping, 1, memory_order_relaxed);
+            int val = atomic_load_explicit(&wake_futex, memory_order_acquire);
+            lace_futex_wait(&wake_futex, val, timeout_us);
+            atomic_fetch_sub_explicit(&n_sleeping, 1, memory_order_relaxed);
 #if LACE_PIE_TIMES
             PR_ADD(__lace_worker, CTR_backoff, lace_gethrtime() - prev);
 #endif
+
+            if (atomic_load_explicit(&external_task_count, memory_order_acquire) > 0) {
+                lace_steal_external(__lace_worker, __lace_dq_head);
+                idle_count = 0;
+                continue;
+            }
+        } else {
+            /* Stage 1: yield the CPU briefly */
+            lace_cpu_yield();
         }
 #endif
 
@@ -855,7 +1102,7 @@ lace_start(unsigned int _n_workers, size_t dequesize)
     else {
         n_pus = (unsigned)hwloc_get_nbobjs_by_type(topo, HWLOC_OBJ_PU);
     }
-    if (allowed) hwloc_bitmap_free(allowed); 
+    if (allowed) hwloc_bitmap_free(allowed);
 #else
     n_pus = lace_get_pu_count();
 #endif
@@ -1025,7 +1272,7 @@ lace_start(unsigned int _n_workers, size_t dequesize)
             worker_stacks[i] = stack;
             }
         }
-#elif !defined(_WIN32)
+#elif !defined(_WIN32) && !defined(__FreeBSD__)
     // Use mmap so first-touch places pages on the right NUMA node after pinning
     {
         long ps = sysconf(_SC_PAGESIZE);
@@ -1059,7 +1306,7 @@ lace_start(unsigned int _n_workers, size_t dequesize)
         }
     }
 #else
-    // _WIN32 without HWLOC: just set stack size, let the OS handle it
+    // _WIN32 or FreeBSD without HWLOC: just set stack size, let the OS handle it
     if (pthread_attr_setstacksize(&worker_attr, stacksize) != 0) {
         fprintf(stderr, "Lace error: unable to set stack size to %zu bytes!\n", stacksize);
         exit(1);
@@ -1112,7 +1359,7 @@ lace_start(unsigned int _n_workers, size_t dequesize)
     /* Spawn all workers */
     for (unsigned int i = 0; i < n_workers; i++) {
 #if !LACE_MSVC
-#if LACE_USE_HWLOC || !defined(_WIN32)
+#if LACE_USE_HWLOC || (!defined(_WIN32) && !defined(__FreeBSD__))
         if (pthread_attr_setstack(&worker_attr,
             (char*)worker_stacks[i] + worker_stack_page_size,
             worker_stack_size - worker_stack_page_size) != 0) {
@@ -1298,6 +1545,10 @@ void lace_stop(void)
 {
     atomic_store_explicit(&lace_quits, 1, memory_order_relaxed);
 
+    /* Wake all sleeping workers so they observe the quit flag */
+    atomic_fetch_add_explicit(&wake_futex, 1, memory_order_release);
+    lace_futex_wake_all(&wake_futex);
+
     for (unsigned int i = 0; i < n_workers; i++) {
 #if !LACE_MSVC
         pthread_join(handles[i], NULL);
@@ -1317,7 +1568,7 @@ void lace_stop(void)
         free(worker_stacks);
         worker_stacks = NULL;
     }
-#elif !defined(_WIN32)
+#elif !defined(_WIN32) && !defined(__FreeBSD__)
     if (worker_stacks != NULL) {
         for (unsigned int i = 0; i < n_workers; i++) {
             munmap(worker_stacks[i], worker_stack_size);

--- a/3rd-party/lace/src/lace14.h
+++ b/3rd-party/lace/src/lace14.h
@@ -21,7 +21,7 @@
 // Lace version
 #define LACE_VERSION_MAJOR 1
 #define LACE_VERSION_MINOR 6
-#define LACE_VERSION_PATCH 0
+#define LACE_VERSION_PATCH 3
 
 #if defined(_MSC_VER) && !defined(__clang__)
     #define LACE_MSVC 1
@@ -886,9 +886,10 @@ typedef struct _WorkerP {
 #endif
 } WorkerP;
 
-#define LACE_STOLEN   ((Worker*)0)
-#define LACE_BUSY     ((Worker*)1)
-#define LACE_NOWORK   ((Worker*)2)
+#define LACE_STOLEN      ((Worker*)0)
+#define LACE_BUSY        ((Worker*)1)
+#define LACE_NOWORK      ((Worker*)2)
+#define LACE_STOLEN_LAST ((Worker*)3)
 
 LACE_NORETURN void lace_abort_stack_overflow(void);
 
@@ -1036,7 +1037,7 @@ Worker* lace_steal(WorkerP *self, Task *__dq_head, Worker *victim)
                 lace_time_event(self, 2);
                 atomic_store_explicit(&t->thief, THIEF_COMPLETED, memory_order_release);
                 lace_time_event(self, 8);
-                return LACE_STOLEN;
+                return ts_new.ts.tail < ts_new.ts.split ? LACE_STOLEN : LACE_STOLEN_LAST;
             }
  
             lace_time_event(self, 7);

--- a/3rd-party/lace/src/lace14.pc.in
+++ b/3rd-party/lace/src/lace14.pc.in
@@ -7,3 +7,4 @@ URL: @PROJECT_HOMEPAGE_URL@
 Version: @PROJECT_VERSION@
 Cflags: -I${includedir}
 Libs: -L${libdir} -lpthread -llace14
+Libs.private: @PC_EXTRA_LIBS@

--- a/3rd-party/sylvan/src/CMakeLists.txt
+++ b/3rd-party/sylvan/src/CMakeLists.txt
@@ -45,14 +45,14 @@ target_sources(sylvan
 )
 
 # ── Optional C++ bindings ────────────────────────────────────────────────────
- 
+
 if(SYLVAN_BUILD_CPP)
     list(APPEND SYLVAN_HDRS sylvan_obj.hpp)
     target_sources(sylvan PRIVATE sylvan_obj.cpp sylvan_obj.hpp)
 endif()
 
 # ── Optional GMP support ────────────────────────────────────────────────────
- 
+
 option(SYLVAN_GMP "Include custom MTBDD type GMP" OFF)
 if(SYLVAN_GMP)
     find_package(GMP REQUIRED)
@@ -62,20 +62,20 @@ if(SYLVAN_GMP)
 endif()
 
 # ── Compile features ────────────────────────────────────────────────────────
- 
+
 target_compile_features(sylvan PUBLIC c_std_11)
 if(SYLVAN_BUILD_CPP)
     target_compile_features(sylvan PUBLIC cxx_std_11)
 endif()
 
 # ── Target properties ───────────────────────────────────────────────────────
- 
+
 # PIC: required for shared libraries, optional for static (e.g. embedding
 # Sylvan in a downstream shared library).
 if(BUILD_SHARED_LIBS OR SYLVAN_ENABLE_PIC)
     set_target_properties(sylvan PROPERTIES POSITION_INDEPENDENT_CODE ON)
 endif()
- 
+
 # Shared library versioning (ignored for static builds)
 if(BUILD_SHARED_LIBS)
     set_target_properties(sylvan PROPERTIES
@@ -88,7 +88,7 @@ endif()
 # set_target_properties(sylvan PROPERTIES PUBLIC_HEADER "${SYLVAN_HDRS}")
 
 # ── Compiler flags ──────────────────────────────────────────────────────────
- 
+
 if(CMAKE_C_COMPILER_ID MATCHES "Clang|GNU")
     target_compile_options(sylvan PRIVATE
         $<$<CONFIG:Debug>:-O0 -Wall -Wextra -Wpedantic -pipe>
@@ -102,14 +102,14 @@ elseif(MSVC)
 endif()
 
 # ── Include directories ─────────────────────────────────────────────────────
- 
+
 target_include_directories(sylvan PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}>
     $<INSTALL_INTERFACE:include>
 )
 
 # ── Link dependencies ───────────────────────────────────────────────────────
- 
+
 find_package(Threads REQUIRED)
 target_link_libraries(sylvan PUBLIC Threads::Threads)
 target_link_libraries(sylvan PUBLIC lace::lace)
@@ -118,7 +118,7 @@ if(NOT WIN32)
 endif()
 
 # ── Platform feature detection ───────────────────────────────────────────────
- 
+
 option(SYLVAN_USE_MMAP "Let Sylvan use mmap to allocate (virtual) memory" ON)
 if(SYLVAN_USE_MMAP)
     include(CheckSymbolExists)
@@ -132,7 +132,7 @@ if(SYLVAN_USE_MMAP)
 endif()
 
 # ── Optional runtime statistics ──────────────────────────────────────────────
- 
+
 option(SYLVAN_STATS "Let Sylvan collect statistics at runtime" OFF)
 if(SYLVAN_STATS)
     target_compile_definitions(sylvan PUBLIC SYLVAN_STATS)
@@ -151,9 +151,9 @@ if(NOT PROJECT_IS_TOP_LEVEL)
 endif()
 
 # ── Installation ─────────────────────────────────────────────────────────────
- 
+
 include(GNUInstallDirs)
- 
+
 install(TARGETS sylvan
     EXPORT sylvan-targets
     ARCHIVE       DESTINATION ${CMAKE_INSTALL_LIBDIR}
@@ -162,7 +162,7 @@ install(TARGETS sylvan
     INCLUDES      DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
     PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
- 
+
 install(EXPORT sylvan-targets
     FILE      sylvan-targets.cmake
     NAMESPACE sylvan::
@@ -170,34 +170,34 @@ install(EXPORT sylvan-targets
 )
 
 # ── CMake package config ─────────────────────────────────────────────────────
- 
+
 include(CMakePackageConfigHelpers)
- 
+
 if(SYLVAN_GMP)
     set(SYLVAN_CONFIG_FIND_GMP "find_dependency(GMP REQUIRED)")
 else()
     set(SYLVAN_CONFIG_FIND_GMP "")
 endif()
- 
+
 configure_package_config_file(
     ${PROJECT_SOURCE_DIR}/cmake/sylvan-config.cmake.in
     ${CMAKE_CURRENT_BINARY_DIR}/cmake/sylvan-config.cmake
     INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/sylvan
 )
- 
+
 write_basic_package_version_file(
     ${CMAKE_CURRENT_BINARY_DIR}/cmake/sylvan-config-version.cmake
     VERSION ${PROJECT_VERSION}
     COMPATIBILITY SameMinorVersion
 )
- 
+
 install(
     FILES
         ${CMAKE_CURRENT_BINARY_DIR}/cmake/sylvan-config.cmake
         ${CMAKE_CURRENT_BINARY_DIR}/cmake/sylvan-config-version.cmake
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/sylvan
 )
- 
+
 if(SYLVAN_GMP)
     install(FILES ${PROJECT_SOURCE_DIR}/cmake/FindGMP.cmake
         DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/sylvan
@@ -205,20 +205,20 @@ if(SYLVAN_GMP)
 endif()
 
 # ── pkg-config ───────────────────────────────────────────────────────────────
- 
+
 if(SYLVAN_GMP)
     set(PKGC_REQUIRES "lace >= 1.6.0 gmp")
 else()
     set(PKGC_REQUIRES "lace >= 1.6.0")
 endif()
- 
+
 # -lm is needed by consumers for static linking; Threads are already pulled
 # in transitively via the lace.pc Requires line.
 set(PKGC_LIBS_PRIVATE "")
 if(NOT WIN32 AND NOT APPLE)
     set(PKGC_LIBS_PRIVATE "-lm")
 endif()
- 
+
 if(NOT MSVC)
     configure_file(
         "${PROJECT_SOURCE_DIR}/cmake/sylvan.pc.in"


### PR DESCRIPTION
The most important changes are in lace version 1.6.1, which changes the way sleeping workers and work stealing are dealt with. See the Lace changelog for details.
