### PR TITLE
lps2lts extensions

### DIFF
--- a/libraries/atermpp/include/mcrl2/atermpp/detail/aterm_container.h
+++ b/libraries/atermpp/include/mcrl2/atermpp/detail/aterm_container.h
@@ -10,8 +10,11 @@
 #ifndef MCRL2_ATERMPP_DETAIL_ATERM_CONTAINER_H
 #define MCRL2_ATERMPP_DETAIL_ATERM_CONTAINER_H
 
+#include <concepts>
 #include <stack>
 #include <type_traits>
+#include <utility>
+#include <vector>
 #include "mcrl2/atermpp/aterm_core.h"
 #include "mcrl2/atermpp/detail/aterm_core.h"
 #include "mcrl2/atermpp/detail/aterm_pool_storage_implementation.h"
@@ -26,10 +29,9 @@ inline void mark_term(const aterm_core& t, term_mark_stack& todo)
 {
   if (t.defined())
   {
-    detail::mark_term(*atermpp::detail::address(t),todo);
+    detail::mark_term(*atermpp::detail::address(t), todo);
   }
 }
-
 
 namespace detail
 {
@@ -47,8 +49,8 @@ mcrl2::utilities::shared_guard lock_shared_aterm_pool();
 
 /// \brief Provides safe storage of unprotected_aterm_core instances in a container by marking
 ///        them during garbage collection.
-/// 
-/// \details Can not be inherited since it is being registered during construction and the 
+///
+/// \details Can not be inherited since it is being registered during construction and the
 ///          vptr is being updated by inherited classes otherwise.
 class aterm_container final : private mcrl2::utilities::noncopyable
 {
@@ -56,13 +58,13 @@ public:
   aterm_container(std::function<void(term_mark_stack&)> mark_func, std::function<std::size_t()> size_func);
   ~aterm_container();
 
-  /// \brief Ensure that all the terms in the containers.
+  /// \brief Mark all terms held by this container.
   void mark(term_mark_stack& todo) const
   {
     mark_func(todo);
   }
 
-  inline std::size_t size() const 
+  std::size_t size() const
   {
     return size_func();
   }
@@ -72,358 +74,307 @@ private:
   std::function<std::size_t()> size_func;
 };
 
-template<class T, typename Type = void >  
-class reference_aterm;
+// Forward declaration.
+template<typename T>
+struct markable_aterm;
 
-
-template<class T>
-struct is_pair_helper : public std::false_type
-{};
-
-template<class T, class U>
-struct is_pair_helper<std::pair<T,U> > : public std::true_type
-{};
-
-template <class T>
-struct is_pair : public is_pair_helper<std::decay_t<T>>
-{};
-
-template<class T>
-struct is_reference_aterm_helper : public std::false_type
-{};
-
-template<class T>
-struct is_reference_aterm_helper<reference_aterm<T> > : public std::true_type
-{};
-
-template <class T>
-struct is_reference_aterm : public is_reference_aterm_helper<std::decay_t<T>>
-{};
-
-/// \brief Base class that should not be used. 
-template<class T, typename Type >
-class reference_aterm
+/// \brief Concept for types that support GC marking.
+/// \details A Markable type provides void mark(term_mark_stack&) const that recursively marks
+///          all aterm_core instances it contains.
+template<typename T>
+concept Markable = requires(const T& t, term_mark_stack& todo)
 {
-protected:
-  using T_type = std::decay_t<T>;
-  T_type m_t;
-public:
-  reference_aterm() = default;
+  { t.mark(todo) } -> std::same_as<void>;
+};
 
-  reference_aterm(const T_type& other) noexcept
-   : m_t(other)
-  { }
- 
-  template <class... Args>
-  reference_aterm(Args&&... args) noexcept
-   : m_t(std::forward<Args>(args)...)
-  { }
- 
-  template <class... Args>
-  reference_aterm(const Args&... args) noexcept
-   : m_t(args...)
-  { }
- 
-  reference_aterm(T_type&& other) noexcept
-   : m_t(std::move(other))
+/// \brief Type trait to detect markable_aterm instantiations.
+template<typename T>
+struct is_markable_aterm : std::false_type
+{};
+
+template<typename T>
+struct is_markable_aterm<markable_aterm<T>> : std::true_type
+{};
+
+/// \brief Returns T if T is already a markable_aterm<U>, otherwise markable_aterm<T>.
+/// \details Prevents double-wrapping when T is already a markable_aterm.
+template<typename T>
+using markable_t = std::conditional_t<is_markable_aterm<std::decay_t<T>>::value, T, markable_aterm<T>>;
+
+// ---- Specialization: fundamental types ----
+
+/// \brief Wrapper for fundamental types (int, bool, etc.) — mark is a no-op.
+template<typename T>
+  requires std::is_fundamental_v<std::decay_t<T>>
+struct markable_aterm<T>
+{
+private:
+  using stored_type = std::decay_t<T>;
+  stored_type m_t{};
+
+public:
+  markable_aterm() noexcept = default;
+
+  markable_aterm(const T& other) noexcept
+    : m_t(other)
   {}
 
-  reference_aterm& operator=(const T_type& other) noexcept
+  markable_aterm(stored_type&& other) noexcept
+    : m_t(std::move(other))
+  {}
+
+  markable_aterm& operator=(const T& other) noexcept
   {
-    static_assert(std::is_base_of_v<aterm_core, T_type>);
+    m_t = other;
+    return *this;
     m_t = other;
     return *this;
   }
 
-  reference_aterm& operator=(T_type&& other) noexcept
-  {
-    static_assert(std::is_base_of_v<aterm_core, T_type>);
-    m_t = std::move(other);
-    return *this;
-  }
-
-  /// Converts implicitly to a protected term of type T.
-  operator T_type&()
-  {
-    return m_t;
-  }
-
-  operator const T_type&() const
-  {
-    return m_t;
-  }
-
-  /// For types that are not a std::pair, or a type convertible to an aterm_core
-  /// it is necessary that a dedicated mark function is provided that calls mark_term
-  /// on all aterm_core types in the class T, when this class is stored in an atermpp container.
-  /// See below for an example, where the code is given for pairs, aterms and built in types.
-  /// The container is traversed during garbage collection, such that all terms in these
-  /// containers are protected individually, without putting them all explicitly in 
-  /// protection sets. 
-  void mark(std::stack<std::reference_wrapper<detail::_aterm>>& todo) const
-  {
-    m_t.mark(todo);
-  }
-
-};
-
-/// \brief A reference aterm_core applied to fundamental types, such as int, bool. Nothing needs to happen with such
-///       terms. But a special class is needed, because such types are not classes, and we cannot derive from it.
-template <class T>
-  requires std::is_fundamental_v<std::decay_t<T>>
-class reference_aterm<T, void>
-{
-protected:
-  using T_type = std::decay_t<T>;
-  T_type m_t;
-
-public:
-
-  /// \brief Default constructor.
-  reference_aterm() noexcept = default;
-  
-  reference_aterm(const T& other) noexcept
-   : m_t(other)
-  { }
-  
-  reference_aterm(T_type&& other) noexcept  
-   : m_t(std::move(other))
-  {} 
-  
-  reference_aterm& operator=(const T& other) noexcept
-  {
-    m_t = other;
-    return *this;
-  }
-
-  reference_aterm& operator=(T&& other) noexcept
+  markable_aterm& operator=(T&& other) noexcept
   {
     m_t = std::move(other);
     return *this;
+    return *this;
   }
 
-  /// Converts implicitly to a protected term of type T.
-  operator T&()
-  {
-    return m_t;
-  } 
+  operator T&() noexcept { return m_t; }
+  operator const T&() const noexcept { return m_t; }
 
-  operator const T&() const
-  {
-    return m_t;
-  }
+  void mark(term_mark_stack& /* todo */) const noexcept {}
 
-  void mark(std::stack<std::reference_wrapper<detail::_aterm>>& /* todo */) const
-  {
-    /* Do nothing */
-  } 
-
-  bool operator==(const reference_aterm& other) const
-  {
-    return m_t==other.m_t;
-  }
-
+  bool operator==(const markable_aterm& other) const { return m_t == other.m_t; }
 };
 
-/// \brief An unprotected term that is stored inside an aterm_container.
-template <typename T>
+// ---- Specialization: aterm_core-derived types ----
+
+/// \brief Unprotected wrapper for aterm_core-derived types stored inside an aterm container.
+/// \details Stores a raw _aterm* without registering it in the GC variable root set.
+///          The owning container registers once via aterm_container instead.
+template<typename T>
   requires std::is_base_of_v<aterm_core, T>
-class reference_aterm<T, void> : public unprotected_aterm_core
+struct markable_aterm<T> : unprotected_aterm_core
 {
-public:
   /// \brief Default constructor.
-  reference_aterm() noexcept = default;
+  markable_aterm() noexcept = default;
 
-  explicit reference_aterm(const unprotected_aterm_core& other) noexcept
+  explicit markable_aterm(const unprotected_aterm_core& other) noexcept
   {
     m_term = detail::address(other);
   }
 
-  reference_aterm(const T& other) noexcept
-   : unprotected_aterm_core(detail::address(other))
-  { }
+  markable_aterm(const T& other) noexcept
+    : unprotected_aterm_core(detail::address(other))
+  {}
 
-  // NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved) unprotected_aterm_core is a non-owning handle; there is nothing to move.
-  reference_aterm(unprotected_aterm_core&& other) noexcept
-   : unprotected_aterm_core(detail::address(other))
-  {
-  }
+  markable_aterm(unprotected_aterm_core&& other) noexcept
+    : unprotected_aterm_core(detail::address(other))
+  {}
 
-  reference_aterm& operator=(const unprotected_aterm_core& other) noexcept
-  {
-    mcrl2::utilities::shared_guard guard = lock_shared_aterm_pool();
-    m_term = detail::address(other);
-    return *this;
-  }
+  markable_aterm& operator=(const unprotected_aterm_core& other) noexcept;
+  markable_aterm& operator=(unprotected_aterm_core&& other) noexcept;
 
-  reference_aterm& operator=(unprotected_aterm_core&& other) noexcept
-  {
-    mcrl2::utilities::shared_guard guard = lock_shared_aterm_pool();
-    m_term = detail::address(std::move(other));
-    return *this;
-  }
-
-  /// Converts implicitly to a protected term of type T.
-  operator T&()
+  operator T&() noexcept
   {
     static_assert(std::is_base_of_v<aterm_core, T>, "Term must be derived from an aterm_core");
-    static_assert(sizeof(T)==sizeof(std::size_t),"Term derived from an aterm_core must not have extra fields");
+    static_assert(sizeof(T) == sizeof(std::size_t), "Term derived from an aterm_core must not have extra fields");
     return reinterpret_cast<T&>(*this);
   }
 
-  operator const T&() const
+  operator const T&() const noexcept
   {
     static_assert(std::is_base_of_v<aterm_core, T>, "Term must be derived from an aterm_core");
-    static_assert(sizeof(T)==sizeof(std::size_t),"Term derived from an aterm_core must not have extra fields");
+    static_assert(sizeof(T) == sizeof(std::size_t), "Term derived from an aterm_core must not have extra fields");
     return reinterpret_cast<const T&>(*this);
-
   }
 
-  void mark(std::stack<std::reference_wrapper<detail::_aterm>>& todo) const
+  void mark(term_mark_stack& todo) const
   {
     if (defined())
     {
-      mark_term(*m_term,todo);
+      mark_term(*m_term, todo);
     }
   }
 };
 
-template <typename T>
-typename std::pair<std::conditional_t<is_reference_aterm<typename T::first_type>::value,
-                       typename T::first_type,
-                       reference_aterm<typename T::first_type>>,
-    std::conditional_t<is_reference_aterm<typename T::second_type>::value,
-        typename T::second_type,
-        reference_aterm<typename T::second_type>>>
-reference_aterm_pair_constructor_helper(const T& other)
+// ---- Specialization: std::pair<F, S> ----
+
+/// \brief Wrapper for std::pair — recursively marks both elements.
+/// \details Each element is stored as markable_t<F> / markable_t<S> to avoid double-wrapping.
+///          Because markable_t<T> always provides mark(), the mark() implementations below
+///          call it directly without any if-constexpr dispatch.
+template<typename F, typename S>
+struct markable_aterm<std::pair<F, S>> : std::pair<markable_t<F>, markable_t<S>>
 {
-  if constexpr (is_reference_aterm<typename T::first_type>::value && is_reference_aterm<typename T::second_type>::value)
-  {
-    return other; 
-  }
-  else if constexpr (is_reference_aterm<typename T::first_type>::value && !is_reference_aterm<typename T::second_type>::value)
-  {
-    return std::pair(other.first, reference_aterm<typename T::second_type>(other.second));
-  }
-  else if constexpr (!is_reference_aterm<typename T::first_type>::value && is_reference_aterm<typename T::second_type>::value)
-  {
-    return std::pair(reference_aterm<typename T::first_type>(other.first),other.second);
-  }
-  else 
-  { 
-    static_assert(!is_reference_aterm<typename T::first_type>::value && 
-                  !is_reference_aterm<typename T::second_type>::value,"Logic error");
-  
-    return std::pair(reference_aterm<typename T::first_type>(other.first), reference_aterm<typename T::second_type>(other.second));
-  }
-}
-
-
-
-
-/// \brief A pair that is stored into an atermpp container. This class takes care that all aterms that occur (recursively) inside
-///        such a pair are marked, whears non-aterm_core types are not marked.
-template <typename T>
-  requires is_pair<T>::value
-class reference_aterm<T, void>
-    : public std::pair<std::conditional_t<is_reference_aterm<typename T::first_type>::value,
-                           typename T::first_type,
-                           reference_aterm<typename T::first_type>>,
-          std::conditional_t<is_reference_aterm<typename T::second_type>::value,
-              typename T::second_type,
-              reference_aterm<typename T::second_type>>>
-{
-protected:
-  using super = std::pair<std::conditional_t<is_reference_aterm<typename T::first_type>::value,
-                              typename T::first_type,
-                              reference_aterm<typename T::first_type>>,
-      std::conditional_t<is_reference_aterm<typename T::second_type>::value,
-          typename T::second_type,
-          reference_aterm<typename T::second_type>>>;
-  using std_pair = T;
+private:
+  using std_pair = std::pair<F, S>;
+  using super = std::pair<markable_t<F>, markable_t<S>>;
 
 public:
-  /// \brief Default constructor.
-  reference_aterm() = default;
+  markable_aterm() = default;
+  markable_aterm(const markable_aterm&) = default;
+  markable_aterm(markable_aterm&&) = default;
+  markable_aterm& operator=(const markable_aterm&) = default;
+  markable_aterm& operator=(markable_aterm&&) = default;
 
-  reference_aterm(const reference_aterm& other)
-    : super()
-  {
-    *this = other;
-  }
-
-  reference_aterm(const std_pair& other)
-    : super(reference_aterm_pair_constructor_helper(other))
+  markable_aterm(const std_pair& other)
+    : super(markable_t<F>(other.first), markable_t<S>(other.second))
   {}
 
-  // NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved) both members of other are moved individually below.
-  reference_aterm(std_pair&& other)
-   : super(reference_aterm<typename T::first_type >(std::move(other.first)),
-           reference_aterm<typename T::second_type>(std::move(other.second)))
+  markable_aterm(std_pair&& other)
+    : super(markable_t<F>(std::move(other.first)), markable_t<S>(std::move(other.second)))
   {}
 
-  reference_aterm& operator=(const reference_aterm& other)
+  markable_aterm& operator=(const std_pair& other)
   {
-    super::first=other.first;
-    super::second=other.second;
+    super::first = other.first;
+    super::second = other.second;
     return *this;
   }
 
-  reference_aterm& operator=(const std_pair& other)
-  {
-    super::first=other.first;
-    super::second=other.second;
-    return *this;
-  }
-
-  reference_aterm& operator=(reference_aterm&& other) noexcept
+  markable_aterm& operator=(std_pair&& other)
   {
     super::first = std::move(other.first);
     super::second = std::move(other.second);
     return *this;
   }
 
-  // NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved) both members of other are moved individually below.
-  reference_aterm& operator=(std_pair&& other)
-  {
-    super::first = std::move(other.first);
-    super::second = std::move(other.second);
-    return *this;
-  }
-
-
-  /// Converts implicitly to a protected term of type std::pair<T,U>..
   operator std_pair&()
   {
+    return *reinterpret_cast<std_pair*>(this);
     return *reinterpret_cast<std_pair*>(this);
   }
 
   operator const std_pair&() const
   {
-    return *reinterpret_cast<std_pair const*>(this);
+    return *reinterpret_cast<const std_pair*>(this);
   }
 
-  void mark(std::stack<std::reference_wrapper<detail::_aterm>>& todo) const
+  void mark(term_mark_stack& todo) const
   {
-    if constexpr (is_reference_aterm<typename T::first_type>::value)
-    {
-      super::first.mark(todo);
-    }
-    else 
-    {
-      reference_aterm<typename T::first_type>(super::first).mark(todo);
-    }
-
-    if constexpr (is_reference_aterm<typename T::second_type>::value)
-    {
-      super::second.mark(todo);
-    }
-    else 
-    {
-      reference_aterm<typename T::second_type>(super::second).mark(todo);
-    }
+    super::first.mark(todo);
+    super::second.mark(todo);
   }
-}; 
+};
+
+// ---- Specialization: std::vector<T, Alloc> ----
+
+/// \brief Wrapper for std::vector — recursively marks all elements.
+/// \details Elements are stored as markable_t<T> to avoid double-wrapping.
+template<typename T, typename Alloc>
+struct markable_aterm<std::vector<T, Alloc>>
+  : std::vector<markable_t<T>, typename std::allocator_traits<Alloc>::template rebind_alloc<markable_t<T>>>
+{
+private:
+  using stored_type = markable_t<T>;
+  using stored_alloc = typename std::allocator_traits<Alloc>::template rebind_alloc<stored_type>;
+  using std_vector = std::vector<T, Alloc>;
+  using super = std::vector<stored_type, stored_alloc>;
+
+public:
+  markable_aterm() = default;
+
+  markable_aterm(const std_vector& other)
+  {
+    this->reserve(other.size());
+    for (const auto& v : other)
+      this->emplace_back(v);
+  }
+
+  markable_aterm(std_vector&& other)
+  {
+    this->reserve(other.size());
+    for (auto& v : other)
+      this->emplace_back(std::move(v));
+  }
+
+  markable_aterm& operator=(const std_vector& other)
+  {
+    this->clear();
+    this->reserve(other.size());
+    for (const auto& v : other)
+      this->emplace_back(v);
+    return *this;
+  }
+
+  markable_aterm& operator=(std_vector&& other)
+  {
+    this->clear();
+    this->reserve(other.size());
+    for (auto& v : other)
+      this->emplace_back(std::move(v));
+    return *this;
+  }
+
+  operator std_vector&()
+  {
+    return *reinterpret_cast<std_vector*>(this);
+  }
+
+  operator const std_vector&() const
+  {
+    return *reinterpret_cast<const std_vector*>(this);
+  }
+
+  void mark(term_mark_stack& todo) const
+  {
+    for (const auto& element : *this)
+      element.mark(todo);
+  }
+};
+
+// ---- Primary template: user-defined Markable types ----
+
+/// \brief Wrapper for user-defined types that provide their own mark() implementation.
+/// \details T must satisfy the Markable concept by providing void mark(term_mark_stack&) const.
+///          This is the extension point for types that contain aterm_core instances but are
+///          not fundamental, aterm-derived, std::pair, or std::vector.
+template<typename T>
+struct markable_aterm
+{
+private:
+  using stored_type = std::decay_t<T>;
+  stored_type m_t;
+
+public:
+  markable_aterm() = default;
+
+  markable_aterm(const stored_type& other) noexcept
+    : m_t(other)
+  {}
+
+  template<typename... Args>
+  markable_aterm(Args&&... args) noexcept
+    : m_t(std::forward<Args>(args)...)
+  {}
+
+  markable_aterm& operator=(const stored_type& other) noexcept
+  {
+    m_t = other;
+    return *this;
+  }
+
+  markable_aterm& operator=(stored_type&& other) noexcept
+  {
+    m_t = std::move(other);
+    return *this;
+  }
+
+  operator stored_type&() { return m_t; }
+  operator const stored_type&() const { return m_t; }
+
+  void mark(term_mark_stack& todo) const
+  {
+    static_assert(Markable<stored_type>,
+      "T must be a fundamental type, an aterm_core-derived type, a std::pair, "
+      "a std::vector, or provide void mark(term_mark_stack&) const");
+    m_t.mark(todo);
+  }
+};
+
+/// \brief Backward-compatible alias for markable_aterm.
+template<typename T>
+using reference_aterm = markable_aterm<T>;
 
 template<typename T, typename Allocator>
 class aterm_allocator
