### PR TITLE
Move otherwise orphaned terms to main thread.

### DIFF
--- a/libraries/atermpp/include/mcrl2/atermpp/detail/thread_aterm_pool.h
+++ b/libraries/atermpp/include/mcrl2/atermpp/detail/thread_aterm_pool.h
@@ -21,6 +21,14 @@
 namespace atermpp::detail
 {
 
+// Forward declaration needed by the extern below.
+class thread_aterm_pool;
+
+/// \brief Pointer to the main thread's pool; set on its first access and used
+///        by ~thread_aterm_pool to transfer orphaned protection-set entries
+///        when a worker thread exits.
+extern thread_aterm_pool* g_main_thread_pool;
+
 /// \brief This is a thread's specific access to the global aterm pool which ensures that
 ///        garbage collection and hash table resizing can proceed.
 class thread_aterm_pool final : public mcrl2::utilities::noncopyable
@@ -46,12 +54,40 @@ public:
     }
   }
 
-  ~thread_aterm_pool() 
+  ~thread_aterm_pool()
   {
-      // We leak values for the global aterm pool since they contain global variables (for which initialisation order is undefined).
+    // We leak values for the global aterm pool since they contain global
+    // variables (for which initialisation order is undefined).
     if (!m_is_main_thread)
     {
-      // We need to prematurely unregister this thread pool since we are going to delete reference variables.
+      // Transfer any remaining variables and containers to the main-thread
+      // pool BEFORE unregistering.  This keeps them reachable during GC,
+      // which is essential for static-local aterm_core objects (e.g. those
+      // in sort/data header files) that were first initialised on this worker
+      // thread and will be destroyed at program exit on the main thread.
+      // Without the transfer those objects become invisible to the garbage
+      // collector the moment this pool is unregistered, so the next GC cycle
+      // would reclaim their underlying _aterm nodes.
+      if (g_main_thread_pool != nullptr)
+      {
+        for (const aterm_core* v : *m_variables)
+        {
+          if (v != nullptr)
+          {
+            g_main_thread_pool->register_variable(const_cast<aterm_core*>(v));
+          }
+        }
+        for (const aterm_container* c : *m_containers)
+        {
+          if (c != nullptr)
+          {
+            g_main_thread_pool->register_container(
+                const_cast<aterm_container*>(c));
+          }
+        }
+      }
+      // We need to prematurely unregister this thread pool since we are going
+      // to delete the reference-variable hashtables.
       m_thread_interface.unregister();
       delete m_variables;
       delete m_containers;

--- a/libraries/atermpp/source/aterm_implementation.cpp
+++ b/libraries/atermpp/source/aterm_implementation.cpp
@@ -27,16 +27,29 @@ void atermpp::add_deletion_hook(const function_symbol& function, term_callback c
 
 namespace atermpp::detail
 {
+
+// Pointer to the main thread's pool.  Set once, on the first call to
+// g_thread_term_pool() (which is always from the main thread in practice).
+// Used by ~thread_aterm_pool to transfer orphaned entries when a worker
+// thread exits.
+thread_aterm_pool* g_main_thread_pool = nullptr;
+
 /// \brief A reference to the thread local term pool storage
 thread_aterm_pool& g_thread_term_pool()
 {
 #ifdef MCRL2_ENABLE_MULTITHREADING
   static_assert(mcrl2::utilities::detail::GlobalThreadSafe);
   thread_local thread_aterm_pool instance(g_aterm_pool_instance);
-#else 
+#else
   static_assert(!mcrl2::utilities::detail::GlobalThreadSafe);
   static thread_aterm_pool instance(g_aterm_pool_instance);
 #endif
+  // Record the main-thread pool on first call.  This is always safe: the
+  // main thread initialises its pool before spawning any worker threads.
+  if (g_main_thread_pool == nullptr)
+  {
+    g_main_thread_pool = &instance;
+  }
   return instance;
 }
 

--- a/libraries/atermpp/test/parallel_thread_pool_test.cpp
+++ b/libraries/atermpp/test/parallel_thread_pool_test.cpp
@@ -1,0 +1,102 @@
+// Author(s): Maurice Laveaux, Jeroen Keiren.
+// Copyright: see the accompanying file COPYING or copy at
+// https://github.com/mCRL2org/mCRL2/blob/master/COPYING
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#define BOOST_TEST_MODULE parallel_thread_pool_test
+#include <boost/test/included/unit_test.hpp>
+
+#include "mcrl2/atermpp/aterm.h"
+#include "mcrl2/atermpp/aterm_io.h"
+#include "mcrl2/atermpp/detail/global_aterm_pool.h"
+#include "mcrl2/utilities/configuration.h"
+
+#include <atomic>
+#include <thread>
+
+using namespace atermpp;
+
+// Verify that an aterm_core created on a worker thread remains protected after
+// that thread exits.
+//
+// Root cause of issue #1934: the thread_local thread_aterm_pool destructor for
+// non-main threads deletes m_variables without transferring the contained
+// aterm_core* entries to another pool.  Any aterm_core that was registered on
+// the worker (e.g. a static-local variable first initialised on that thread)
+// therefore becomes invisible to the garbage collector.  The first subsequent
+// collection reclaims the underlying _aterm node; later accesses or the
+// static destructor at program exit then exhibit undefined behaviour or print
+// "Element not found in protection set."
+//
+// The test encodes the failure mode directly:
+//   1. A heap-allocated aterm is constructed on a worker thread so that its
+//      aterm_core is registered in the worker's per-thread pool.
+//   2. The worker is joined; without the fix the pool is torn down and the
+//      entry is simply dropped.
+//   3. A full garbage collection is forced.
+//   4. The deletion hook must NOT have fired: the underlying _aterm node must
+//      still be live because the aterm_core is reachable (either via the main
+//      pool after the fix, or via its own still-valid pointer after the fix).
+//
+// Without the fix step 3 collects the node and step 4 fires the hook, failing
+// the BOOST_CHECK.  With the fix the entries are moved to the main-thread pool
+// before the worker pool is destroyed, so the node survives GC.
+BOOST_AUTO_TEST_CASE(test_worker_thread_aterm_survives_gc)
+{
+  // This test only makes sense in a multi-threaded build where each thread
+  // has its own protection set.
+  if constexpr (!mcrl2::utilities::detail::GlobalThreadSafe)
+  {
+    return;
+  }
+
+  // Use a unique function symbol so the deletion hook cannot be confused with
+  // terms created elsewhere in the test suite.
+  const atermpp::function_symbol sym("__test_thread_orphan__", 0);
+
+  // term_callback is a raw function pointer, so use a file-scope flag.
+  static std::atomic<bool> term_was_collected{ false };
+  term_was_collected = false;
+  atermpp::add_deletion_hook(sym,
+    [](const atermpp::aterm&) { term_was_collected = true; });
+
+  // Heap-allocate so the aterm_core outlives the worker thread's stack.
+  atermpp::aterm* orphan = nullptr;
+
+  {
+    std::thread worker([&]()
+    {
+      // Constructor runs on the worker thread: registers the aterm_core in the
+      // worker's per-thread pool, NOT the main thread's pool.
+      orphan = new atermpp::aterm(sym);
+    });
+    worker.join();
+    // The worker's thread_local thread_aterm_pool destructor has now run.
+    // Without the fix: *orphan is no longer in any root set.
+    // With the fix:    *orphan was transferred to the main-thread pool.
+  }
+
+  BOOST_REQUIRE(orphan != nullptr);
+
+  // Force a full GC cycle.  Without the fix the orphaned term is not reachable
+  // from any root set, so the underlying _aterm node is swept and the deletion
+  // hook fires, setting term_was_collected = true.
+  atermpp::detail::g_thread_term_pool().collect();
+
+  BOOST_CHECK_MESSAGE(!term_was_collected,
+    "The aterm constructed on a worker thread was garbage-collected after the "
+    "worker exited, indicating it was orphaned from all protection sets."
+    "The code should transfer pool entries to the main-thread pool on worker "
+    "teardown.");
+
+  // Clean up only if the term survived GC; if it was collected the pointer is
+  // dangling and must not be dereferenced.
+  if (!term_was_collected)
+  {
+    delete orphan;
+  }
+}


### PR DESCRIPTION
In thread_aterm_pool.h, an `extern thread_aterm_pool* g_main_thread_pool` declaration was added before the class.
The destructor now iterates `m_variables` and `m_containers` and calls `g_main_thread_pool->register_variable/register_container` for each surviving entry before calling `m_thread_interface.unregister()`. Doing the transfer first is essential: if GC were to run in the window between unregister and delete, the orphaned terms would be invisible to the mark phase.

In aterm_implementation.cpp we make sure that `g_main_thread_pool is set on the first call to `g_thread_term_pool()`. This should always happen on the main thread.

A test has been added to show the root cause of the issue.

The code and test are coauthored by Claude code.

Fixes #1934.