### PR TITLE
(LPS/LTS)2(PBES/PRES) logging: Clearer message for warning

### DIFF
--- a/tools/release/lps2pbes/lps2pbes.cpp
+++ b/tools/release/lps2pbes/lps2pbes.cpp
@@ -30,9 +30,9 @@ inline void check_lps2pbes_actions(const state_formulas::state_formula& formula,
   std::set<process::action_label> diff = utilities::detail::set_difference(used_state_formula_actions, used_lps_actions);
   if (!diff.empty())
   {
-    mCRL2log(log::warning) << "Warning: the modal formula contains an action "
-                           << *diff.begin()
-                           << " that does not appear in the LPS!" << std::endl;
+    mCRL2log(log::warning) << "Warning: the modal formula contains actions "
+                           << core::detail::print_list(diff)
+                           << " that are in the data specification, but does not appear in the LPS!" << std::endl;
   }
 }
 

--- a/tools/release/lps2pbes/lps2pbes.cpp
+++ b/tools/release/lps2pbes/lps2pbes.cpp
@@ -32,7 +32,7 @@ inline void check_lps2pbes_actions(const state_formulas::state_formula& formula,
   {
     mCRL2log(log::warning) << "Warning: the modal formula contains actions "
                            << core::detail::print_list(diff)
-                           << " that are in the data specification, but does not appear in the LPS!" << std::endl;
+                           << " that are in the data specification, but do not appear in the LPS!" << std::endl;
   }
 }
 

--- a/tools/release/lps2pres/lps2pres.cpp
+++ b/tools/release/lps2pres/lps2pres.cpp
@@ -34,9 +34,9 @@ inline void check_lps2pres_actions(const state_formulas::state_formula& formula,
   std::set<process::action_label> diff = utilities::detail::set_difference(used_state_formula_actions, used_lps_actions);
   if (!diff.empty())
   {
-    mCRL2log(log::warning) << "Warning: the modal formula contains an action "
-                           << *diff.begin()
-                           << " that does not appear in the LPS!" << std::endl;
+    mCRL2log(log::warning) << "Warning: the modal formula contains actions "
+                           << core::detail::print_list(diff)
+                           << " that are in the data specification, but does not appear in the LPS!" << std::endl;
   }
 }
 

--- a/tools/release/lps2pres/lps2pres.cpp
+++ b/tools/release/lps2pres/lps2pres.cpp
@@ -36,7 +36,7 @@ inline void check_lps2pres_actions(const state_formulas::state_formula& formula,
   {
     mCRL2log(log::warning) << "Warning: the modal formula contains actions "
                            << core::detail::print_list(diff)
-                           << " that are in the data specification, but does not appear in the LPS!" << std::endl;
+                           << " that are in the data specification, but do not appear in the LPS!" << std::endl;
   }
 }
 

--- a/tools/release/lts2pbes/lts2pbes.cpp
+++ b/tools/release/lts2pbes/lts2pbes.cpp
@@ -64,9 +64,9 @@ inline void check_lts2pbes_actions(const state_formulas::state_formula& formula,
   std::set<process::action_label> diff = utilities::detail::set_difference(used_state_formula_actions, used_lts_actions);
   if (!diff.empty())
   {
-    mCRL2log(log::warning) << "Warning: the modal formula contains an action "
-                           << *diff.begin()
-                           << " that does not appear in the LTS!" << std::endl;
+    mCRL2log(log::warning) << "Warning: the modal formula contains actions "
+                           << core::detail::print_list(diff)
+                           << " that are in the data specification, but does not appear in the LTS!" << std::endl;
   }
 }
 

--- a/tools/release/lts2pbes/lts2pbes.cpp
+++ b/tools/release/lts2pbes/lts2pbes.cpp
@@ -66,7 +66,7 @@ inline void check_lts2pbes_actions(const state_formulas::state_formula& formula,
   {
     mCRL2log(log::warning) << "Warning: the modal formula contains actions "
                            << core::detail::print_list(diff)
-                           << " that are in the data specification, but does not appear in the LTS!" << std::endl;
+                           << " that are in the data specification, but do not appear in the LTS!" << std::endl;
   }
 }
 

--- a/tools/release/lts2pres/lts2pres.cpp
+++ b/tools/release/lts2pres/lts2pres.cpp
@@ -61,9 +61,9 @@ inline void check_lts2pres_actions(const state_formulas::state_formula& formula,
   std::set<process::action_label> diff = utilities::detail::set_difference(used_state_formula_actions, used_lts_actions);
   if (!diff.empty())
   {
-    mCRL2log(log::warning) << "Warning: the modal formula contains an action "
-                           << *diff.begin()
-                           << " that does not appear in the LTS!" << std::endl;
+    mCRL2log(log::warning) << "Warning: the modal formula contains actions "
+                           << core::detail::print_list(diff)
+                           << " that are in the data specification, but does not appear in the LTS!" << std::endl;
   }
 }
 

--- a/tools/release/lts2pres/lts2pres.cpp
+++ b/tools/release/lts2pres/lts2pres.cpp
@@ -63,7 +63,7 @@ inline void check_lts2pres_actions(const state_formulas::state_formula& formula,
   {
     mCRL2log(log::warning) << "Warning: the modal formula contains actions "
                            << core::detail::print_list(diff)
-                           << " that are in the data specification, but does not appear in the LTS!" << std::endl;
+                           << " that are in the data specification, but do not appear in the LTS!" << std::endl;
   }
 }
 


### PR DESCRIPTION
Previously, it sounds like one is trying to use actions that do not exist.
Instead, the actions are defined, but they do not appear in the LPS/LTS.
Also, print the entire list to improve the usefulness of the warning.