@@ -441,15 +392,13 @@ public:
 
   aterm_allocator() = default;
 
-  /// \details The unused parameter is to make the interface equivalent
-  ///          to the allocator.
+  /// \details The unused parameter is to make the interface equivalent to the allocator.
   T* allocate(size_type n, const void* hint = nullptr)
   {
     return m_allocator.allocate(n, hint);
   }
 
-  /// \details The unused parameter is to make the interface equivalent
-  ///          to the allocator.
+  /// \details The unused parameter is to make the interface equivalent to the allocator.
   void deallocate(T* p, size_type n);
 
   // Move assignment and construction is possible.
@@ -464,42 +413,32 @@ template<typename Container>
 class generic_aterm_container
 {
 public:
-  /// \brief Constructor
+  /// \brief Constructor. Registers the container with the GC.
   generic_aterm_container(const Container& container)
-   : m_container([&container](term_mark_stack& todo) {   
-      // Marking contained terms.       
-      for (const typename Container::value_type& element: container) 
-      {
-        static_assert(is_reference_aterm<reference_aterm<typename Container::value_type> >::value);
-        if constexpr (is_reference_aterm<typename Container::value_type>::value)
-        {
-          static_assert(is_reference_aterm<typename Container::value_type >::value);
-          element.mark(todo);
-        }
-        else
-        {
-          static_assert(!is_reference_aterm<typename Container::value_type >::value);
-          reference_aterm<typename Container::value_type>(element).mark(todo);
-        }
-      }
-    },
-    [&container]() -> std::size_t {  
-      // Return the number of elements in the container.
-      return container.size();
-     })
+    : m_container(
+        [&container](term_mark_stack& todo) {
+          for (const auto& element : container)
+          {
+            if constexpr (Markable<typename Container::value_type>)
+            {
+              element.mark(todo);
+            }
+            else
+            {
+              markable_aterm<typename Container::value_type>(element).mark(todo);
+            }
+          }
+        },
+        [&container]() -> std::size_t { return container.size(); })
   {}
 
-  // Container is a reference so unclear what to do in these cases.
+  // Container is a reference so copy/move construction is not meaningful.
   generic_aterm_container(const generic_aterm_container&) = delete;
   generic_aterm_container(generic_aterm_container&&) = delete;
 
-  // It is fine here if the container gets updated, but the functions stay the same.
-  generic_aterm_container& operator=(const generic_aterm_container&) 
-  {
-    return *this;
-  };
-
-  generic_aterm_container& operator=(generic_aterm_container&&) noexcept { return *this; }
+  // The captured reference stays valid; assignment is a no-op.
+  generic_aterm_container& operator=(const generic_aterm_container&) { return *this; }
+  generic_aterm_container& operator=(generic_aterm_container&&) { return *this; }
 
 protected:
   aterm_container m_container;
@@ -512,10 +451,10 @@ namespace std
 {
 
 /// \brief specialization of the standard std::hash function.
-template<class T>
-struct hash<atermpp::detail::reference_aterm<T>>
+template<typename T>
+struct hash<atermpp::detail::markable_aterm<T>>
 {
-  std::size_t operator()(const atermpp::detail::reference_aterm<T>& t) const
+  std::size_t operator()(const atermpp::detail::markable_aterm<T>& t) const
   {
     return std::hash<T>()(t);
   }

--- a/libraries/atermpp/include/mcrl2/atermpp/detail/aterm_implementation.h
+++ b/libraries/atermpp/include/mcrl2/atermpp/detail/aterm_implementation.h
@@ -18,6 +18,24 @@ namespace atermpp
 
 namespace detail
 {
+template <typename T>
+  requires std::is_base_of_v<aterm_core, T>
+markable_aterm<T>& markable_aterm<T>::operator=(const unprotected_aterm_core& other) noexcept
+{
+  mcrl2::utilities::shared_guard guard = detail::g_thread_term_pool().lock_shared();
+  m_term = address(other);
+  return *this;
+}
+
+template <typename T>
+  requires std::is_base_of_v<aterm_core, T>
+markable_aterm<T>& markable_aterm<T>::operator=(unprotected_aterm_core&& other) noexcept
+{
+  mcrl2::utilities::shared_guard guard = detail::g_thread_term_pool().lock_shared();
+  m_term = address(other);
+  return *this;
+}
+
   template<typename T, typename Allocator>
   void aterm_allocator<T,Allocator>::deallocate(T* p, size_type n)
   {

--- a/libraries/atermpp/include/mcrl2/atermpp/standard_containers/deque.h
+++ b/libraries/atermpp/include/mcrl2/atermpp/standard_containers/deque.h
@@ -29,13 +29,13 @@ namespace atermpp
 {
 
 /// \brief A deque class in which aterms can be stored. 
-template < class T, class Alloc = std::allocator<detail::reference_aterm<T> > > 
-class deque : public std::deque< detail::reference_aterm<T>, Alloc >              
+template < class T, class Alloc = std::allocator<detail::markable_aterm<T> > > 
+class deque : public std::deque< detail::markable_aterm<T>, Alloc >              
 {
 protected:
-  using super = std::deque<detail::reference_aterm<T>, Alloc>;
+  using super = std::deque<detail::markable_aterm<T>, Alloc>;
 
-  detail::generic_aterm_container<std::deque<detail::reference_aterm<T>, Alloc>> container_wrapper;
+  detail::generic_aterm_container<std::deque<detail::markable_aterm<T>, Alloc>> container_wrapper;
 
 public:
   
@@ -67,7 +67,7 @@ public:
 
   /// \brief Constructor.
   deque(size_type n, const value_type& val, const allocator_type& alloc = allocator_type())
-   : super::deque(n, detail::reference_aterm(val), alloc),
+   : super::deque(n, detail::markable_aterm<T>(val), alloc),
      container_wrapper(*this)    
   {}
 

--- a/libraries/atermpp/include/mcrl2/atermpp/standard_containers/unordered_map.h
+++ b/libraries/atermpp/include/mcrl2/atermpp/standard_containers/unordered_map.h
@@ -30,16 +30,16 @@ namespace atermpp
 /// \brief A unordered_map class in which aterms can be stored. 
 template < class Key, 
            class T,
-           class Hash = std::hash<detail::reference_aterm<Key> >,
-           class Pred = std::equal_to<detail::reference_aterm<Key> >,
-           class Alloc = std::allocator< std::pair<const detail::reference_aterm<Key>, detail::reference_aterm<T> > > >
+           class Hash = std::hash<detail::markable_aterm<Key> >,
+           class Pred = std::equal_to<detail::markable_aterm<Key> >,
+           class Alloc = std::allocator< std::pair<const detail::markable_aterm<Key>, detail::markable_aterm<T> > > >
 
-class unordered_map : public std::unordered_map< detail::reference_aterm<Key>, detail::reference_aterm<T>, Hash, Pred, Alloc >
+class unordered_map : public std::unordered_map< detail::markable_aterm<Key>, detail::markable_aterm<T>, Hash, Pred, Alloc >
 {
 protected:
-  using super = std::unordered_map<detail::reference_aterm<Key>, detail::reference_aterm<T>, Hash, Pred, Alloc>;
+  using super = std::unordered_map<detail::markable_aterm<Key>, detail::markable_aterm<T>, Hash, Pred, Alloc>;
 
-  detail::generic_aterm_container<std::unordered_map< detail::reference_aterm<Key>, detail::reference_aterm<T>, Hash, Pred, Alloc > > container_wrapper;
+  detail::generic_aterm_container<std::unordered_map< detail::markable_aterm<Key>, detail::markable_aterm<T>, Hash, Pred, Alloc > > container_wrapper;
 
 public:
   
@@ -68,6 +68,11 @@ public:
   /// \brief Constructor.
   explicit unordered_map (size_type n, const allocator_type& alloc = allocator_type())
    : super::unordered_map(n, alloc),
+     container_wrapper(*this)     
+  {}
+
+  unordered_map (size_type n, const value_type& val, const allocator_type& alloc = allocator_type())
+   : super::unordered_map(n, detail::markable_aterm<std::pair<const Key, T>>(val), alloc),
      container_wrapper(*this)     
   {}
 
@@ -228,19 +233,19 @@ namespace utilities
 /// \brief A unordered_map class in which aterms can be stored. 
 template < class Key,
   class T,
-  class Hash = std::hash<detail::reference_aterm<Key> >,
-  class Pred = std::equal_to<detail::reference_aterm<Key> >,
-  class Alloc = std::allocator< std::pair<const detail::reference_aterm<Key>, detail::reference_aterm<T> > >,
+  class Hash = std::hash<detail::markable_aterm<Key> >,
+  class Pred = std::equal_to<detail::markable_aterm<Key> >,
+  class Alloc = std::allocator< std::pair<const detail::markable_aterm<Key>, detail::markable_aterm<T> > >,
   bool ThreadSafe = false >
 
-class unordered_map : public mcrl2::utilities::unordered_map< detail::reference_aterm<Key>, 
-                                                              detail::reference_aterm<T>, Hash, Pred, Alloc, ThreadSafe, false >
+class unordered_map : public mcrl2::utilities::unordered_map< detail::markable_aterm<Key>, 
+                                                              detail::markable_aterm<T>, Hash, Pred, Alloc, ThreadSafe, false >
 {
   protected:
     using super = mcrl2::utilities::
-        unordered_map<detail::reference_aterm<Key>, detail::reference_aterm<T>, Hash, Pred, Alloc, ThreadSafe, false>;
+        unordered_map<detail::markable_aterm<Key>, detail::markable_aterm<T>, Hash, Pred, Alloc, ThreadSafe, false>;
 
-    detail::generic_aterm_container<mcrl2::utilities::unordered_map< detail::reference_aterm<Key>, detail::reference_aterm<T>, Hash, Pred, Alloc, ThreadSafe, false > > container_wrapper;
+    detail::generic_aterm_container<mcrl2::utilities::unordered_map< detail::markable_aterm<Key>, detail::markable_aterm<T>, Hash, Pred, Alloc, ThreadSafe, false > > container_wrapper;
 
   public:
 
@@ -267,6 +272,11 @@ class unordered_map : public mcrl2::utilities::unordered_map< detail::reference_
     /// \brief Constructor.
     explicit unordered_map(size_type n, const allocator_type& alloc = allocator_type())
       : super::unordered_map(n, alloc),
+      container_wrapper(*this)
+    {}
+
+    unordered_map(size_type n, const value_type& val, const allocator_type& alloc = allocator_type())
+      : super::unordered_map(n, detail::markable_aterm<std::pair<const Key, T>>(val), alloc),
       container_wrapper(*this)
     {}
 

--- a/libraries/atermpp/include/mcrl2/atermpp/standard_containers/vector.h
+++ b/libraries/atermpp/include/mcrl2/atermpp/standard_containers/vector.h
@@ -29,13 +29,13 @@ namespace atermpp
 {
 
 /// \brief A vector class in which aterms can be stored. 
-template < class T, class Alloc = std::allocator<detail::reference_aterm<T> >, bool ThreadSafe = false > 
-class vector : public std::vector< detail::reference_aterm<T>, Alloc >
+template < class T, class Alloc = std::allocator<detail::markable_aterm<T> >, bool ThreadSafe = false > 
+class vector : public std::vector< detail::markable_aterm<T>, Alloc >
 {
 protected:
-  using super = std::vector<detail::reference_aterm<T>, Alloc>;
+  using super = std::vector<detail::markable_aterm<T>, Alloc>;
 
-  detail::generic_aterm_container<std::vector<detail::reference_aterm<T>, Alloc>> container_wrapper;
+  detail::generic_aterm_container<std::vector<detail::markable_aterm<T>, Alloc>> container_wrapper;
 
 public: 
   /// Standard typedefs.
@@ -65,7 +65,7 @@ public:
   {}
 
   vector (size_type n, const value_type& val, const allocator_type& alloc = allocator_type())
-   : super::vector(n, detail::reference_aterm(val), alloc),
+   : super::vector(n, detail::markable_aterm<T>(val), alloc),
      container_wrapper(*this)
   {}
 

--- a/libraries/atermpp/source/aterm_io_binary.cpp
+++ b/libraries/atermpp/source/aterm_io_binary.cpp
@@ -79,7 +79,7 @@ binary_aterm_ostream::~binary_aterm_ostream()
 /// \brief Keep track of whether the term can be written to the stream.
 struct write_todo
 {
-  detail::reference_aterm<aterm> term;
+  detail::markable_aterm<aterm> term;
   bool write = false;
 
   write_todo(const aterm& term)

--- a/libraries/data/include/mcrl2/data/substitutions/mutable_indexed_substitution.h
+++ b/libraries/data/include/mcrl2/data/substitutions/mutable_indexed_substitution.h
@@ -183,7 +183,7 @@ public:
   /// \param   v The variable to which the subsitution is applied.
   /// \param   target The target into which the substitution is stored. 
   template <class ResultType>
-  void apply(const variable_type& v, ResultType& target)
+  void apply(const variable_type& v, ResultType& target) const
   {
     static_assert(
         std::is_same_v<ResultType&, expression_type&> || std::is_same_v<ResultType&, atermpp::unprotected_aterm_core&>);

--- a/libraries/lps/include/mcrl2/lps/explorer.h
+++ b/libraries/lps/include/mcrl2/lps/explorer.h
@@ -35,10 +35,7 @@
 #include "mcrl2/lps/replace_constants_by_variables.h"
 #include "mcrl2/lps/resolve_name_clashes.h"
 #include "mcrl2/lps/stochastic_state.h"
-
-#ifdef MCRL2_USE_PROJECTIONS
 #include "mcrl2/lps/explorer_projections.h"
-#endif
 
 #ifdef MCRL2_USE_CONTROL_FLOW
 #include <boost/container/small_vector.hpp>
@@ -200,8 +197,7 @@ class explorer: public abortable
         compute_state(result.states.back(),next_state,sigma,rewr);
       }
     }
-
-#ifdef MCRL2_USE_PROJECTIONS
+    
     template <typename DataExpressionSequence, typename IndexSequence>
     void compute_projected_state(
         lps::state& result,
@@ -262,7 +258,6 @@ class explorer: public abortable
         compute_projected_state(result.states.back(), next_state, I_w, sigma, rewr);
       }
     }
-#endif
 
     /// Rewrite action a, and put it back in place.
     lps::multi_action rewrite_action(
@@ -316,7 +311,6 @@ class explorer: public abortable
       }
     }
 
-#ifdef MCRL2_USE_PROJECTIONS
     // Generic enumeration primitive.
     // The callback determines whether solutions are:
     //  - consumed immediately,
@@ -376,7 +370,6 @@ class explorer: public abortable
         }
       );
     }
-#endif
 
     // Generates outgoing transitions for a summand, and reports them via the callback function report_transition.
     // It is assumed that the substitution sigma contains the assignments corresponding to the current state.
@@ -406,7 +399,6 @@ class explorer: public abortable
       }
 #endif
 
-#ifdef MCRL2_USE_PROJECTIONS
       auto process_transition =
         [&](const data::data_expression_list* assignments)
         {
@@ -546,14 +538,12 @@ class explorer: public abortable
             }
           }
         };
-#endif
 
       if (!m_recursive)
       {
         id_generator.clear();
       }
 
-#ifdef MCRL2_USE_PROJECTIONS
       if (m_options.use_projections && !summand.I_r.empty())
       {
         lps::state key;
@@ -621,170 +611,7 @@ class explorer: public abortable
           process_transition(e.empty() ? nullptr : &e);
         }
       }
-#else
-      if (summand.cache_strategy == caching::none)
-      {
-        rewr(condition, summand.condition, sigma);
-        if (!data::is_false(condition))
-        {
-          if (summand.variables.size()==0)
-          {
-            // There is only one solution that is generated as there are no variables. 
-            check_enumerator_solution(condition, summand,sigma,rewr);
-            if constexpr (Stochastic)
-            {
-              compute_stochastic_state(s1, summand.distribution, summand.next_state, sigma, rewr, enumerator);
-            }
-            else
-            {
-              compute_state(s1,summand.next_state,sigma,rewr);
-              if (!confluent_summands.empty())
-              {
-                s1 = find_representative(s1, confluent_summands, sigma, rewr, enumerator, id_generator); 
-              }
-            }
-            if constexpr (ReportActions)
-            {
-              if (m_options.rewrite_actions)
-              {
-                lps::multi_action a=rewrite_action(summand.multi_action,sigma,rewr);
-                report_transition(a,s1);
-              }
-              else
-              {
-                report_transition(summand.multi_action,s1);
-              }
-            }
-            else
-            {
-              report_transition(s1);
-            }
-          }
-          else // There are variables to be enumerated.
-          {
-            enumerator.enumerate<enumerator_element>(
-                        summand.variables, 
-                        condition,
-                        sigma,
-                        [&](const enumerator_element& p) {
-                          check_enumerator_solution(p.expression(), summand, sigma, rewr);
-                          p.add_assignments(summand.variables, sigma, rewr);
-                          variables_are_assigned_to_sigma=true;
-                          state_type s1; // TODO: wasn't the redundant parameter s1 added to the interface to avoid this declaration?
-                          if constexpr (Stochastic)
-                          {
-                            compute_stochastic_state(s1, summand.distribution, summand.next_state, sigma, rewr, enumerator);
-                          }
-                          else
-                          {
-                            compute_state(s1,summand.next_state,sigma,rewr);
-                            if (!confluent_summands.empty())
-                            {
-                              s1 = find_representative(s1, confluent_summands, sigma, rewr, enumerator, id_generator);
-                            }
-                          }
-                          if (m_recursive && variables_are_assigned_to_sigma)
-                          {
-                            data::remove_assignments(sigma, summand.variables);
-                            variables_are_assigned_to_sigma=false;
-                          }
-                          if constexpr (ReportActions)
-                          {
-                            if (m_options.rewrite_actions)
-                            {
-                              lps::multi_action a=rewrite_action(summand.multi_action,sigma,rewr);
-                              report_transition(a,s1);
-                            }
-                            else
-                            {
-                              report_transition(summand.multi_action,s1);
-                            }
-                          }
-                          else
-                          {
-                            report_transition(s1);
-                          }
-                          return false;
-                        },
-                        data::is_false
-            );
-          }
-        }
-      }
-      else
-      {
-        summand_cache_map& cache = summand.cache_strategy == caching::global ? global_cache : summand.local_cache;
-        // The result of find is sometimes compared with the "end()" below, where the end() belongs to
-        // the cache which is resized in the meantime. The lock is needed to avoid this premature resizing.
-        utilities::shared_guard g=atermpp::detail::g_thread_term_pool().lock_shared();
-        summand_cache_map::iterator q = cache.find(detail::cheap_cache_key(sigma, summand.gamma));
-        if (q == cache.end())
-        {
-          g.unlock_shared();
-          rewr(condition, summand.condition, sigma);
-          atermpp::term_list<data::data_expression_list> solutions;
-          if (!data::is_false(condition))
-          {
-            enumerator.enumerate<enumerator_element>(
-                        summand.variables,
-                        condition,
-                        sigma,
-                        [&](const enumerator_element& p) {
-                          check_enumerator_solution(p.expression(), summand, sigma, rewr);
-                          solutions.push_front(p.assign_expressions(summand.variables, rewr));
-                          return false;
-                        },
-                        data::is_false
-                      );
-          }
-          summand.compute_key(key, sigma);
-          q = cache.insert({key, solutions}).first;
-        }
-        else
-        {
-          g.unlock_shared();
-        }
 
-        for (const data::data_expression_list& e: static_cast<atermpp::term_list<data::data_expression_list>&>(q->second))
-        {
-          data::add_assignments(sigma, summand.variables, e);
-          variables_are_assigned_to_sigma=true;
-          if constexpr (Stochastic)
-          {
-            compute_stochastic_state(s1, summand.distribution, summand.next_state, sigma, rewr, enumerator);
-          }
-          else
-          {
-            compute_state(s1,summand.next_state,sigma,rewr);
-            if (!confluent_summands.empty())
-            {
-              s1 = find_representative(s1, confluent_summands, sigma, rewr, enumerator, id_generator);
-            }
-          }
-          if (m_recursive && variables_are_assigned_to_sigma)
-          {
-            data::remove_assignments(sigma, summand.variables);
-            variables_are_assigned_to_sigma=false;
-          }
-          if constexpr (ReportActions)
-          {
-            if (m_options.rewrite_actions)
-            {
-              lps::multi_action a=rewrite_action(summand.multi_action,sigma,rewr);
-              report_transition(a,s1);
-            }
-            else
-            {
-              report_transition(summand.multi_action,s1);
-            }
-          }
-          else
-          {
-            report_transition(s1);
-          }
-        }
-      }
-#endif // !MCRL2_USE_PROJECTIONS
       if (!m_recursive && variables_are_assigned_to_sigma)
       {
         data::remove_assignments(sigma, summand.variables);
@@ -991,7 +818,6 @@ class explorer: public abortable
         }
       }
 
-#ifdef MCRL2_USE_PROJECTIONS
       // Initialize the read/write projections
       if (m_options.use_projections)
       {
@@ -1001,7 +827,6 @@ class explorer: public abortable
           m_regular_summands[i].set_projection_attributes(R[i], W[i]);
         }
       }
