### PR TITLE
Fix  "map::at:  key not found" error in lpsparunfold.

### DIFF
--- a/libraries/lps/include/mcrl2/lps/lpsparunfoldlib.h
+++ b/libraries/lps/include/mcrl2/lps/lpsparunfoldlib.h
@@ -165,7 +165,10 @@ namespace detail
         args.push_back(rhs);
       }
 
-      return data::application(cache_elem.case_functions.at(rhss.front().sort()), args);
+      // Create the case function on demand:
+      // the output sort may not have been creation of case functions.
+      const data::function_symbol case_func = create_case_function(target.sort(), rhss.front().sort());
+      return data::application(case_func, args);
     }
 
     const data::function_symbol_vector& get_projection_funcs(const data::function_symbol& f)
@@ -351,7 +354,7 @@ namespace detail
     bool is_det_or_pi(const data::application& expr) const
     {
       using utilities::detail::contains;
-      
+
       const data::function_symbol f = data::detail::get_top_fs(expr);
       // If f is not unary, then it is certainly unequal to Det or pi
       if (f == data::function_symbol() || expr.size() != 1)
@@ -387,7 +390,7 @@ namespace detail
       }
       auto udm = m_datamgr.dataspec().mappings();
       const data::data_specification& dataspec = m_datamgr.dataspec();
-      if (std::find_if(udm.begin(), udm.end(), 
+      if (std::find_if(udm.begin(), udm.end(),
           [&](const auto& f2){ return f.name() == f2.name() && dataspec.equal_sorts(f.sort(), f2.sort()); }) == udm.end())
       {
         // f is not a mapping, but likely a constructor
@@ -507,7 +510,7 @@ namespace detail
           super::apply(branch1, x[1]);
           data::data_expression branch2;
           super::apply(branch2, x[2]);
-          
+
           data::make_application(result,
             data::if_(x.sort()),
             x[0],

--- a/libraries/lps/test/lpsparunfold_test.cpp
+++ b/libraries/lps/test/lpsparunfold_test.cpp
@@ -7,7 +7,7 @@
 // http://www.boost.org/LICENSE_1_0.txt)
 //
 /// \file lpsparunfold_test.cpp
-/// \brief Add your file description here.
+/// \brief Tests for the lpsparunfold algorithm.
 
 #define BOOST_TEST_MODULE lpsparunfold_test
 #include <boost/algorithm/string.hpp>
@@ -114,3 +114,42 @@ BOOST_AUTO_TEST_CASE(test_main)
     }
 }
 
+// Regression test: unfolding a List(T) parameter when a pattern-matching mapping has a
+// nested constructor subpattern caused create_cases() to look up a case function for a
+// sort (List(Pair)) that was never registered in the Pair cache element.
+// Issue originally spotted by Jan Friso Groote.
+BOOST_AUTO_TEST_CASE(test_unfold_list_pair_nested_constructor_pattern)
+{
+  // `toggle` pattern-matches on |> with the Pair-typed head expressed as `pair(n, b)`.
+  // After unfolding the List(Pair) parameter, the pattern-match unfolder encounters
+  // Det_ListPair(toggle(C_ListPair(...))), unfolds `toggle`, and eventually calls
+  // create_cases(pi_ListPair(x), [List(Pair)-typed rhs]), needing case_functions[List(Pair)]
+  // in the Pair cache — which did not exist before the fix.
+  const std::string spec_text =
+    "sort Pair = struct pair(Nat, Bool);\n"
+    "\n"
+    "map  toggle: List(Pair) -> List(Pair);\n"
+    "     cons_pair: Nat # Bool # List(Pair) -> List(Pair);\n"
+    "var  n: Nat; b: Bool; t: List(Pair);\n"
+    "eqn  toggle([]) = [];\n"
+    "     toggle(pair(n, b) |> t) = pair(n, !b) |> toggle(t);\n"
+    "     cons_pair(n, b, t) = pair(n, b) |> t;\n"
+    "\n"
+    "act  add: Nat # Bool;\n"
+    "     flip;\n"
+    "\n"
+    "proc P(s: List(Pair)) =\n"
+    "       sum n: Nat, b: Bool. add(n, b) . P(cons_pair(n, b, s))\n"
+    "     + flip . P(toggle(s));\n"
+    "\n"
+    "init P([]);\n";
+
+  stochastic_specification spec;
+  parse_lps(spec_text, spec);
+
+  std::map<data::sort_expression, unfold_cache_element> cache;
+  lpsparunfold unfolder(spec, cache, false, false, true);
+  // Index 0 is s: List(Pair).  Unfolding it triggers the pattern-match unfolder on
+  // Det_ListPair(toggle(C_ListPair(...))), which hits the missing case function.
+  BOOST_CHECK_NO_THROW(unfolder.algorithm(0));
+}


### PR DESCRIPTION
Especially when performing pattern match unfolding, the code could try to access case functions that were not yet generated. We now always go through the code to generate the case function (which is a noop if the case function already exists).

Jan Friso originally reported this issue using 1394-fin with the following commands:

```
mcrl22lps 1394-fin.mcrl2 1394-fin.lps -vb &&
lpsparunfold -sBoolTABLE -n2 1394-fin.lps temp.lps -v
```

I added a regression test that shows the problem.