-#endif
     }
 
     ~explorer() override = default;

--- a/libraries/lps/include/mcrl2/lps/explorer.h
+++ b/libraries/lps/include/mcrl2/lps/explorer.h
@@ -36,6 +36,15 @@
 #include "mcrl2/lps/resolve_name_clashes.h"
 #include "mcrl2/lps/stochastic_state.h"
 
+#ifdef MCRL2_USE_PROJECTIONS
+#include "mcrl2/lps/explorer_projections.h"
+#endif
+
+#ifdef MCRL2_USE_CONTROL_FLOW
+#include <boost/container/small_vector.hpp>
+#include "mcrl2/lps/explorer_control_flow.h"
+#endif
+
 namespace mcrl2::lps {
 
 template <bool Stochastic, bool Timed, typename Specification>
@@ -90,6 +99,10 @@ class explorer: public abortable
 
     // used by make_timed_state, to avoid needless creation of vectors
     mutable std::vector<data::data_expression> timed_state;
+
+#ifdef MCRL2_USE_CONTROL_FLOW
+    std::vector<cf_graph> m_control_flow_graphs;
+#endif
 
     Specification preprocess(const Specification& lpsspec)
     {
@@ -188,6 +201,69 @@ class explorer: public abortable
       }
     }
 
+#ifdef MCRL2_USE_PROJECTIONS
+    template <typename DataExpressionSequence, typename IndexSequence>
+    void compute_projected_state(
+        lps::state& result,
+        const DataExpressionSequence& next_state,
+        const IndexSequence& I_w,
+        data::mutable_indexed_substitution<>& sigma,
+        const data::rewriter& rewr) const
+    {
+      lps::make_state(
+        result,
+        I_w.begin(),
+        I_w.size(),
+        [&](data::data_expression& target, std::size_t i)
+        {
+          rewr(target, next_state[i], sigma);
+        }
+      );
+    }
+
+    template <typename DataExpressionSequence, typename IndexSequence>
+    void compute_stochastic_projected_state(
+        stochastic_state& result,
+        const stochastic_distribution& distribution,
+        const DataExpressionSequence& next_state,
+        const IndexSequence& I_w,
+        data::mutable_indexed_substitution<>& sigma,
+        const data::rewriter& rewr,
+        data::enumerator_algorithm<>& enumerator) const
+    {
+      result.clear();
+      if (distribution.is_defined())
+      {
+        enumerator.enumerate<enumerator_element>(
+          distribution.variables(),
+          distribution.distribution(),
+          sigma,
+          [&](const enumerator_element& p)
+          {
+            p.add_assignments(distribution.variables(), sigma, rewr);
+            result.probabilities.push_back(p.expression());
+            result.states.emplace_back();
+            compute_projected_state(result.states.back(), next_state, I_w, sigma, rewr);
+            return false;
+          },
+          [](const data::data_expression& x) { return x == data::sort_real::real_zero(); }
+        );
+        data::remove_assignments(sigma, distribution.variables());
+
+        if (m_options.check_probabilities)
+        {
+          check_stochastic_state(result, rewr);
+        }
+      }
+      else
+      {
+        result.probabilities.push_back(data::sort_real::real_one());
+        result.states.emplace_back();
+        compute_projected_state(result.states.back(), next_state, I_w, sigma, rewr);
+      }
+    }
+#endif
+
     /// Rewrite action a, and put it back in place.
     lps::multi_action rewrite_action(
                              const lps::multi_action& a,
@@ -209,7 +285,7 @@ class explorer: public abortable
                                                                      args.end(), 
                                                                      [&](data::data_expression& result, 
                                                                          const data::data_expression& x) -> void
-                                                                                 { rewr(result, x, sigma); })); return;     
+                                                                                 { rewr(result, x, sigma); }));
             }
           ),
           a.has_time() ? rewr(time, sigma) : time
@@ -240,9 +316,71 @@ class explorer: public abortable
       }
     }
 
+#ifdef MCRL2_USE_PROJECTIONS
+    // Generic enumeration primitive.
+    // The callback determines whether solutions are:
+    //  - consumed immediately,
+    //  - stored in an enumeration cache, or
+    //  - transformed into projected transitions.
+    template <typename EmitSolution>
+    void enumerate_solutions(
+      const explorer_summand& summand,
+      data::mutable_indexed_substitution<>& sigma,
+      data::rewriter& rewr,
+      data::data_expression& condition,
+      data::enumerator_algorithm<>& enumerator,
+      EmitSolution emit_solution
+    )
+    {
+      rewr(condition, summand.condition, sigma);
+      if (data::is_false(condition))
+      {
+        return;
+      }
+
+      if (summand.variables.empty())
+      {
+        // No enumeration needed
+        check_enumerator_solution(condition, summand, sigma, rewr);
+        emit_solution(data::data_expression_list{});
+      }
+      else
+      {
+        enumerator.enumerate<enumerator_element>(
+          summand.variables,
+          condition,
+          sigma,
+          [&](const enumerator_element& p)
+          {
+            check_enumerator_solution(p.expression(), summand, sigma, rewr);
+            emit_solution(p.assign_expressions(summand.variables, rewr));
+            return false;
+          },
+          data::is_false
+        );
+      }
+    }
+
+    // Projects the current state `x` on the read parameters `I_r`.
+    // * The current state x is encoded in the substitution sigma.
+    // * As a side effect the projected state is assigned to `result`.
+    void project(lps::state& result, const std::vector<std::size_t>& I_r, const data::mutable_indexed_substitution<>& sigma)
+    {
+      lps::make_state(
+        result,
+        I_r.begin(),
+        I_r.size(),
+        [&](data::data_expression& target, std::size_t j)
+        {
+          sigma.apply(m_process_parameters[j], target);
+        }
+      );
+    }
+#endif
+
     // Generates outgoing transitions for a summand, and reports them via the callback function report_transition.
     // It is assumed that the substitution sigma contains the assignments corresponding to the current state.
-    template <typename SummandSequence, typename ReportTransition = utilities::skip>
+    template <bool ReportActions = true, typename SummandSequence, typename ReportTransition = utilities::skip>
     void generate_transitions(
       const explorer_summand& summand,
       const SummandSequence& confluent_summands,
@@ -253,14 +391,237 @@ class explorer: public abortable
       atermpp::aterm key,
       data::enumerator_algorithm<>& enumerator,
       data::enumerator_identifier_generator& id_generator,
+#ifdef MCRL2_USE_CONTROL_FLOW
+      const boost::container::small_vector<std::size_t, 64>& active_cfg_vertices,
+#endif
       ReportTransition report_transition = ReportTransition()
     )
     {
       bool variables_are_assigned_to_sigma=false;
+
+#ifdef MCRL2_USE_CONTROL_FLOW
+      if (m_options.use_control_flow && !m_control_flow_graphs.empty() && !cfg_allows_summand(summand.index, m_control_flow_graphs, active_cfg_vertices))
+      {
+        return;
+      }
+#endif
+
+#ifdef MCRL2_USE_PROJECTIONS
+      auto process_transition =
+        [&](const data::data_expression_list* assignments)
+        {
+          if (assignments)
+          {
+            data::add_assignments(sigma, summand.variables, *assignments);
+            variables_are_assigned_to_sigma = true;
+          }
+
+          if constexpr (Stochastic)
+          {
+            compute_stochastic_state(s1, summand.distribution, summand.next_state, sigma, rewr, enumerator);
+          }
+          else
+          {
+            compute_state(s1, summand.next_state, sigma, rewr);
+            if (!confluent_summands.empty())
+            {
+              s1 = find_representative(s1, confluent_summands, sigma, rewr, enumerator, id_generator);
+            }
+          }
+
+          if constexpr (ReportActions)
+          {
+            if (m_options.rewrite_actions)
+            {
+              lps::multi_action a = rewrite_action(summand.multi_action, sigma, rewr);
+              report_transition(a, s1);
+            }
+            else
+            {
+              report_transition(summand.multi_action, s1);
+            }
+          }
+          else
+          {
+            report_transition(s1);
+          }
+
+          if (m_recursive && variables_are_assigned_to_sigma)
+          {
+            data::remove_assignments(sigma, summand.variables);
+            variables_are_assigned_to_sigma = false;
+          }
+        };
+
+      auto enumerate_projected_transitions =
+        [&]()
+        {
+          std::vector<projected_transition> result;
+          // Enumerate all satisfying valuations and compute projected transitions (action, projected state).
+          // Results are stored in the projection cache.
+          enumerate_solutions(
+            summand, sigma, rewr, condition, enumerator,
+            [&](const data::data_expression_list& e)
+            {
+              data::add_assignments(sigma, summand.variables, e);
+              lps::multi_action a = m_options.rewrite_actions ? rewrite_action(summand.multi_action, sigma, rewr) : summand.multi_action;
+
+              if constexpr (Stochastic)
+              {
+                // lps::stochastic_state q;
+                // compute_stochastic_projected_state(q, summand.distribution, summand.next_state, summand.I_w, sigma, rewr, enumerator);
+                // out.emplace_back(a, q);
+                throw mcrl2::runtime_error("A stochastic projection cache has not been implemented yet");
+              }
+              else
+              {
+                lps::state q;
+                compute_projected_state(q, summand.next_state, summand.I_w, sigma, rewr);
+                result.emplace_back(a, q);
+              }
+
+              data::remove_assignments(sigma, summand.variables);
+            }
+          );
+          return result;
+        };
+
+      auto consume_projected_transitions =
+        [&](const projected_transition& t)
+        {
+          const lps::multi_action& a = t.first;
+          const lps::state& q = t.second;
+
+          // reconstruct full state from sigma and the projected write values q
+          state s_y;
+          std::size_t j = 0;
+          lps::make_state(
+            s_y,
+            counting_iterator(0),
+            m_n, // total number of process parameters
+            [&](data::data_expression& r, std::size_t i)
+            {
+              if (j < summand.I_w.size() && summand.I_w[j] == i)
+              {
+                r = q[j++];
+              }
+              else
+              {
+                // reconstruct x[i] from the substitution sigma
+                rewr(r, m_process_parameters[i], sigma);
+              }
+            }
+          );
+
+          if constexpr (!Stochastic)
+          {
+            state_type y = s_y;
+            if (!confluent_summands.empty())
+            {
+              y = find_representative(y, confluent_summands, sigma, rewr, enumerator, id_generator);
+            }
+            if constexpr (utilities::is_applicable<ReportTransition, state_type, void>::value)
+            {
+              report_transition(y);
+            }
+            else
+            {
+              report_transition(a, y);
+            }
+          }
+          else
+          {
+            // Convert reconstructed state to a Dirac stochastic state.
+            state_type y;
+            y.clear();
+            y.probabilities.push_back(data::sort_real::real_one());
+            y.states.push_back(s_y);
+            if constexpr (utilities::is_applicable<ReportTransition, state_type, void>::value)
+            {
+              report_transition(y);
+            }
+            else
+            {
+              report_transition(a, y);
+            }
+          }
+        };
+#endif
+
       if (!m_recursive)
       {
         id_generator.clear();
       }
+
+#ifdef MCRL2_USE_PROJECTIONS
+      if (m_options.use_projections && !summand.I_r.empty())
+      {
+        lps::state key;
+        project(key, summand.I_r, sigma);
+        utilities::shared_guard g = atermpp::detail::g_thread_term_pool().lock_shared();
+
+        auto it = summand.projection_cache.find(key);
+        if (it == summand.projection_cache.end())
+        {
+          g.unlock_shared();
+
+          std::vector<projected_transition> projected = enumerate_projected_transitions();
+          it = summand.projection_cache.emplace(key, std::move(projected)).first;
+        }
+        else
+        {
+          g.unlock_shared();
+        }
+
+        for (const projected_transition& t : it->second)
+        {
+          consume_projected_transitions(t);
+        }
+      }
+      else if (summand.cache_strategy == caching::none)
+      {
+        // Enumerate and immediately consume all satisfying valuations (no caching, no projection).
+        enumerate_solutions(
+          summand, sigma, rewr, condition, enumerator,
+          [&](const data::data_expression_list& e)
+          {
+            process_transition(&e);
+          }
+        );
+      }
+      else
+      {
+        summand_cache_map& cache = summand.cache_strategy == caching::global ? global_cache : summand.local_cache;
+        utilities::shared_guard g = atermpp::detail::g_thread_term_pool().lock_shared();
+
+        auto q = cache.find(detail::cheap_cache_key(sigma, summand.gamma));
+        if (q == cache.end())
+        {
+          g.unlock_shared();
+
+          atermpp::term_list<data::data_expression_list> solutions;
+          // Enumerate all satisfying valuations for this summand and store them in the cache.
+          enumerate_solutions(
+            summand, sigma, rewr, condition, enumerator,
+            [&](const data::data_expression_list& e)
+            {
+              solutions.push_front(e);
+            }
+          );
+          summand.compute_key(key, sigma);
+          q = cache.insert({key, solutions}).first;
+        }
+        else
+        {
+          g.unlock_shared();
+        }
+
+        for (const auto& e : static_cast<atermpp::term_list<data::data_expression_list>&>(q->second))
+        {
+          process_transition(e.empty() ? nullptr : &e);
+        }
+      }
+#else
       if (summand.cache_strategy == caching::none)
       {
         rewr(condition, summand.condition, sigma);
@@ -282,12 +643,7 @@ class explorer: public abortable
                 s1 = find_representative(s1, confluent_summands, sigma, rewr, enumerator, id_generator); 
               }
             }
-            // Check whether report transition only needs a state, and no action.
-            if constexpr (utilities::is_applicable<ReportTransition,state_type,void>::value)
-            {
-              report_transition(s1);
-            }
-            else
+            if constexpr (ReportActions)
             {
               if (m_options.rewrite_actions)
               {
@@ -298,6 +654,10 @@ class explorer: public abortable
               {
                 report_transition(summand.multi_action,s1);
               }
+            }
+            else
+            {
+              report_transition(s1);
             }
           }
           else // There are variables to be enumerated.
@@ -310,7 +670,7 @@ class explorer: public abortable
                           check_enumerator_solution(p.expression(), summand, sigma, rewr);
                           p.add_assignments(summand.variables, sigma, rewr);
                           variables_are_assigned_to_sigma=true;
-                          state_type s1;
+                          state_type s1; // TODO: wasn't the redundant parameter s1 added to the interface to avoid this declaration?
                           if constexpr (Stochastic)
                           {
                             compute_stochastic_state(s1, summand.distribution, summand.next_state, sigma, rewr, enumerator);
@@ -328,12 +688,7 @@ class explorer: public abortable
                             data::remove_assignments(sigma, summand.variables);
                             variables_are_assigned_to_sigma=false;
                           }
-                          // Check whether report transition only needs a state, and no action.
-                          if constexpr (utilities::is_applicable<ReportTransition,state_type,void>::value)
-                          {
-                            report_transition(s1);
-                          }
-                          else 
+                          if constexpr (ReportActions)
                           {
                             if (m_options.rewrite_actions)
                             {
@@ -345,6 +700,10 @@ class explorer: public abortable
                               report_transition(summand.multi_action,s1);
                             }
                           }
+                          else
+                          {
+                            report_transition(s1);
+                          }
                           return false;
                         },
                         data::is_false
@@ -355,8 +714,8 @@ class explorer: public abortable
       else
       {
         summand_cache_map& cache = summand.cache_strategy == caching::global ? global_cache : summand.local_cache;
-        // The result of find is sometimes compared with the "end()" below, where the end() belongs to 
-        // the cache which is resized in the meantime. The lock is needed to avoid this premature resizing. 
+        // The result of find is sometimes compared with the "end()" below, where the end() belongs to
+        // the cache which is resized in the meantime. The lock is needed to avoid this premature resizing.
         utilities::shared_guard g=atermpp::detail::g_thread_term_pool().lock_shared();
         summand_cache_map::iterator q = cache.find(detail::cheap_cache_key(sigma, summand.gamma));
         if (q == cache.end())
@@ -367,7 +726,7 @@ class explorer: public abortable
           if (!data::is_false(condition))
           {
             enumerator.enumerate<enumerator_element>(
-                        summand.variables, 
+                        summand.variables,
                         condition,
                         sigma,
                         [&](const enumerator_element& p) {
@@ -407,12 +766,7 @@ class explorer: public abortable
             data::remove_assignments(sigma, summand.variables);
             variables_are_assigned_to_sigma=false;
           }
-          // If report transition does not require a transition, do not calculate it. 
-          if constexpr (utilities::is_applicable<ReportTransition,state_type,void>::value)
-          {
-            report_transition(s1);
-          }
-          else
+          if constexpr (ReportActions)
           {
             if (m_options.rewrite_actions)
             {
@@ -424,9 +778,13 @@ class explorer: public abortable
               report_transition(summand.multi_action,s1);
             }
           }
+          else
+          {
+            report_transition(s1);
+          }
         }
-        
       }
+#endif // !MCRL2_USE_PROJECTIONS
       if (!m_recursive && variables_are_assigned_to_sigma)
       {
         data::remove_assignments(sigma, summand.variables);
@@ -448,6 +806,9 @@ class explorer: public abortable
       atermpp::aterm key;
       std::list<transition> transitions;
       data::add_assignments(sigma, m_process_parameters, s);
+#ifdef MCRL2_USE_CONTROL_FLOW
+      auto active_cfg_vertices = compute_active_cfg_vertices(sigma, m_process_parameters, m_control_flow_graphs);
+#endif
       for (const explorer_summand& summand: regular_summands)
       {
         generate_transitions(
@@ -460,6 +821,9 @@ class explorer: public abortable
           key,
           enumerator,
           id_generator,
+#ifdef MCRL2_USE_CONTROL_FLOW
+          active_cfg_vertices,
+#endif
           [&](const lps::multi_action& a, const state_type& s1)
           {
             if constexpr (Timed)
@@ -500,9 +864,12 @@ class explorer: public abortable
       atermpp::aterm key;
       std::vector<state> result;
       data::add_assignments(sigma, m_process_parameters, s0);
+#ifdef MCRL2_USE_CONTROL_FLOW
+      auto active_cfg_vertices = compute_active_cfg_vertices(sigma, m_process_parameters, m_control_flow_graphs);
+#endif
       for (const explorer_summand& summand: summands)
       {
-        generate_transitions(
+        generate_transitions<false>(
           summand,
           confluent_summands,
           sigma,
@@ -512,6 +879,9 @@ class explorer: public abortable
           key,
           enumerator,
           id_generator,
+#ifdef MCRL2_USE_CONTROL_FLOW
+          active_cfg_vertices,
+#endif
           // [&](const lps::multi_action& /* a */, const state& s1) OLD. Calculates transitions, that are not used. 
           [&](const state& s1)
           {
@@ -556,7 +926,7 @@ class explorer: public abortable
       }
     }
 
-private:
+  private:
     bool is_confluent_tau(const multi_action& a)
     {
       if (a.actions().empty())
@@ -571,13 +941,33 @@ private:
     }
 
   public:
-    explorer(const Specification& lpsspec, const explorer_options& options_, const data::rewriter& rewr)
+    explorer(const Specification& lpsspec, const explorer_options& options_, const data::rewriter& rewr
+#ifdef MCRL2_USE_CONTROL_FLOW
+            , const pbes_system::pbesstategraph_options& stategraph_options = {}
+            , bool compute_marking = false
+#endif
+            )
       : m_options(options_),
         m_global_rewr(rewr),
         m_global_enumerator(m_global_rewr, lpsspec.data(), m_global_rewr, m_global_id_generator, false),
         m_global_lpsspec(preprocess(lpsspec)),
         m_discovered(m_options.number_of_threads)
     {
+#ifdef MCRL2_USE_CONTROL_FLOW
+      if constexpr (!Stochastic)
+      {
+        lps::specification control_flow_lpsspec = lpsspec;
+        m_control_flow_graphs = compute_control_flow_graphs(control_flow_lpsspec, stategraph_options, compute_marking);
+        if (mCRL2logEnabled(log::debug))
+        {
+          for (const cf_graph& G: m_control_flow_graphs)
+          {
+            print_graph(G);
+          }
+        }
+      }
+#endif
+
       const data::variable_list& params = m_global_lpsspec.process().process_parameters();
       m_process_parameters = std::vector<data::variable>(params.begin(), params.end());
       m_n = m_process_parameters.size();
@@ -600,6 +990,18 @@ private:
           m_regular_summands.emplace_back(summand, i, m_global_lpsspec.process().process_parameters(), cache_strategy);
         }
       }
+
+#ifdef MCRL2_USE_PROJECTIONS
+      // Initialize the read/write projections
+      if (m_options.use_projections)
+      {
+        auto [R, W] = compute_read_write_patterns_separated(lpsspec);
+        for (std::size_t i = 0; i < m_regular_summands.size(); ++i)
+        {
+          m_regular_summands[i].set_projection_attributes(R[i], W[i]);
+        }
+      }
+#endif
     }
 
     ~explorer() override = default;
@@ -757,6 +1159,9 @@ private:
       data::data_expression condition;
       atermpp::aterm key;
       state_type state;
+#ifdef MCRL2_USE_CONTROL_FLOW
+      auto active_cfg_vertices = compute_active_cfg_vertices(sigma, m_process_parameters, m_control_flow_graphs);
+#endif
       for (const explorer_summand& summand: m_regular_summands)
       {
         generate_transitions(
@@ -769,6 +1174,9 @@ private:
           key,
           enumerator,
           id_generator,
+#ifdef MCRL2_USE_CONTROL_FLOW
+          active_cfg_vertices,
+#endif
           [&](const lps::multi_action& a, const state_type& d1)
           {
             result.emplace_back(lps::multi_action(a.actions(), a.time()), d1);
@@ -814,6 +1222,9 @@ private:
       compute_state(d0,init,sigma,rewr);
       std::vector<std::pair<lps::multi_action, state_type>> result;
       data::add_assignments(sigma, m_process_parameters, d0);
+#ifdef MCRL2_USE_CONTROL_FLOW
+      auto active_cfg_vertices = compute_active_cfg_vertices(sigma, m_process_parameters, m_control_flow_graphs);
+#endif
       generate_transitions(
         m_regular_summands[i],
         m_confluent_summands,
@@ -823,6 +1234,9 @@ private:
         d0,
         enumerator,
         id_generator,
+#ifdef MCRL2_USE_CONTROL_FLOW
+        active_cfg_vertices,
+#endif
         [&](const lps::multi_action& a, const state_type& d1)
         {
           result.emplace_back(lps::multi_action(a), d1);

--- a/libraries/lps/include/mcrl2/lps/explorer_bfs.h
+++ b/libraries/lps/include/mcrl2/lps/explorer_bfs.h
@@ -79,6 +79,9 @@ namespace mcrl2::lps
             std::size_t s_index = discovered.index(current_state,thread_index);
             start_state(thread_index, current_state, s_index);
             data::add_assignments(thread_sigma, m_process_parameters, current_state);
+#ifdef MCRL2_USE_CONTROL_FLOW
+            auto active_cfg_vertices = compute_active_cfg_vertices(thread_sigma, m_process_parameters, m_control_flow_graphs);
+#endif
             for (const explorer_summand& summand: regular_summands)
             {   
               generate_transitions(
@@ -91,8 +94,11 @@ namespace mcrl2::lps
                 key,
                 thread_enumerator,
                 thread_id_generator,
+#ifdef MCRL2_USE_CONTROL_FLOW
+                active_cfg_vertices,
+#endif
                 [&](const lps::multi_action& a, const state_type& s1)
-                {   
+                {
                   if constexpr (Timed)
                   { 
                     const data::data_expression& t = current_state[m_n];

--- a/libraries/lps/include/mcrl2/lps/explorer_control_flow.h
+++ b/libraries/lps/include/mcrl2/lps/explorer_control_flow.h
@@ -1,0 +1,467 @@
+// Author(s): Wieger Wesselink
+// Copyright: see the accompanying file COPYING or copy at
+// https://github.com/mCRL2org/mCRL2/blob/master/COPYING
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+/// \file mcrl2/lps/explorer_control_flow.h
+/// \brief add your file description here.
+
+
+#ifndef MCRL2_EXPLORER_CONTROL_FLOW_H
+#define MCRL2_EXPLORER_CONTROL_FLOW_H
+
+#include <cassert>
+#include <chrono>
+#include <iostream>
+#include <boost/container/small_vector.hpp>
+#include <boost/dynamic_bitset/dynamic_bitset.hpp>
+#include "mcrl2/data/variable.h"
+#include "mcrl2/pbes/detail/lpsstategraph_algorithm.h"
+#include "mcrl2/pbes/io.h"
+
+namespace mcrl2::lps
+{
+
+struct cf_edge;
+
+struct cf_vertex
+{
+  std::size_t j;                    // index of the process parameter
+  data::data_expression value;      // value of the process parameter
+  std::vector<cf_edge*> edges;      // set of outgoing edges
+  boost::dynamic_bitset<> enabled;  // bitset of possibly enabled summands
+};
+
+struct cf_edge
+{
+  cf_vertex* source;             // the source of this edge
+  cf_vertex* target;             // the target of this edge
+  boost::dynamic_bitset<> mask;  // bitset of summands responsible for this transition
+};
+
+struct cf_graph
+{
+  std::vector<cf_vertex> V;                            // vertices of the graph
+  std::vector<cf_edge> E;                              // edges of the graph
+  std::size_t j;                                       // index of the control flow parameter of the graph
+  std::map<data::data_expression, std::size_t> index;  // mapping from parameter values to indices in V
+  boost::dynamic_bitset<> relevant;                    // bitset of summands relevant to this CFG
+};
+
+using edge_label_map = std::unordered_map<const cf_edge*, std::set<std::size_t>>;
+
+inline
+bool cfg_mentions_summand(const cf_graph& G, std::size_t s)
+{
+  for (const cf_edge& e : G.E)
+  {
+    if (e.mask.test(s))
+    {
+      return true;
+    }
+  }
+  return false;
+}
+
+inline
+void initialize_control_flow_bitsets(cf_graph& G, const edge_label_map& edge_labels, std::size_t number_of_summands)
+{
+  // Initialize vertex enabled bitsets
+  for (cf_vertex& v : G.V)
+  {
+    v.enabled = boost::dynamic_bitset<>(number_of_summands);
+  }
+
+  // Initialize edge masks using the external map
+  for (cf_edge& e: G.E)
+  {
+    e.mask = boost::dynamic_bitset<>(number_of_summands);
+
+    auto it = edge_labels.find(&e);
+    if (it != edge_labels.end())
+    {
+      for (std::size_t summand: it->second)
+      {
+        e.mask.set(summand);
+      }
+    }
+  }
+
+  // Compute enabled bitsets per vertex
+  for (cf_vertex& v: G.V)
+  {
+    for (cf_edge* e: v.edges)
+    {
+      v.enabled |= e->mask;
+    }
+  }
+
+  // Set G.relevant bitset
+  G.relevant = boost::dynamic_bitset<>(number_of_summands);
+  for (const cf_vertex& v: G.V)
+  {
+    G.relevant |= v.enabled; // union of all edge masks
+  }
+}
+
+inline
+void print_edge_label_map(const edge_label_map& m)
+{
+  std::cout << "\n=== Edge label map ===\n";
+
+  for (const auto& [edge, labels] : m)
+  {
+    std::cout << "edge " << edge
+              << "  [" << edge->source->value
+              << " -> " << edge->target->value << "]"
+              << "  labels = {";
+
+    bool first = true;
+    for (auto l : labels)
+    {
+      if (!first) std::cout << ", ";
+      std::cout << l;
+      first = false;
+    }
+
+    std::cout << "}\n";
+  }
+
+  std::cout << "======================\n";
+}
+
+inline
+std::vector<cf_graph> extract_local_control_flow_graphs(const pbes_system::detail::lpsstategraph_algorithm& algorithm)
+{
+  using pbes_system::detail::local_control_flow_graph_vertex;
+
+  std::size_t action_summand_count = algorithm.original_lps().process().action_summands().size();
+
+  const auto& local_graphs = algorithm.local_graphs();
+  std::vector<cf_graph> result;
+  result.reserve(local_graphs.size());
+
+  for (const auto& lg: local_graphs)
+  {
+    cf_graph g;
+
+    // All vertices correspond to the same control-flow parameter
+    if (!lg.vertices.empty())
+    {
+      g.j = lg.vertices.begin()->index();
+    }
+
+    // Reserve to keep pointers stable
+    g.V.reserve(lg.vertices.size());
+
+    // Map local CFG vertices to indices in g.V
+    std::map<const local_control_flow_graph_vertex*, std::size_t> vertex_index;
+
+    // First pass: create vertices
+    for (const auto& v: lg.vertices)
+    {
+      cf_vertex cv;
+      cv.j     = g.j;
+      cv.value = v.value();
+      // cv.enabled left empty on purpose
+
+      g.V.push_back(std::move(cv));
+      std::size_t i = g.V.size() - 1;
+
+      g.index[g.V[i].value] = i;
+      vertex_index[&v] = i;
+    }
+
+    // Estimate number of edges to reserve storage
+    std::size_t edge_count = 0;
+    for (const auto& v: lg.vertices)
+    {
+      for (const auto& e: v.outgoing_edges())
+      {
+        edge_count += e.second.size();
+      }
+    }
+    g.E.reserve(edge_count);
+
+    // Second pass: create edges
+    edge_label_map edge_labels;
+
+    for (const auto& v: lg.vertices)
+    {
+      cf_vertex* source = &g.V[vertex_index[&v]];
+
+      for (const auto& entry: v.outgoing_edges())
+      {
+        const local_control_flow_graph_vertex* tgt = entry.first;
+        const std::set<std::size_t>& labels = entry.second;
+
+        cf_vertex* target = &g.V[vertex_index[tgt]];
+
+        for (std::size_t label: labels)
+        {
+          if (label >= action_summand_count)
+          {
+            continue; // ignore deadlock summands
+          }
+          cf_edge e;
+          e.source = source;
+          e.target = target;
+          // e.mask intentionally left empty
+
+          g.E.push_back(std::move(e));
+
+          cf_edge* eptr = &g.E.back();
+          source->edges.push_back(eptr);
+          edge_labels[eptr].insert(label);
+        }
+      }
+    }
+
+    initialize_control_flow_bitsets(g, edge_labels, action_summand_count);
+    result.push_back(std::move(g));
+
+    if (mCRL2logEnabled(log::debug))
+    {
+      print_edge_label_map(edge_labels);
+    }
+  }
+
+  return result;
+}
+
+inline
+std::vector<cf_graph> compute_control_flow_graphs(lps::specification& lpsspec, const pbes_system::pbesstategraph_options& stategraph_options, bool compute_marking = false)
+{
+  if (stategraph_options.use_global_variant)
+  {
+    throw mcrl2::runtime_error("The use global variant option is not supported in lpsstategraph!");
+  }
+  if (stategraph_options.print_influence_graph)
+  {
+    throw mcrl2::runtime_error("The print influence graph option is not supported in lpsstategraph!");
+  }
+  lps::detail::instantiate_global_variables(lpsspec);
+  pbes_system::detail::lpsstategraph_algorithm algorithm(lpsspec, stategraph_options);
+
+  if (compute_marking)
+  {
+    algorithm.run();
+    algorithm.local_graphs().pop_back();
+  }
+  else
+  {
+    algorithm.execute_preprocessing();
+    algorithm.execute_local_graphs_step();  // N.B. The 'extra' graph is not included
+  }
+
+  return extract_local_control_flow_graphs(algorithm);
+}
+
+template <typename Bitset>
+void print_bitset(std::ostream& os, const Bitset& bs)
+{
+  os << "{";
+  bool first = true;
+  for (std::size_t i = 0; i < bs.size(); ++i)
+  {
+    if (bs[i])
+    {
+      if (!first)
+      {
+        os << ", ";
+      }
+      os << i;
+      first = false;
+    }
+  }
+  os << "}";
+}
+
+inline
+void print_graph(const cf_graph& G)
+{
+  const bool is_extra_graph = G.j == std::numeric_limits<std::size_t>::max();
+
+  if (is_extra_graph)
+  {
+    std::cout << "Extra control-flow graph (summands without control-flow parameter)\n";
+  }
+  else
+  {
+    std::cout << "Control-flow graph for parameter index j = " << G.j << "\n";
+  }
+
+  std::cout << "Number of vertices: " << G.V.size() << "\n";
+  std::cout << "Number of edges:    " << G.E.size() << "\n\n";
+
+  for (std::size_t i = 0; i < G.V.size(); ++i)
+  {
+    const cf_vertex& v = G.V[i];
+
+    std::cout << "Vertex " << i << " (value = " << v.value << ")\n";
+    std::cout << "  enabled summands: " << v.enabled << "\n";
+    std::cout << "  outgoing edges:\n";
+
+    for (const cf_edge* e: v.edges)
+    {
+      const cf_vertex* tgt = e->target;
+      std::size_t tgt_index = G.index.at(tgt->value);
+
+      std::cout << "    -> Vertex "
+                << tgt_index
+                << " (value = "
+                << tgt->value
+                << ")";
+
+      if (!is_extra_graph)
+      {
+        std::cout << "  mask = " << e->mask;
+      }
+
+      std::cout << "\n";
+    }
+
+    std::cout << "\n";
+  }
+}
+
+inline
+bool cfg_allows_summand(std::size_t summand,
+                        const data::mutable_indexed_substitution<>& sigma,
+                        const std::vector<data::variable>& process_parameters,
+                        const std::vector<cf_graph>& cfgs)
+{
+  for (const cf_graph& G: cfgs)
+  {
+    if (!G.relevant.test(summand))
+    {
+      continue; // CFG not relevant for this summand
+    }
+    const auto value = sigma(process_parameters[G.j]);
+    const std::size_t v_index = G.index.at(value);
+    const cf_vertex& v = G.V[v_index];
+    if (!v.enabled.test(summand))
+    {
+      return false;
+    }
+  }
+  return true;
+}
+
+struct update_active_cfg_vertices_timer
+{
+  using clock = std::chrono::steady_clock;
+
+  static inline std::chrono::nanoseconds total_time{0};
+
+  clock::time_point start;
+
+  update_active_cfg_vertices_timer()
+    : start(clock::now())
+  {}
+
+  ~update_active_cfg_vertices_timer()
+  {
+    total_time += clock::now() - start;
+  }
+
+  // Printed automatically at program shutdown
+  static void report()
+  {
+    const double seconds =
+      std::chrono::duration<double>(total_time).count();
+
+    std::cerr << "[timing] update_active_cfg_vertices total time: "
+              << seconds << " s\n";
+  }
+};
+
+// Ensures report() is called at program exit
+struct update_active_cfg_vertices_timer_reporter
+{
+  ~update_active_cfg_vertices_timer_reporter()
+  {
+    update_active_cfg_vertices_timer::report();
+  }
+};
+
+// One instance per program
+inline update_active_cfg_vertices_timer_reporter update_active_cfg_vertices_timer_reporter_instance;
+
+template <typename Container>
+void update_active_cfg_vertices(const data::mutable_indexed_substitution<>& sigma,
+                                const std::vector<data::variable>& process_parameters,
+                                const std::vector<cf_graph>& cfgs,
+                                Container& active_cfg_vertices)
+{
+  active_cfg_vertices.resize(cfgs.size());
+  for (std::size_t k = 0; k < cfgs.size(); ++k)
+  {
+    const cf_graph& G = cfgs[k];
+    const auto value = sigma(process_parameters[G.j]);
+    active_cfg_vertices[k] = G.index.at(value);
+  }
+}
+
+template <typename Container = boost::container::small_vector<std::size_t, 64>>
+Container compute_active_cfg_vertices(const data::mutable_indexed_substitution<>& sigma,
+                                      const std::vector<data::variable>& process_parameters,
+                                      const std::vector<cf_graph>& cfgs)
+{
+  Container result;
+  update_active_cfg_vertices(sigma, process_parameters, cfgs, result);
+  return result;
+}
+
+template <typename Container>
+bool cfg_allows_summand(std::size_t summand,
+                        const std::vector<cf_graph>& cfgs,
+                        const Container& active_cfg_vertices)
+{
+  assert(cfgs.size() == active_cfg_vertices.size());
+  for (std::size_t k = 0; k < cfgs.size(); ++k)
+  {
+    const cf_graph& G = cfgs[k];
+    if (!G.relevant.test(summand))
+    {
+      continue; // CFG not relevant for this summand
+    }
+    const cf_vertex& v = G.V[active_cfg_vertices[k]];
+    if (!v.enabled.test(summand))
+    {
+      return false;
+    }
+  }
+  return true;
+}
+
+template <typename State>
+void report_cfg_error(std::size_t summand, const State& state, const std::vector<cf_graph>& cfgs)
+{
+  std::ostringstream out;
+  out << "CFG violation:\n";
+  out << "  summand = " << summand << "\n";
+  out << "  state   = " << state << "\n";
+
+  for (const cf_graph& G: cfgs)
+  {
+    const auto value = state[G.j];
+    const std::size_t v_index = G.index.at(value);
+    const cf_vertex& v = G.V[v_index];
+
+    if (!v.enabled.test(summand))
+    {
+      out << "  rejected by CFG with parameter " << G.j << "\n";
+      out << "  active vertex = " << v.j << "\n";
+    }
+  }
+
+  throw std::runtime_error(out.str());
+}
+
+} // namespace mcrl2::lps
+
+#endif // MCRL2_EXPLORER_CONTROL_FLOW_H

--- a/libraries/lps/include/mcrl2/lps/explorer_options.h
+++ b/libraries/lps/include/mcrl2/lps/explorer_options.h
@@ -30,9 +30,7 @@ struct explorer_options
   bool cached = false;
   bool global_cache = false;
   bool confluence = false;
-#ifdef MCRL2_USE_PROJECTIONS
   bool use_projections = false;
-#endif
 #ifdef MCRL2_USE_CONTROL_FLOW
   bool use_control_flow = false;
 #endif
@@ -82,9 +80,7 @@ std::ostream& operator<<(std::ostream& out, const explorer_options& options)
   out << "global-cache = " << std::boolalpha << options.global_cache << std::endl;
   out << "confluence = " << std::boolalpha << options.confluence << std::endl;
   out << "confluence-action = " << options.confluence_action << std::endl;
-#ifdef MCRL2_USE_PROJECTIONS
   out << "use-projections = " << std::boolalpha << options.use_projections << std::endl;
-#endif
 #ifdef MCRL2_USE_CONTROL_FLOW
   out << "use-control-flow = " << std::boolalpha << options.use_control_flow << std::endl;
 #endif

--- a/libraries/lps/include/mcrl2/lps/explorer_options.h
+++ b/libraries/lps/include/mcrl2/lps/explorer_options.h
@@ -30,6 +30,12 @@ struct explorer_options
   bool cached = false;
   bool global_cache = false;
   bool confluence = false;
+#ifdef MCRL2_USE_PROJECTIONS
+  bool use_projections = false;
+#endif
+#ifdef MCRL2_USE_CONTROL_FLOW
+  bool use_control_flow = false;
+#endif
   bool detect_deadlock = false;
   bool detect_nondeterminism = false;
   bool detect_divergence = false;
@@ -76,6 +82,12 @@ std::ostream& operator<<(std::ostream& out, const explorer_options& options)
   out << "global-cache = " << std::boolalpha << options.global_cache << std::endl;
   out << "confluence = " << std::boolalpha << options.confluence << std::endl;
   out << "confluence-action = " << options.confluence_action << std::endl;
+#ifdef MCRL2_USE_PROJECTIONS
+  out << "use-projections = " << std::boolalpha << options.use_projections << std::endl;
+#endif
+#ifdef MCRL2_USE_CONTROL_FLOW
+  out << "use-control-flow = " << std::boolalpha << options.use_control_flow << std::endl;
+#endif
   out << "one-point-rule-rewrite = " << std::boolalpha << options.one_point_rule_rewrite << std::endl;
   out << "replace-constants-by-variables = " << std::boolalpha << options.replace_constants_by_variables << std::endl;
   out << "remove-unused-rewrite-rules = " << std::boolalpha << options.remove_unused_rewrite_rules << std::endl;

--- a/libraries/lps/include/mcrl2/lps/explorer_projections.h
+++ b/libraries/lps/include/mcrl2/lps/explorer_projections.h
@@ -1,0 +1,174 @@
+// Author(s): Wieger Wesselink
+// Copyright: see the accompanying file COPYING or copy at
+// https://github.com/mCRL2org/mCRL2/blob/master/COPYING
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+/// \file mcrl2/lps/explorer_projections.h
+/// \brief add your file description here.
+
+#ifndef MCRL2_LPS_EXPLORER_PROJECTIONS_H
+#define MCRL2_LPS_EXPLORER_PROJECTIONS_H
+
+#include "mcrl2/lps/lps_summand_group.h"
+#include "mcrl2/lps/state.h"
+#include "mcrl2/lps/find.h"
+
+namespace mcrl2::lps
+{
+
+/// \brief Assigns a unique index to every parameter of the process.
+template <typename Specification>
+std::map<data::variable, std::size_t> compute_process_parameter_index(const Specification& lpsspec)
+{
+  std::map<data::variable, std::size_t> result;
+  std::size_t i = 0;
+  for (const data::variable& v: lpsspec.process().process_parameters())
+  {
+    result[v] = i++;
+  }
+  return result;
+}
+
+// Computes separate bitsets for read and write parameters
+template <typename Specification>
+std::pair<std::vector<std::vector<std::size_t>>, std::vector<std::vector<std::size_t>>> compute_read_write_patterns_separated(const Specification& lpsspec)
+{
+  using utilities::detail::as_vector;
+
+  std::vector<std::vector<std::size_t>> result_r;
+  std::vector<std::vector<std::size_t>> result_w;
+
+  auto process_parameters = as_set(lpsspec.process().process_parameters());
+  std::map<data::variable, std::size_t> index = process_parameter_index(lpsspec);
+
+  for (const auto& summand: lpsspec.process().action_summands())
+  {
+    auto [read_parameters, write_parameters] = read_write_parameters(summand, process_parameters);
+    auto read = symbolic::parameter_indices(read_parameters, index);
+    auto write = symbolic::parameter_indices(write_parameters, index);
+    result_r.push_back(as_vector(read));
+    result_w.push_back(as_vector(write));
+  }
+
+  return {result_r, result_w};
+}
+
+struct counting_iterator
+{
+  using value_type = std::size_t;
+  using difference_type = std::ptrdiff_t;
+  using iterator_category = std::forward_iterator_tag;
+  using pointer = const std::size_t*;
+  using reference = std::size_t;
+
+  std::size_t value;
+
+  explicit counting_iterator(std::size_t v = 0) : value(v) {}
+
+  std::size_t operator*() const
+  {
+    return value;
+  }
+
+  counting_iterator& operator++()
+  {
+    ++value;
+    return *this;
+  }
+
+  counting_iterator operator++(int)
+  {
+    counting_iterator tmp(*this);
+    ++value;
+    return tmp;
+  }
+
+  bool operator==(const counting_iterator& other) const
+  {
+    return value == other.value;
+  }
+
+  bool operator!=(const counting_iterator& other) const
+  {
+    return value != other.value;
+  }
+};
+
+using projected_transition = std::pair<multi_action, state>;
+
+// This struct is used to avoid the explicit construction of the hash key for entries in the projection_cache.
+struct projection_cache_key
+{
+  data::mutable_indexed_substitution<>& sigma;
+  const std::vector<std::size_t>& indices;
+  const data::variable_vector& process_parameters;
+};
+
+// Compare projection_cache_key with a state
+struct projection_cache_equality
+{
+  bool operator()(const atermpp::aterm& key1, const atermpp::aterm& key2) const
+  {
+    return key1 == key2;
+  }
+
+  bool operator()(const atermpp::aterm& stored, const projection_cache_key& k) const
+  {
+    auto it = k.indices.begin();
+    for (const atermpp::aterm& d : stored)
+    {
+      if (it == k.indices.end())
+      {
+        return false;
+      }
+
+      if (d != k.sigma(k.process_parameters[*it]))
+      {
+        return false;
+      }
+      ++it;
+    }
+    return it == k.indices.end();
+  }
+
+  bool operator()(const projection_cache_key& k, const atermpp::aterm& stored) const
+  {
+    return operator()(stored, k);
+  }
+};
+
+struct projection_cache_hash
+{
+  std::size_t operator()(const std::pair<const atermpp::aterm, std::vector<projected_transition>>& pair) const
+  {
+    return operator()(pair.first);
+  }
+
+  std::size_t operator()(const atermpp::aterm& key) const
+  {
+    std::size_t hash = 0;
+    for (const atermpp::aterm& d: key)
+    {
+      hash = atermpp::detail::combine(hash, d);
+    }
+    return hash;
+  }
+
+  std::size_t operator()(const projection_cache_key& key) const
+  {
+    std::size_t hash = 0;
+    for (auto i: key.indices)
+    {
+      const data::variable& v = key.process_parameters[i];
+      hash = atermpp::detail::combine(hash, key.sigma(v));
+    }
+    return hash;
+  }
+};
+
+} // namespace mcrl2::lps
+
+#endif // MCRL2_LPS_EXPLORER_PROJECTIONS_H

--- a/libraries/lps/include/mcrl2/lps/explorer_utilities.h
+++ b/libraries/lps/include/mcrl2/lps/explorer_utilities.h
@@ -16,7 +16,11 @@
 #include "mcrl2/atermpp/standard_containers/detail/unordered_map_implementation.h"
 #include "mcrl2/data/rewriter.h"
 #include "mcrl2/lps/detail/instantiate_global_variables.h"
-#include "mcrl2/lps/explorer_utilities.h"
+#include "mcrl2/atermpp/standard_containers/vector.h"
+
+#ifdef MCRL2_USE_PROJECTIONS
+#include "mcrl2/lps/explorer_projections.h"
+#endif
 
 namespace mcrl2::lps
 {
@@ -168,6 +172,15 @@ using summand_cache_map = atermpp::utilities::unordered_map<atermpp::aterm,
     std::allocator<std::pair<atermpp::aterm, atermpp::term_list<data::data_expression_list>>>,
     true>;
 
+#ifdef MCRL2_USE_PROJECTIONS
+using projection_cache_map = atermpp::utilities::unordered_map<lps::state,
+    std::vector<projected_transition>,
+    projection_cache_hash,
+    projection_cache_equality,
+    std::allocator<std::pair<lps::state, std::vector<projected_transition>>>,
+    true>;
+#endif
+
 struct explorer_summand
 {
   data::variable_list variables;
@@ -182,6 +195,23 @@ struct explorer_summand
   std::vector<data::variable> gamma;
   atermpp::function_symbol f_gamma;
   mutable summand_cache_map local_cache;
+
+#ifdef MCRL2_USE_PROJECTIONS
+  // attributes for projections (these are not initialized during construction!)
+  std::vector<std::size_t> I_r;  // indices of read parameters
+  std::vector<std::size_t> I_w;  // indices of write parameters
+  mutable projection_cache_map projection_cache;
+
+  void set_projection_attributes(const std::vector<std::size_t>& Ir, const std::vector<std::size_t>& Iw)
+  {
+    mCRL2log(log::verbose) << "Setting projection attributes I_r = " << core::detail::print_list(Ir) << " I_w = " << core::detail::print_list(Iw) << std::endl;
+    if (!Ir.empty())
+    {
+      I_r = Ir;
+      I_w = Iw;
+    }
+  }
+#endif
 
   template <typename ActionSummand>
   explorer_summand(const ActionSummand& summand, std::size_t summand_index, const data::variable_list& process_parameters, caching cache_strategy_)

--- a/libraries/lps/include/mcrl2/lps/explorer_utilities.h
+++ b/libraries/lps/include/mcrl2/lps/explorer_utilities.h
@@ -17,10 +17,7 @@
 #include "mcrl2/data/rewriter.h"
 #include "mcrl2/lps/detail/instantiate_global_variables.h"
 #include "mcrl2/atermpp/standard_containers/vector.h"
-
-#ifdef MCRL2_USE_PROJECTIONS
 #include "mcrl2/lps/explorer_projections.h"
-#endif
 
 namespace mcrl2::lps
 {
@@ -172,14 +169,12 @@ using summand_cache_map = atermpp::utilities::unordered_map<atermpp::aterm,
     std::allocator<std::pair<atermpp::aterm, atermpp::term_list<data::data_expression_list>>>,
     true>;
 
-#ifdef MCRL2_USE_PROJECTIONS
 using projection_cache_map = atermpp::utilities::unordered_map<lps::state,
     std::vector<projected_transition>,
     projection_cache_hash,
     projection_cache_equality,
     std::allocator<std::pair<lps::state, std::vector<projected_transition>>>,
     true>;
-#endif
 
 struct explorer_summand
 {
@@ -196,7 +191,6 @@ struct explorer_summand
   atermpp::function_symbol f_gamma;
   mutable summand_cache_map local_cache;
 
-#ifdef MCRL2_USE_PROJECTIONS
   // attributes for projections (these are not initialized during construction!)
   std::vector<std::size_t> I_r;  // indices of read parameters
   std::vector<std::size_t> I_w;  // indices of write parameters
@@ -211,7 +205,6 @@ struct explorer_summand
       I_w = Iw;
     }
   }
-#endif
 
   template <typename ActionSummand>
   explorer_summand(const ActionSummand& summand, std::size_t summand_index, const data::variable_list& process_parameters, caching cache_strategy_)

--- a/libraries/lps/include/mcrl2/lps/lps_summand_group.h
+++ b/libraries/lps/include/mcrl2/lps/lps_summand_group.h
@@ -106,8 +106,8 @@ std::pair<std::set<data::variable>, std::set<data::variable>> read_write_paramet
 }
 
 /// \brief Assigns a unique index to every parameter of the process.
-inline
-std::map<data::variable, std::size_t> process_parameter_index(const lps::specification& lpsspec)
+template <typename Specification>
+std::map<data::variable, std::size_t> process_parameter_index(const Specification& lpsspec)
 {
   std::map<data::variable, std::size_t> result;
   std::size_t i = 0;

--- a/libraries/pbes/include/mcrl2/pbes/detail/lpsstategraph_algorithm.h
+++ b/libraries/pbes/include/mcrl2/pbes/detail/lpsstategraph_algorithm.h
@@ -18,10 +18,6 @@
 #include "mcrl2/pbes/detail/stategraph_global_reset_variables.h"
 #include "mcrl2/pbes/detail/stategraph_local_reset_variables.h"
 
-
-
-
-
 namespace mcrl2::pbes_system::detail {
 
 class lpsstategraph_algorithm;
@@ -117,15 +113,18 @@ class lpsstategraph_algorithm: public local_reset_variables_algorithm
       : local_reset_variables_algorithm(construct_stategraph_pbes(lpsspec), options), m_original_lps(lpsspec)
     {}
 
-    void run() override
+    void execute_postprocessing() override
     {
-      
-      stategraph_local_algorithm::run(); // NOLINT(bugprone-parent-virtual-call)
       m_transformed_lps = m_original_lps;
       compute_occurring_data_parameters();
       start_timer("reset_variables_to_original");
       reset_variables_to_original(m_transformed_lps);
       finish_timer("reset_variables_to_original");
+    }
+
+    const lps::specification& original_lps() const
+    {
+      return m_original_lps;
     }
 
     const lps::specification& result() const
@@ -195,9 +194,5 @@ void lps_reset_variables(lpsstategraph_algorithm& algorithm,
 }
 
 } // namespace mcrl2::pbes_system::detail
-
-
-
-
 
 #endif // MCRL2_PBES_DETAIL_LPSSTATEGRAPH_ALGORITHM_H

--- a/libraries/pbes/include/mcrl2/pbes/detail/stategraph_algorithm.h
+++ b/libraries/pbes/include/mcrl2/pbes/detail/stategraph_algorithm.h
@@ -16,10 +16,6 @@
 #include "mcrl2/pbes/tools/pbesstategraph_options.h"
 #include "mcrl2/utilities/sequence.h"
 
-
-
-
-
 namespace mcrl2::pbes_system::detail {
 
 inline
@@ -61,53 +57,6 @@ class stategraph_algorithm
     data::rewriter m_datar;
 
     // determines how local control flow parameters are computed
-    //
-    // Keuze uit twee alternatieven voor de berekening van lokale CFPs.
-    // <default>
-    //  * Een parameter d^X[n] is een LCFP indien voor alle i waarvoor geldt pred(phi_X,i) = X, danwel:
-    //          a. source(X,i,n) and target(X,i,n) zijn beide defined, of
-    //          b. copy(X,i,n) is defined en gelijk aan n.
-    //
-    // <alternative>
-    //  * Een parameter d^X[n] is een LCFP indien voor alle i waarvoor geldt pred(phi_X,i) = X, danwel:
-    //          a. copy(X,i,n) is undefined en source(X,i,n) and target(X,i,n) zijn beide defined, of
-    //          b. copy(X,i,n) is defined (en gelijk aan n) en source(X,i,n) en target(X,i,n) zijn beide undefined.
-    //
-    // De tweede definieert in feite een exclusive or, terwijl de eerste een standaard or is.
-    bool m_use_alternative_lcfp_criterion;
-
-    // determines how global control flow parameters are related
-    //
-    // Keuze uit twee alternatieven voor het relateren van CFPs.
-    // <default>
-    //  * Parameters d^X[n] and d^Y[m] zijn gerelateerd als danwel:
-    //         a. er is een i z.d.d. copy(X, i, n) = m, of
-    //         b. er is een i z.d.d. copy(Y, i, m) = n
-    //
-    // <alternative>
-    //  * Parameters d^X[n] and d^Y[m] zijn gerelateerd als danwel:
-    //         a. er is een i z.d.d. copy(X, i, n) = m, en target(X, i, m) is ongedefinieerd, of
-    //         b. er is een i z.d.d. copy(Y, i, m) = n en target(Y, i, n) is ongedefinieerd.
-    // Hier zit het verschil er dus in dat we, in het tweede geval, parameters alleen relateren als er een copy is
-    // van de een naar de ander EN de target in dat geval ongedefinieerd is.
-    bool m_use_alternative_gcfp_relation;
-
-    // determines how global control flow parameters are selected
-    //
-    // Keuze voor de selectie van globale CFPs (of globale consistentie eisen).
-    // <default>
-    //  * Een set van CFPs is consistent als voor elke d^X[n], en voor alle Y in bnd(E)\{X} (dus in alle andere vergelijkingen), voor alle i waarvoor geldt pred(phi_Y, i) = X, danwel:
-    //         a. target(Y, i, n) is gedefinieerd, of
-    //         b. copy(Y, i, m) = n voor een of andere globale CFP d^Y[m]
-    // Deze eis is in principe voldoende om globale CFPs te identificeren. Als we echter een strikte scheiding tussen control flow parameters en data parameters willen bewerkstelligen, dan moet hier optioneel de volgende eis aan toegevoegd worden:
-    //
-    // <alternative>
-    //  * Een set van CFPs is consistent als de voorgaande eisen gelden, en bovendien voor elke d^X[n] geldt dat voor alle i waarvoor pred(phi_X, i) = Y != X, als d^X[n] affects data(phi_X, i)[m], dan is d^Y[m] een globale control flow parameter.
-    // Waar de eerste gemarkeerd is als "detect conflicts for parameters of Y in equations of the form X(d) = ... Y(e)"
-    // en de tweede als "detect conflicts for parameters of X in equations of the form X(d) = ... Y(e)".
-    bool m_use_alternative_gcfp_consistency;
-
-    // TODO: remove the three booleans above, since they are also present in m_options
     pbesstategraph_options m_options;
 
     // the local control flow parameters
@@ -253,7 +202,7 @@ class stategraph_algorithm
           {
             for (std::size_t n = 0; n < d_X.size(); n++)
             {
-              if (m_use_alternative_lcfp_criterion)
+              if (m_options.use_alternative_lcfp_criterion)
               {
                 // Een parameter d^X[n] is een LCFP indien voor alle i waarvoor geldt pred(phi_X,i) = X, danwel:
                 // 1. copy(X,i,n) is undefined en source(X,i,n) and target(X,i,n) zijn beide defined, of
@@ -335,7 +284,7 @@ class stategraph_algorithm
         }
 
         // Detect conflicts for parameters of X in equations of the form X(d) = ... Y(e)
-        if (m_use_alternative_gcfp_consistency)
+        if (m_options.use_alternative_gcfp_consistency)
         {
           for (const stategraph_equation& equation: equations)
           {
@@ -472,7 +421,7 @@ class stategraph_algorithm
             std::size_t m = j.second;
             if (is_GCFP_parameter(X, n) && is_GCFP_parameter(Y, m))
             {
-              if (m_use_alternative_gcfp_relation)
+              if (m_options.use_alternative_gcfp_relation)
               {
                 // Twee parameters zijn alleen gerelateerd als er een copy is van de een naar de ander,
                 // EN dat de target in dat geval ongedefinieerd is (dus we weten echt geen concrete waarde
@@ -794,9 +743,6 @@ class stategraph_algorithm
     /// \brief Constructor.
     stategraph_algorithm(const pbes& p, const pbesstategraph_options& options)
       : m_datar(p.data(), options.rewrite_strategy),
-        m_use_alternative_lcfp_criterion(options.use_alternative_lcfp_criterion),
-        m_use_alternative_gcfp_relation(options.use_alternative_gcfp_relation),
-        m_use_alternative_gcfp_consistency(options.use_alternative_gcfp_consistency),
         m_options(options)
     {
       m_pbes = stategraph_pbes(p, m_datar);
@@ -907,8 +853,15 @@ class stategraph_algorithm
       throw mcrl2::runtime_error("error in compute_values: vertex not found");
     }
 
-    /// \brief Computes the control flow graph
-    virtual void run()
+    // Standard execution flow
+    void run()
+    {
+      execute_preprocessing();
+      execute_core();
+      execute_postprocessing();
+    }
+
+    virtual void execute_preprocessing()
     {
       simplify(m_pbes);
       m_pbes.compute_source_target_copy();
@@ -925,6 +878,9 @@ class stategraph_algorithm
       finish_timer("compute_connected_component_values");
     }
 
+    virtual void execute_core() {}
+    virtual void execute_postprocessing() {}
+
     const stategraph_pbes& get_pbes() const
     {
       return m_pbes;
@@ -935,6 +891,11 @@ class stategraph_algorithm
       return m_GCFP_graph;
     }
 
+    std::vector<local_control_flow_graph>& local_graphs()
+    {
+      return m_local_control_flow_graphs;
+    }
+
     const std::vector<local_control_flow_graph>& local_graphs() const
     {
       return m_local_control_flow_graphs;
@@ -943,8 +904,51 @@ class stategraph_algorithm
 
 } // namespace mcrl2::pbes_system::detail
 
+// Documentation of stategraph options.
+//
+// Keuze uit twee alternatieven voor de berekening van lokale CFPs.
+// <default>
+//  * Een parameter d^X[n] is een LCFP indien voor alle i waarvoor geldt pred(phi_X,i) = X, danwel:
+//          a. source(X,i,n) and target(X,i,n) zijn beide defined, of
+//          b. copy(X,i,n) is defined en gelijk aan n.
+//
+// <alternative>
+//  * Een parameter d^X[n] is een LCFP indien voor alle i waarvoor geldt pred(phi_X,i) = X, danwel:
+//          a. copy(X,i,n) is undefined en source(X,i,n) and target(X,i,n) zijn beide defined, of
+//          b. copy(X,i,n) is defined (en gelijk aan n) en source(X,i,n) en target(X,i,n) zijn beide undefined.
+//
+// De tweede definieert in feite een exclusive or, terwijl de eerste een standaard or is.
+// bool m_use_alternative_lcfp_criterion;
 
+// determines how global control flow parameters are related
+//
+// Keuze uit twee alternatieven voor het relateren van CFPs.
+// <default>
+//  * Parameters d^X[n] and d^Y[m] zijn gerelateerd als danwel:
+//         a. er is een i z.d.d. copy(X, i, n) = m, of
+//         b. er is een i z.d.d. copy(Y, i, m) = n
+//
+// <alternative>
+//  * Parameters d^X[n] and d^Y[m] zijn gerelateerd als danwel:
+//         a. er is een i z.d.d. copy(X, i, n) = m, en target(X, i, m) is ongedefinieerd, of
+//         b. er is een i z.d.d. copy(Y, i, m) = n en target(Y, i, n) is ongedefinieerd.
+// Hier zit het verschil er dus in dat we, in het tweede geval, parameters alleen relateren als er een copy is
+// van de een naar de ander EN de target in dat geval ongedefinieerd is.
+// bool m_use_alternative_gcfp_relation;
 
-
+// determines how global control flow parameters are selected
+//
+// Keuze voor de selectie van globale CFPs (of globale consistentie eisen).
+// <default>
+//  * Een set van CFPs is consistent als voor elke d^X[n], en voor alle Y in bnd(E)\{X} (dus in alle andere vergelijkingen), voor alle i waarvoor geldt pred(phi_Y, i) = X, danwel:
+//         a. target(Y, i, n) is gedefinieerd, of
+//         b. copy(Y, i, m) = n voor een of andere globale CFP d^Y[m]
+// Deze eis is in principe voldoende om globale CFPs te identificeren. Als we echter een strikte scheiding tussen control flow parameters en data parameters willen bewerkstelligen, dan moet hier optioneel de volgende eis aan toegevoegd worden:
+//
+// <alternative>
+//  * Een set van CFPs is consistent als de voorgaande eisen gelden, en bovendien voor elke d^X[n] geldt dat voor alle i waarvoor pred(phi_X, i) = Y != X, als d^X[n] affects data(phi_X, i)[m], dan is d^Y[m] een globale control flow parameter.
+// Waar de eerste gemarkeerd is als "detect conflicts for parameters of Y in equations of the form X(d) = ... Y(e)"
+// en de tweede als "detect conflicts for parameters of X in equations of the form X(d) = ... Y(e)".
+// bool m_use_alternative_gcfp_consistency;
 
 #endif // MCRL2_PBES_DETAIL_STATEGRAPH_ALGORITHM_H

--- a/libraries/pbes/include/mcrl2/pbes/detail/stategraph_global_algorithm.h
+++ b/libraries/pbes/include/mcrl2/pbes/detail/stategraph_global_algorithm.h
@@ -16,10 +16,6 @@
 #include "mcrl2/pbes/detail/stategraph_algorithm.h"
 #include "mcrl2/pbes/detail/stategraph_global_graph.h"
 
-
-
-
-
 namespace mcrl2::pbes_system::detail {
 
 /// \brief Algorithm class for the global variant of the stategraph algorithm
@@ -168,10 +164,8 @@ class stategraph_global_algorithm: public stategraph_algorithm
       : stategraph_algorithm(p, options)
     { }
 
-    /// \brief Computes the control flow graph
-    void run() override
+    void execute_core() override
     {
-      super::run();
       start_timer("compute_global_control_flow_graph");
       compute_global_control_flow_graph();
       finish_timer("compute_global_control_flow_graph");
@@ -184,9 +178,5 @@ class stategraph_global_algorithm: public stategraph_algorithm
 };
 
 } // namespace mcrl2::pbes_system::detail
-
-
-
-
 
 #endif // MCRL2_PBES_DETAIL_STATEGRAPH_GLOBAL_ALGORITHM_H

--- a/libraries/pbes/include/mcrl2/pbes/detail/stategraph_global_reset_variables.h
+++ b/libraries/pbes/include/mcrl2/pbes/detail/stategraph_global_reset_variables.h
@@ -15,10 +15,6 @@
 #include "mcrl2/pbes/detail/stategraph_global_algorithm.h"
 #include "mcrl2/pbes/detail/stategraph_reset_variables.h"
 
-
-
-
-
 namespace mcrl2::pbes_system::detail {
 
 class global_reset_variables_algorithm;
@@ -267,12 +263,8 @@ class global_reset_variables_algorithm: public stategraph_global_algorithm
         m_simplify(options.simplify)
     {}
 
-    /// \brief Runs the stategraph algorithm
-    /// \param simplify If true, simplify the resulting PBES
-    /// \param apply_to_original_pbes Apply resetting variables to the original PBES instead of the STATEGRAPH one
-    void run() override
+    void execute_core() override
     {
-      super::run();
       start_timer("compute_global_control_flow_marking");
       compute_global_control_flow_marking(m_control_flow_graph);
       finish_timer("compute_global_control_flow_marking");
@@ -395,9 +387,5 @@ pbes_expression reset_variables(global_reset_variables_algorithm& algorithm, con
 }
 
 } // namespace mcrl2::pbes_system::detail
-
-
-
-
 
 #endif // MCRL2_PBES_DETAIL_STATEGRAPH_GLOBAL_RESET_VARIABLES_H

--- a/libraries/pbes/include/mcrl2/pbes/detail/stategraph_influence.h
+++ b/libraries/pbes/include/mcrl2/pbes/detail/stategraph_influence.h
@@ -14,11 +14,6 @@
 
 #include "mcrl2/pbes/detail/pfnf_pbes.h"
 #include "mcrl2/pbes/detail/stategraph_pbes.h"
-#include <iomanip>
-
-
-
-
 
 namespace mcrl2::pbes_system::detail {
 
@@ -158,9 +153,5 @@ class stategraph_influence_graph_algorithm
   };
 
 } // namespace mcrl2::pbes_system::detail
-
-
-
-
 
 #endif // MCRL2_PBES_DETAIL_STATEGRAPH_INFLUENCE_H

--- a/libraries/pbes/include/mcrl2/pbes/detail/stategraph_local_algorithm.h
+++ b/libraries/pbes/include/mcrl2/pbes/detail/stategraph_local_algorithm.h
@@ -15,10 +15,6 @@
 #include "mcrl2/pbes/algorithms.h"
 #include "mcrl2/pbes/detail/stategraph_algorithm.h"
 
-
-
-
-
 namespace mcrl2::pbes_system::detail {
 
 struct default_rules_predicate
@@ -1137,26 +1133,40 @@ class stategraph_local_algorithm: public stategraph_algorithm
       : stategraph_algorithm(p, options),
         m_cache_marking_updates(options.cache_marking_updates)
     { }
-
-    /// \brief Computes the control flow graph
-    void run() override
+  
+    void execute_core() override
     {
-      super::run();
+      execute_local_graphs_step();
+      execute_belongs_step();
+      execute_extra_graph_step();
+      execute_marking_step();
+    }
 
+    void execute_local_graphs_step()
+    {
       start_timer("compute_local_control_flow_graphs");
       compute_local_control_flow_graphs();
       finish_timer("compute_local_control_flow_graphs");
       print_local_control_flow_graphs();
+    }
 
+    void execute_belongs_step()
+    {
       start_timer("compute_belongs");
       compute_belongs();
       finish_timer("compute_belongs");
       print_belongs();
+    }
 
+    void execute_extra_graph_step()
+    {
       start_timer("compute_extra_local_control_flow_graph");
       compute_extra_local_control_flow_graph();
       finish_timer("compute_extra_local_control_flow_graph");
+    }
 
+    void execute_marking_step()
+    {
       start_timer("compute_control_flow_marking");
       switch (m_options.marking_algorithm)
       {
@@ -1185,9 +1195,7 @@ class stategraph_local_algorithm: public stategraph_algorithm
 
       print_marking_statistics();
     }
-
-
-
+  
     const std::vector<belongs_relation>& belongs() const
     {
       return m_belongs;
@@ -1195,9 +1203,5 @@ class stategraph_local_algorithm: public stategraph_algorithm
 };
 
 } // namespace mcrl2::pbes_system::detail
-
-
-
-
 
 #endif // MCRL2_PBES_DETAIL_STATEGRAPH_LOCAL_ALGORITHM_H

--- a/libraries/pbes/include/mcrl2/pbes/detail/stategraph_local_reset_variables.h
+++ b/libraries/pbes/include/mcrl2/pbes/detail/stategraph_local_reset_variables.h
@@ -15,10 +15,6 @@
 #include "mcrl2/pbes/detail/stategraph_local_algorithm.h"
 #include "mcrl2/pbes/detail/stategraph_reset_variables.h"
 
-
-
-
-
 namespace mcrl2::pbes_system::detail {
 
 template <typename Container>
@@ -133,15 +129,10 @@ class local_reset_variables_algorithm: public stategraph_local_algorithm
         m_simplify(options.simplify)
     {}
 
-    /// \brief Runs the stategraph algorithm
-    /// \param simplify If true, simplify the resulting PBES
-    /// \param apply_to_original_pbes Apply resetting variables to the original PBES instead of the STATEGRAPH one
-    void run() override
+    void execute_postprocessing() override
     {
-      super::run();
       m_transformed_pbes = m_original_pbes;
       compute_occurring_data_parameters();
-
       start_timer("reset_variables_to_original");
       reset_variables_to_original(m_transformed_pbes);
       finish_timer("reset_variables_to_original");
@@ -360,11 +351,6 @@ inline data::data_expression_list local_reset_variables_algorithm::reset_variabl
   return data::data_expression_list(e1.begin(), e1.end());
 }
 
-
 } // namespace mcrl2::pbes_system::detail
-
-
-
-
 
 #endif // MCRL2_PBES_DETAIL_STATEGRAPH_LOCAL_RESET_VARIABLES_H

--- a/tools/release/lps2lts/CMakeLists.txt
+++ b/tools/release/lps2lts/CMakeLists.txt
@@ -4,25 +4,7 @@ mcrl2_add_tool(lps2lts
   DEPENDS
     mcrl2_lps
     mcrl2_lts
-)
-
-# This adds projections
-mcrl2_add_tool(lps2ltspr
-  SOURCES
-    lps2lts.cpp
-  DEPENDS
-    mcrl2_lps
-    mcrl2_lts
-)
-target_compile_definitions(lps2ltspr PRIVATE MCRL2_USE_PROJECTIONS)
-
-# This adds control flow summand pruning
-mcrl2_add_tool(lps2ltscf
-  SOURCES
-    lps2lts.cpp
-  DEPENDS
-    mcrl2_lps
-    mcrl2_lts
     mcrl2_pbes
 )
-target_compile_definitions(lps2ltscf PRIVATE MCRL2_USE_CONTROL_FLOW)
+
+target_compile_definitions(lps2lts PRIVATE MCRL2_USE_CONTROL_FLOW)

--- a/tools/release/lps2lts/CMakeLists.txt
+++ b/tools/release/lps2lts/CMakeLists.txt
@@ -5,3 +5,24 @@ mcrl2_add_tool(lps2lts
     mcrl2_lps
     mcrl2_lts
 )
+
+# This adds projections
+mcrl2_add_tool(lps2ltspr
+  SOURCES
+    lps2lts.cpp
+  DEPENDS
+    mcrl2_lps
+    mcrl2_lts
+)
+target_compile_definitions(lps2ltspr PRIVATE MCRL2_USE_PROJECTIONS)
+
+# This adds control flow summand pruning
+mcrl2_add_tool(lps2ltscf
+  SOURCES
+    lps2lts.cpp
+  DEPENDS
+    mcrl2_lps
+    mcrl2_lts
+    mcrl2_pbes
+)
+target_compile_definitions(lps2ltscf PRIVATE MCRL2_USE_CONTROL_FLOW)

--- a/tools/release/lps2lts/lps2lts.cpp
+++ b/tools/release/lps2lts/lps2lts.cpp
@@ -6,9 +6,9 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 //
-/// \file lps2lts_parallel.cpp
+/// \file lps2lts.cpp
 /// \brief This tool transforms an .lps file into a labelled transition system.
-///        Optionally, it can be run with multiple treads. 
+///        Optionally, it can be run with multiple treads.
 
 #include <csignal>
 #include <memory>
@@ -20,6 +20,10 @@
 #include "mcrl2/lts/stochastic_lts_builder.h"
 #include "mcrl2/lts/state_space_generator.h"
 
+#ifdef MCRL2_USE_CONTROL_FLOW
+#include "mcrl2/lps/explorer_control_flow.h"
+#endif
+
 using namespace mcrl2;
 using utilities::tools::input_output_tool;
 using utilities::tools::parallel_tool;
@@ -29,10 +33,15 @@ class lps2lts_tool: public parallel_tool<rewriter_tool<input_output_tool>>
 {
   using super = parallel_tool<rewriter_tool<input_output_tool>>;
 
-  lps::explorer_options options;
+  lps::explorer_options options{};
   lts::lts_type output_format = lts::lts_none;
   lps::abortable* current_explorer = nullptr;
   std::set<std::string> trace_multiaction_strings;
+
+#ifdef MCRL2_USE_CONTROL_FLOW
+  pbes_system::pbesstategraph_options stategraph_options{};
+  bool compute_marking = false;
+#endif
 
   public:
     lps2lts_tool()
@@ -55,6 +64,12 @@ class lps2lts_tool: public parallel_tool<rewriter_tool<input_output_tool>>
       desc.add_option("no-probability-checking", "do not check if probabilities in stochastic specifications have sensible values");
       desc.add_hidden_option("dfs-recursive", "use recursive depth first search for divergence detection");
       desc.add_option("cached", "use enumeration caching techniques to speed up state space generation. ");
+#ifdef MCRL2_USE_PROJECTIONS
+      desc.add_option("project", "use read/write projections ");
+#endif
+#ifdef MCRL2_USE_CONTROL_FLOW
+      desc.add_option("control-flow", "use control flow based summand pruning");
+#endif
       desc.add_option("todo-max", utilities::make_mandatory_argument("NUM"),
                  "keep at most NUM states in the todo list; this option is only relevant for "
                  "highway search, where NUM is the maximum number of states per level per thread. ");
@@ -111,6 +126,22 @@ class lps2lts_tool: public parallel_tool<rewriter_tool<input_output_tool>>
       desc.add_option("save-at-end", "delay saving of the generated LTS until the end. "
                  "This option only applies to .aut and .lts files, which are by default saved on the fly.");
       desc.add_option("no-info", "do not add state label information to OUTFILE. This option only applies to .lts files.");
+
+#ifdef MCRL2_PREPROCESS
+      desc.add_option("preprocess","apply some preprocessing, which sometimes benefits.");
+      desc.add_option("mcrl2file", utilities::make_mandatory_argument<std::string>("FILE"), "A .mcrl2 file");
+#endif
+
+#ifdef MCRL2_USE_CONTROL_FLOW
+      //--- stategraph options ---//
+      desc.add_hidden_option("no-simplify", "do not simplify the PBES during reduction (works only in combination with -g)");
+      desc.add_hidden_option("disable-cache-marking-updates", "disable caching of rewriter calls in marking updates");
+      desc.add_option("compute-marking", "compute the marking of the control flow graph");
+      desc.add_option("marking-algorithm", utilities::make_optional_argument("NAME", "0"), "specifies the algorithm that is used for the marking computation 0 (default), 1 or 2. In certain cases this choice can have a significant impact on the performance.");
+      desc.add_hidden_option("use-alternative-lcfp-criterion", "use an alternative criterion for local control flow parameter computation");
+      desc.add_hidden_option("use-alternative-gcfp-relation", "use an alternative global control flow parameter relation");
+      desc.add_hidden_option("use-alternative-gcfp-consistency", "use an alternative global control flow parameter consistency");
+#endif
     }
 
     static std::list<std::string> split_actions(const std::string& s)
@@ -204,6 +235,12 @@ class lps2lts_tool: public parallel_tool<rewriter_tool<input_output_tool>>
       options.cached                                = parser.has_option("cached");
       options.global_cache                          = parser.has_option("global-cache");
       options.confluence                            = parser.has_option("confluence");
+#ifdef MCRL2_USE_PROJECTIONS
+      options.use_projections                       = parser.has_option("project");
+#endif
+#ifdef MCRL2_USE_CONTROL_FLOW
+      options.use_control_flow                      = parser.has_option("control-flow");
+#endif
       options.one_point_rule_rewrite                = !parser.has_option("no-one-point-rule-rewrite");
       options.remove_unused_rewrite_rules           = !parser.has_option("no-remove-unused-rewrite-rules");
       options.replace_constants_by_variables        = !parser.has_option("no-replace-constants-by-variables");
@@ -338,13 +375,50 @@ class lps2lts_tool: public parallel_tool<rewriter_tool<input_output_tool>>
                                 options.save_error_trace ||
                                 options.generate_traces;
 
+#ifdef MCRL2_USE_PROJECTIONS
+      if (parser.has_option("project") && (parser.has_option("cached") || parser.has_option("global-cache")))
+      {
+        parser.error("Option --project cannot be combined with --cached or --global-cache.");
+      }
+#endif
+
+#ifdef MCRL2_USE_CONTROL_FLOW
+      stategraph_options.rewrite_strategy = rewrite_strategy();
+      stategraph_options.simplify = !parser.has_option("no-simplify");
+      stategraph_options.use_global_variant = false;
+      stategraph_options.print_influence_graph = false;
+      stategraph_options.cache_marking_updates = !parser.has_option("disable-cache-marking-updates");
+      compute_marking = parser.has_option("compute-marking");
+      stategraph_options.marking_algorithm = parser.option_argument_as<int>("marking-algorithm");
+      if (stategraph_options.marking_algorithm < 0 || stategraph_options.marking_algorithm > 2)
+      {
+        throw mcrl2::runtime_error("invalid value for marking-algorithm!");
+      }
+      stategraph_options.use_alternative_lcfp_criterion = parser.has_option("use-alternative-lcfp-criterion");
+      stategraph_options.use_alternative_gcfp_relation = parser.has_option("use-alternative-gcfp-relation");
+      stategraph_options.use_alternative_gcfp_consistency = parser.has_option("use-alternative-gcfp-consistency");
+      stategraph_options.timer = &timer();
+#endif
     }
 
     template <bool Stochastic, bool Timed, typename Specification, typename LTSBuilder>
-    bool generate_state_space(const Specification& lpsspec, LTSBuilder& builder)
+    bool generate_state_space(const Specification& lpsspec,
+                              LTSBuilder& builder
+#ifdef MCRL2_USE_CONTROL_FLOW
+                              , const pbes_system::pbesstategraph_options& stategraph_options = {}
+                              , bool compute_marking = false
+#endif
+                             )
     {
       data::rewriter rewr = lps::construct_rewriter(lpsspec, options.rewrite_strategy, options.remove_unused_rewrite_rules);
-      lps::explorer<Stochastic, Timed, Specification> explorer(lpsspec, options, rewr);
+      lps::explorer<Stochastic, Timed, Specification> explorer(lpsspec,
+                                                               options,
+                                                               rewr
+#ifdef MCRL2_USE_CONTROL_FLOW
+                                                               , stategraph_options
+                                                               , compute_marking
+#endif
+      );
       lts::state_space_generator<Stochastic, Timed, Specification> generator(lpsspec, options, explorer);
       current_explorer = &generator.explorer;
       
@@ -368,6 +442,13 @@ class lps2lts_tool: public parallel_tool<rewriter_tool<input_output_tool>>
 
       if (lps::is_stochastic(stochastic_lpsspec))
       {
+#ifdef MCRL2_USE_PROJECTIONS
+        if (options.use_projections) {
+            options.use_projections = false;
+            mCRL2log(log::warning) << "Projections are currently not supported for stochastic specifications. "
+                                   << "Projections have been disabled.\n";
+        }
+#endif
         auto builder = create_stochastic_lts_builder(stochastic_lpsspec, options, output_format);
         if (is_timed)
         {
@@ -384,11 +465,25 @@ class lps2lts_tool: public parallel_tool<rewriter_tool<input_output_tool>>
         auto builder = create_lts_builder(lpsspec, options, output_format, output_filename());
         if (is_timed)
         {
-          result = generate_state_space<false, true>(lpsspec, *builder);
+          result = generate_state_space<false, true>(
+            lpsspec,
+            *builder
+#ifdef MCRL2_USE_CONTROL_FLOW
+            , stategraph_options
+            , compute_marking
+#endif
+          );
         }
         else
         {
-          result = generate_state_space<false, false>(lpsspec, *builder);
+          result = generate_state_space<false, false>(
+            lpsspec,
+            *builder
+#ifdef MCRL2_USE_CONTROL_FLOW
+            , stategraph_options
+            , compute_marking
+#endif
+          );
         }
       }
 

--- a/tools/release/lps2lts/lps2lts.cpp
+++ b/tools/release/lps2lts/lps2lts.cpp
@@ -64,9 +64,7 @@ class lps2lts_tool: public parallel_tool<rewriter_tool<input_output_tool>>
       desc.add_option("no-probability-checking", "do not check if probabilities in stochastic specifications have sensible values");
       desc.add_hidden_option("dfs-recursive", "use recursive depth first search for divergence detection");
       desc.add_option("cached", "use enumeration caching techniques to speed up state space generation. ");
-#ifdef MCRL2_USE_PROJECTIONS
       desc.add_option("project", "use read/write projections ");
-#endif
 #ifdef MCRL2_USE_CONTROL_FLOW
       desc.add_option("control-flow", "use control flow based summand pruning");
 #endif
@@ -235,9 +233,7 @@ class lps2lts_tool: public parallel_tool<rewriter_tool<input_output_tool>>
       options.cached                                = parser.has_option("cached");
       options.global_cache                          = parser.has_option("global-cache");
       options.confluence                            = parser.has_option("confluence");
-#ifdef MCRL2_USE_PROJECTIONS
       options.use_projections                       = parser.has_option("project");
-#endif
 #ifdef MCRL2_USE_CONTROL_FLOW
       options.use_control_flow                      = parser.has_option("control-flow");
 #endif
@@ -375,12 +371,10 @@ class lps2lts_tool: public parallel_tool<rewriter_tool<input_output_tool>>
                                 options.save_error_trace ||
                                 options.generate_traces;
 
-#ifdef MCRL2_USE_PROJECTIONS
       if (parser.has_option("project") && (parser.has_option("cached") || parser.has_option("global-cache")))
       {
         parser.error("Option --project cannot be combined with --cached or --global-cache.");
       }
-#endif
 
 #ifdef MCRL2_USE_CONTROL_FLOW
       stategraph_options.rewrite_strategy = rewrite_strategy();
@@ -442,13 +436,12 @@ class lps2lts_tool: public parallel_tool<rewriter_tool<input_output_tool>>
 
       if (lps::is_stochastic(stochastic_lpsspec))
       {
-#ifdef MCRL2_USE_PROJECTIONS
         if (options.use_projections) {
             options.use_projections = false;
             mCRL2log(log::warning) << "Projections are currently not supported for stochastic specifications. "
                                    << "Projections have been disabled.\n";
         }
-#endif
+
         auto builder = create_stochastic_lts_builder(stochastic_lpsspec, options, output_format);
         if (is_timed)
         {


### PR DESCRIPTION
This pull request adds the tools **lps2ltscf** and **lps2ltspr**. They contain extensions of lps2lts:

- lps2ltscf uses a stategraph control flow analysis to filter summands

- lps2ltspr uses a read/write parameter analysis to project states and
  cache transitions

The corresponding code is guarded by the flags MCRL2_USE_CONTROL_FLOW and
MCRL2_USE_PROJECTIONS to avoid interference with the existing lps2lts.

Usage examples:

```
lps2ltscf -v --control-flow --cached examples/academic/abp/abp.lps
lps2ltspr -v --project examples/academic/abp/abp.lps
```
