### PR TITLE
Optimised the block allocator for concurrent allocations

### DIFF
--- a/libraries/lts/include/mcrl2/lts/state_space_generator.h
+++ b/libraries/lts/include/mcrl2/lts/state_space_generator.h
@@ -15,6 +15,8 @@
 #include "mcrl2/lps/explorer.h"
 #include "mcrl2/lts/trace.h"
 
+#include <forward_list>
+
 namespace mcrl2::lts 
 {
 

--- a/libraries/utilities/include/mcrl2/utilities/block_allocator.h
+++ b/libraries/utilities/include/mcrl2/utilities/block_allocator.h
@@ -203,18 +203,18 @@ private:
       return reinterpret_cast<T*>(e);
     }
 
+    // Fast path 2: bump-allocate from the current thread's block.
+    if (state.current_block != nullptr && state.bump_offset < N)
+    {
+      return reinterpret_cast<T*>(&state.current_block->data[state.bump_offset++]);
+    }
+
     // Refill the thread-local freelist from a shared chunk.
     if (refill_local_free(state) && state.free_head != nullptr)
     {
       Entry* e = state.free_head;
       state.free_head = e->next;
       return reinterpret_cast<T*>(e);
-    }
-
-    // Fast path 2: bump-allocate from the current thread's block.
-    if (state.current_block != nullptr && state.bump_offset < N)
-    {
-      return reinterpret_cast<T*>(&state.current_block->data[state.bump_offset++]);
     }
 
     // Slow path: allocate a new block under the mutex.

--- a/libraries/utilities/include/mcrl2/utilities/block_allocator.h
+++ b/libraries/utilities/include/mcrl2/utilities/block_allocator.h
@@ -6,30 +6,113 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 //
+/// \file block_allocator.h
+/// \brief Fixed-size block allocator with per-thread allocation state.
 
 #ifndef MCRL2_UTILITIES_BLOCK_ALLOCATOR_H_
 #define MCRL2_UTILITIES_BLOCK_ALLOCATOR_H_
 
-#include "memory_pool.h"
+#include "mcrl2/utilities/noncopyable.h"
+#include "mcrl2/utilities/thread_local.h"
 
-#include <memory>
-#include <stddef.h>
-
+#include <array>
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <mutex>
+#include <new>
+#include <vector>
 
 namespace mcrl2::utilities
 {
 
-/// \brief The block allocator provides the allocator interface for the memory pool class.
-///        As such is can be used as an allocator for allocator aware storages.
-/// \details Also provides several non-standard allocate functions specifically for the term pool.
+namespace detail
+{
+
+/// Sentinel written to `next` to identify freed entries during consolidation.
+static constexpr uintptr_t BlockAllocSentinel = std::numeric_limits<uintptr_t>::max();
+
+/// Number of entries per shared free chunk handed between threads.
+static constexpr std::size_t FreeChunkSize = 1000;
+
+/// Union entry: active as `value` while live, as `next` while on a freelist.
+template <typename T>
+union BlockEntry
+{
+  T value;
+  BlockEntry* next;
+
+  BlockEntry() noexcept : next(nullptr) {}
+  ~BlockEntry() noexcept {}
+};
+
+/// A fixed-size block of N entries linked in a singly-linked list.
+template <typename T, std::size_t N>
+struct Block
+{
+  std::array<BlockEntry<T>, N> data;
+  Block<T, N>* next = nullptr;
+};
+
+/// The shared block list and free chunks. Protected by the allocator mutex.
+template <typename T, std::size_t N>
+struct BlockList
+{
+  Block<T, N>* head = nullptr;
+
+  /// Heads of linked chains of freed entries available for redistribution.
+  std::vector<BlockEntry<T>*> free_chunks;
+
+  BlockList() = default;
+
+  ~BlockList() noexcept
+  {
+    Block<T, N>* block = head;
+    while (block != nullptr)
+    {
+      Block<T, N>* next = block->next;
+      delete block;
+      block = next;
+    }
+  }
+
+  BlockList(BlockList&&) = default;
+  BlockList& operator=(BlockList&&) = default;
+};
+
+/// Per-thread allocation state: current bump block and thread-local freelist.
+template <typename T, std::size_t N>
+struct ThreadLocalAllocState
+{
+  Block<T, N>* current_block = nullptr;
+  std::size_t bump_offset = N;   ///< N or greater means the block is exhausted.
+  BlockEntry<T>* free_head = nullptr;
+};
+
+/// No-op mutex used when ThreadSafe=false.
+struct no_op_mutex
+{
+  void lock() noexcept {}
+  void unlock() noexcept {}
+};
+
+} // namespace detail
+
+/// \brief Fixed-size block allocator compatible with the STL allocator interface.
+///
+/// Stores blocks of ElementsPerBlock entries, minimising per-allocation overhead.
+/// Maintains per-thread state so allocation and deallocation are contention-free
+/// on the common path; the shared mutex is only taken when a new block must be
+/// allocated or during consolidate().
+///
+/// consolidate() must not be called concurrently with any allocations or
+/// deallocations.
 template <class T,
           std::size_t ElementsPerBlock = 1024,
           bool ThreadSafe = false>
-class block_allocator : public memory_pool<T, ElementsPerBlock, ThreadSafe>
+class block_allocator : private noncopyable
 {
-private:
-  using super = memory_pool<T, ElementsPerBlock, ThreadSafe>;
-
 public:
   using value_type = T;
   using size_type = std::size_t;
@@ -43,31 +126,247 @@ public:
 
   block_allocator() = default;
 
-  /// \details The unused parameter is to make the interface equivalent
-  ///          to the allocator.
   T* allocate(size_type n, const void* hint = nullptr)
   {
-    if (n != 1 || hint)
+    if (n != 1 || hint != nullptr)
     {
       throw std::bad_alloc();
     }
-
-    return super::allocate();
+    return allocate_object();
   }
 
-  /// \details The unused parameter is to make the interface equivalent
-  ///          to the allocator.
   void deallocate(T* p, size_type)
   {
-    super::deallocate(p);
+    deallocate_object(p);
   }
 
-  // Move assignment and construction is possible.
-  block_allocator(block_allocator&&) = default;
-  block_allocator& operator=(block_allocator&&) = default;
+  /// \brief Removes empty blocks and returns the number of blocks removed.
+  ///
+  /// Must not be called concurrently with allocate or deallocate.
+  std::size_t consolidate()
+  {
+    return remove_free_blocks();
+  }
+
+private:
+  static constexpr std::size_t N = ElementsPerBlock;
+
+  using Entry     = detail::BlockEntry<T>;
+  using Block     = detail::Block<T, N>;
+  using BlockList = detail::BlockList<T, N>;
+  using LocalState = detail::ThreadLocalAllocState<T, N>;
+  using MutexType = std::conditional_t<ThreadSafe, std::mutex, detail::no_op_mutex>;
+
+  // When ThreadSafe=true each thread gets its own LocalState via ThreadLocal.
+  // When ThreadSafe=false there is only one thread, so a plain struct suffices.
+  using AllocState = std::conditional_t<ThreadSafe, ThreadLocal<LocalState>, LocalState>;
+
+  static Entry* sentinel_ptr() noexcept
+  {
+    return reinterpret_cast<Entry*>(detail::BlockAllocSentinel);
+  }
+
+  LocalState& get_local_state()
+  {
+    if constexpr (ThreadSafe)
+    {
+      return *m_alloc_state.get_or_mut([] { return LocalState{}; });
+    }
+    else
+    {
+      return m_alloc_state;
+    }
+  }
+
+  template <typename F>
+  void for_each_local_state(const F& func)
+  {
+    if constexpr (ThreadSafe)
+    {
+      m_alloc_state.for_each_mut(func);
+    }
+    else
+    {
+      func(m_alloc_state);
+    }
+  }
+
+  T* allocate_object()
+  {
+    LocalState& state = get_local_state();
+
+    // Fast path 1: pop from the thread-local freelist.
+    if (state.free_head != nullptr)
+    {
+      Entry* e = state.free_head;
+      state.free_head = e->next;
+      return reinterpret_cast<T*>(e);
+    }
+
+    // Refill the thread-local freelist from a shared chunk.
+    if (refill_local_free(state) && state.free_head != nullptr)
+    {
+      Entry* e = state.free_head;
+      state.free_head = e->next;
+      return reinterpret_cast<T*>(e);
+    }
+
+    // Fast path 2: bump-allocate from the current thread's block.
+    if (state.current_block != nullptr && state.bump_offset < N)
+    {
+      return reinterpret_cast<T*>(&state.current_block->data[state.bump_offset++]);
+    }
+
+    // Slow path: allocate a new block under the mutex.
+    return allocate_new_block(state);
+  }
+
+  bool refill_local_free(LocalState& state)
+  {
+    Entry* chunk;
+    {
+      std::lock_guard<MutexType> lock(m_mutex);
+      if (m_block_list.free_chunks.empty())
+      {
+        return false;
+      }
+      chunk = m_block_list.free_chunks.back();
+      m_block_list.free_chunks.pop_back();
+    }
+    state.free_head = chunk;
+    return true;
+  }
+
+  T* allocate_new_block(LocalState& state)
+  {
+    std::lock_guard<MutexType> lock(m_mutex);
+    Block* block = new Block;
+    block->next = m_block_list.head;
+    m_block_list.head = block;
+
+    state.current_block = block;
+    state.bump_offset = 1;
+
+    return reinterpret_cast<T*>(&block->data[0]);
+  }
+
+  void deallocate_object(T* p)
+  {
+    LocalState& state = get_local_state();
+    Entry* e = reinterpret_cast<Entry*>(p);
+    e->next = state.free_head;
+    state.free_head = e;
+  }
+
+  std::size_t remove_free_blocks()
+  {
+    // Step 1: Walk every thread-local freelist, mark each entry with the
+    // sentinel, then reset the per-thread state so threads get fresh blocks
+    // after consolidation.
+    for_each_local_state([](LocalState& state) {
+      Entry* e = state.free_head;
+      while (e != nullptr)
+      {
+        Entry* next = e->next;
+        e->next = block_allocator::sentinel_ptr();
+        e = next;
+      }
+      state.free_head = nullptr;
+      state.current_block = nullptr;
+      state.bump_offset = N;
+    });
+
+    std::lock_guard<MutexType> lock(m_mutex);
+
+    // Step 2: Mark entries in shared free chunks with the sentinel.
+    for (Entry* chunk : m_block_list.free_chunks)
+    {
+      Entry* e = chunk;
+      while (e != nullptr)
+      {
+        Entry* next = e->next;
+        e->next = sentinel_ptr();
+        e = next;
+      }
+    }
+    m_block_list.free_chunks.clear();
+
+    // Step 3: Remove blocks where every entry carries the sentinel (all freed).
+    std::size_t removed = 0;
+    Block** prev = &m_block_list.head;
+    while (*prev != nullptr)
+    {
+      Block* block = *prev;
+      bool all_free = true;
+      for (const Entry& e : block->data)
+      {
+        if (e.next != sentinel_ptr())
+        {
+          all_free = false;
+          break;
+        }
+      }
+
+      if (all_free)
+      {
+        *prev = block->next;
+        delete block;
+        ++removed;
+      }
+      else
+      {
+        prev = &block->next;
+      }
+    }
+
+    // Step 4: Rebuild shared free chunks from sentinel-marked entries in
+    // surviving blocks, in chains of FreeChunkSize.
+    Entry* chunk_head = nullptr;
+    Entry* chunk_tail = nullptr;
+    std::size_t chunk_len = 0;
+
+    for (Block* block = m_block_list.head; block != nullptr; block = block->next)
+    {
+      for (Entry& e : block->data)
+      {
+        if (e.next == sentinel_ptr())
+        {
+          e.next = nullptr;
+          if (chunk_tail != nullptr)
+          {
+            chunk_tail->next = &e;
+          }
+          else
+          {
+            chunk_head = &e;
+          }
+          chunk_tail = &e;
+          ++chunk_len;
+
+          if (chunk_len == detail::FreeChunkSize)
+          {
+            m_block_list.free_chunks.push_back(chunk_head);
+            chunk_head = nullptr;
+            chunk_tail = nullptr;
+            chunk_len = 0;
+          }
+        }
+      }
+    }
+
+    if (chunk_head != nullptr)
+    {
+      m_block_list.free_chunks.push_back(chunk_head);
+    }
+
+    return removed;
+  }
+
+  MutexType m_mutex;
+  BlockList m_block_list;
+  AllocState m_alloc_state;
 };
 
 } // namespace mcrl2::utilities
 
-
-#endif
+#endif // MCRL2_UTILITIES_BLOCK_ALLOCATOR_H_

--- a/libraries/utilities/include/mcrl2/utilities/thread_local.h
+++ b/libraries/utilities/include/mcrl2/utilities/thread_local.h
@@ -1,0 +1,424 @@
+// Author(s): Maurice Laveaux
+// Copyright: see the accompanying file COPYING or copy at
+// https://github.com/mCRL2org/mCRL2/blob/master/COPYING
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+// Based on the Rust thread_local crate by Amanieu d'Antras
+// (Licensed under Apache License, Version 2.0 <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option)
+
+#ifndef MCRL2_UTILITIES_THREAD_LOCAL_H_
+#define MCRL2_UTILITIES_THREAD_LOCAL_H_
+
+#include <atomic>
+#include <memory>
+#include <stdexcept>
+#include <optional>
+#include <cstring>
+#include <iterator>
+
+#include "mcrl2/utilities/noncopyable.h"
+
+namespace mcrl2::utilities
+{
+
+namespace detail
+{
+
+/// \brief Get a unique identifier for the current thread.
+inline std::size_t get_thread_id()
+{
+  static thread_local std::size_t thread_id_cache = 0;
+  if (thread_id_cache == 0)
+  {
+    static std::atomic<std::size_t> next_id(1);
+    thread_id_cache = next_id.fetch_add(1, std::memory_order_relaxed);
+  }
+  return thread_id_cache;
+}
+
+/// \brief Information about a thread's position in the bucket structure.
+struct ThreadBucket
+{
+  std::size_t id;       ///< Unique thread identifier
+  std::size_t bucket;   ///< Which bucket this thread's entry is in
+  std::size_t index;    ///< Index within the bucket
+  std::size_t bucket_size; ///< Size of the current bucket
+
+  ThreadBucket(std::size_t thread_id)
+    : id(thread_id)
+  {
+    // Compute bucket and index from thread ID using bit operations
+    // Bucket n contains 2^n elements
+    if (thread_id == 0)
+    {
+      bucket = 0;
+      index = 0;
+      bucket_size = 1;
+    }
+    else
+    {
+      bucket = (sizeof(std::size_t) * 8) - __builtin_clzll(thread_id);
+      std::size_t offset = thread_id - (1ULL << (bucket - 1));
+      index = offset;
+      bucket_size = 1ULL << bucket;
+    }
+  }
+};
+
+/// \brief Entry in the thread-local bucket.
+template <typename T>
+struct Entry
+{
+  std::atomic<bool> present{false};
+  std::aligned_storage_t<sizeof(T), alignof(T)> value;
+
+  ~Entry()
+  {
+    if (present.load(std::memory_order_acquire))
+    {
+      reinterpret_cast<T*>(&value)->~T();
+    }
+  }
+};
+
+} // namespace detail
+
+/// \brief Per-object thread-local storage container.
+/// \details This class provides per-object thread-local storage, allowing
+///          each thread to have its own copy of a value. Unlike std::thread_local
+///          which is static, this allows creating multiple independent thread-local
+///          storages within a single program.
+///
+///          Per-thread objects are not destroyed when a thread exits. Instead,
+///          objects are only destroyed when the ThreadLocal container is destroyed.
+///
+///          Thread-local values can be iterated over using iter() and iter_mut()
+///          methods (the latter requires a mutable borrow, guaranteeing thread safety).
+template <typename T>
+class ThreadLocal : private noncopyable
+{
+private:
+  using Entry = detail::Entry<T>;
+
+  // Compute the number of buckets needed (based on pointer width)
+  static constexpr std::size_t POINTER_WIDTH = sizeof(std::size_t) * 8;
+  static constexpr std::size_t BUCKETS = POINTER_WIDTH - 1;
+
+  std::array<std::atomic<Entry*>, BUCKETS> buckets;
+  std::atomic<std::size_t> values_count{0};
+
+  /// \brief Helper to deallocate a bucket.
+  static void deallocate_bucket(Entry* bucket_ptr, std::size_t size)
+  {
+    delete[] bucket_ptr;
+  }
+
+  /// \brief Helper to allocate a bucket.
+  static Entry* allocate_bucket(std::size_t size)
+  {
+    Entry* bucket = new Entry[size];
+    return bucket;
+  }
+
+  /// \brief Get the value for the given thread, if it exists.
+  const T* get_inner(const detail::ThreadBucket& thread) const
+  {
+    Entry* bucket_ptr = buckets[thread.bucket].load(std::memory_order_acquire);
+    if (!bucket_ptr)
+    {
+      return nullptr;
+    }
+
+    Entry& entry = bucket_ptr[thread.index];
+    if (entry.present.load(std::memory_order_relaxed))
+    {
+      return reinterpret_cast<const T*>(&entry.value);
+    }
+    return nullptr;
+  }
+
+  /// \brief Insert a value for the given thread.
+  const T* insert(const detail::ThreadBucket& thread, T value)
+  {
+    std::atomic<Entry*>& bucket_atomic_ptr = buckets[thread.bucket];
+    Entry* bucket_ptr = bucket_atomic_ptr.load(std::memory_order_acquire);
+
+    // Allocate the bucket if it doesn't exist
+    if (!bucket_ptr)
+    {
+      Entry* new_bucket = allocate_bucket(thread.bucket_size);
+
+      Entry* expected = nullptr;
+      if (bucket_atomic_ptr.compare_exchange_strong(
+            expected, new_bucket, std::memory_order_acq_rel, std::memory_order_acquire))
+      {
+        bucket_ptr = new_bucket;
+      }
+      else
+      {
+        // Another thread allocated before us, use theirs
+        deallocate_bucket(new_bucket, thread.bucket_size);
+        bucket_ptr = expected;
+      }
+    }
+
+    // Insert the value into the bucket
+    Entry& entry = bucket_ptr[thread.index];
+    new (&entry.value) T(std::move(value));
+    entry.present.store(true, std::memory_order_release);
+
+    values_count.fetch_add(1, std::memory_order_release);
+
+    return reinterpret_cast<const T*>(&entry.value);
+  }
+
+public:
+  /// \brief Create a new empty ThreadLocal container.
+  ThreadLocal()
+  {
+    for (std::size_t i = 0; i < BUCKETS; ++i)
+    {
+      buckets[i].store(nullptr, std::memory_order_relaxed);
+    }
+  }
+
+  /// \brief Destructor that cleans up all allocated buckets.
+  ~ThreadLocal()
+  {
+    for (std::size_t i = 0; i < BUCKETS; ++i)
+    {
+      Entry* bucket_ptr = buckets[i].load(std::memory_order_relaxed);
+      if (bucket_ptr)
+      {
+        deallocate_bucket(bucket_ptr, 1ULL << i);
+      }
+    }
+  }
+
+  /// \brief Get the thread-local value for the current thread, if it exists.
+  const T* get() const
+  {
+    detail::ThreadBucket thread(detail::get_thread_id());
+    return get_inner(thread);
+  }
+
+  /// \brief Get the thread-local value for the current thread, or create it if it doesn't exist.
+  template <typename F>
+  const T* get_or(F&& create)
+  {
+    detail::ThreadBucket thread(detail::get_thread_id());
+    const T* val = get_inner(thread);
+    if (val)
+    {
+      return val;
+    }
+    return insert(thread, std::forward<F>(create)());
+  }
+
+  /// \brief Get the thread-local value for the current thread, or create it if it doesn't exist.
+  /// \returns The value, or nullptr if creation failed.
+  template <typename F>
+  const T* get_or_try(F&& create)
+  {
+    detail::ThreadBucket thread(detail::get_thread_id());
+    const T* val = get_inner(thread);
+    if (val)
+    {
+      return val;
+    }
+    try
+    {
+      return insert(thread, std::forward<F>(create)());
+    }
+    catch (...)
+    {
+      return nullptr;
+    }
+  }
+
+  /// \brief Iterator over thread-local values.
+  class Iter
+  {
+  private:
+    const ThreadLocal* m_thread_local;
+    mutable std::size_t bucket;
+    mutable std::size_t bucket_size;
+    mutable std::size_t index;
+    mutable std::size_t yielded;
+
+    /// \brief Advance to the next bucket.
+    void next_bucket() const
+    {
+      bucket_size <<= 1;
+      bucket += 1;
+      index = 0;
+    }
+
+  public:
+    using difference_type = std::ptrdiff_t;
+    using value_type = const T;
+    using pointer = const T*;
+    using reference = const T&;
+    using iterator_category = std::forward_iterator_tag;
+
+    Iter(const ThreadLocal* tl, bool begin)
+      : m_thread_local(tl), bucket(0), bucket_size(1), index(0), yielded(0)
+    {
+      if (!begin)
+      {
+        bucket = BUCKETS;
+      }
+    }
+
+    const T& operator*() const
+    {
+      while (bucket < BUCKETS)
+      {
+        Entry* bucket_ptr = m_thread_local->buckets[bucket].load(std::memory_order_acquire);
+        if (!bucket_ptr)
+        {
+          next_bucket();
+          continue;
+        }
+
+        while (index < bucket_size)
+        {
+          Entry& entry = bucket_ptr[index];
+          ++index;
+          if (entry.present.load(std::memory_order_acquire))
+          {
+            return *reinterpret_cast<const T*>(&entry.value);
+          }
+        }
+
+        next_bucket();
+      }
+
+      throw std::out_of_range("ThreadLocal iterator out of bounds");
+    }
+
+    const T* operator->() const
+    {
+      return &**this;
+    }
+
+    Iter& operator++()
+    {
+      while (bucket < BUCKETS)
+      {
+        Entry* bucket_ptr = m_thread_local->buckets[bucket].load(std::memory_order_acquire);
+        if (!bucket_ptr)
+        {
+          next_bucket();
+          continue;
+        }
+
+        while (index < bucket_size)
+        {
+          Entry& entry = bucket_ptr[index];
+          ++index;
+          if (entry.present.load(std::memory_order_acquire))
+          {
+            ++yielded;
+            return *this;
+          }
+        }
+
+        next_bucket();
+      }
+
+      return *this;
+    }
+
+    Iter operator++(int)
+    {
+      Iter tmp = *this;
+      ++*this;
+      return tmp;
+    }
+
+    bool operator==(const Iter& other) const
+    {
+      return m_thread_local == other.m_thread_local && bucket == other.bucket && index == other.index;
+    }
+
+    bool operator!=(const Iter& other) const
+    {
+      return !(*this == other);
+    }
+  };
+
+  /// \brief Get an iterator over all thread-local values.
+  Iter begin() const
+  {
+    return Iter(this, true);
+  }
+
+  /// \brief Get the end iterator.
+  Iter end() const
+  {
+    return Iter(this, false);
+  }
+
+  /// \brief Get a mutable pointer to the thread-local value for the current thread, or create it.
+  template <typename F>
+  T* get_or_mut(F&& create)
+  {
+    return const_cast<T*>(get_or(std::forward<F>(create)));
+  }
+
+  /// \brief Apply func to every present thread-local value via a mutable reference.
+  /// \pre Requires exclusive access to this ThreadLocal (no concurrent operations).
+  template <typename F>
+  void for_each_mut(const F& func)
+  {
+    for (std::size_t i = 0; i < BUCKETS; ++i)
+    {
+      Entry* bucket_ptr = buckets[i].load(std::memory_order_acquire);
+      if (!bucket_ptr)
+      {
+        continue;
+      }
+
+      std::size_t bucket_size = 1ULL << i;
+      for (std::size_t j = 0; j < bucket_size; ++j)
+      {
+        Entry& entry = bucket_ptr[j];
+        if (entry.present.load(std::memory_order_acquire))
+        {
+          func(*reinterpret_cast<T*>(&entry.value));
+        }
+      }
+    }
+  }
+
+  /// \brief Clear all thread-local values.
+  void clear()
+  {
+    for (std::size_t i = 0; i < BUCKETS; ++i)
+    {
+      Entry* bucket_ptr = buckets[i].load(std::memory_order_relaxed);
+      if (bucket_ptr)
+      {
+        deallocate_bucket(bucket_ptr, 1ULL << i);
+        buckets[i].store(nullptr, std::memory_order_relaxed);
+      }
+    }
+    values_count.store(0, std::memory_order_relaxed);
+  }
+
+  /// \brief Get the number of thread-local values (approximate).
+  std::size_t size() const
+  {
+    return values_count.load(std::memory_order_acquire);
+  }
+};
+
+} // namespace mcrl2::utilities
+
+#endif // MCRL2_UTILITIES_THREAD_LOCAL_H_

--- a/libraries/utilities/test/thread_local_test.cpp
+++ b/libraries/utilities/test/thread_local_test.cpp
@@ -1,0 +1,142 @@
+// Author(s): Maurice Laveaux
+// Copyright: see the accompanying file COPYING or copy at
+// https://github.com/mCRL2org/mCRL2/blob/master/COPYING
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#define BOOST_TEST_MODULE thread_local_test
+
+#include <boost/test/unit_test.hpp>
+#include "mcrl2/utilities/thread_local.h"
+
+#include <thread>
+#include <vector>
+#include <memory>
+#include <atomic>
+
+using mcrl2::utilities::ThreadLocal;
+
+BOOST_AUTO_TEST_SUITE(thread_local_tests)
+
+BOOST_AUTO_TEST_CASE(test_basic_creation)
+{
+  ThreadLocal<int> tls;
+  const int* val = tls.get();
+  BOOST_CHECK(val == nullptr);
+}
+
+BOOST_AUTO_TEST_CASE(test_get_or_initial_creation)
+{
+  ThreadLocal<int> tls;
+  const int* val1 = tls.get();
+  BOOST_CHECK(val1 == nullptr);
+  
+  const int* val2 = tls.get_or([] { return 42; });
+  BOOST_REQUIRE(val2 != nullptr);
+  BOOST_CHECK_EQUAL(*val2, 42);
+}
+
+BOOST_AUTO_TEST_CASE(test_get_or_returns_same_value)
+{
+  ThreadLocal<int> tls;
+  
+  const int* val1 = tls.get_or([] { return 42; });
+  BOOST_REQUIRE(val1 != nullptr);
+  BOOST_CHECK_EQUAL(*val1, 42);
+  
+  const int* val2 = tls.get();
+  BOOST_REQUIRE(val2 != nullptr);
+  BOOST_CHECK_EQUAL(*val2, 42);
+  
+  const int* val3 = tls.get_or([] { return 100; });
+  BOOST_REQUIRE(val3 != nullptr);
+  BOOST_CHECK_EQUAL(*val3, 42);  // Should return the same value, not create a new one
+}
+
+BOOST_AUTO_TEST_CASE(test_multiple_threads)
+{
+  auto tls = std::make_shared<ThreadLocal<int>>();
+  std::vector<std::atomic<int>> results(3);
+  
+  std::vector<std::thread> threads;
+  for (int i = 0; i < 3; ++i)
+  {
+    threads.emplace_back([tls, i, &results]() {
+      const int* val = tls->get_or([i] { return i * 10; });
+      BOOST_REQUIRE(val != nullptr);
+      results[i].store(*val, std::memory_order_release);
+    });
+  }
+  
+  for (auto& t : threads)
+  {
+    t.join();
+  }
+  
+  // Verify that each thread got a different value
+  for (int i = 0; i < 3; ++i)
+  {
+    BOOST_CHECK_EQUAL(results[i].load(std::memory_order_acquire), i * 10);
+  }
+}
+
+BOOST_AUTO_TEST_CASE(test_thread_local_same_thread)
+{
+  ThreadLocal<int> tls;
+  
+  const int* val1 = tls.get_or([] { return 123; });
+  BOOST_REQUIRE(val1 != nullptr);
+  BOOST_CHECK_EQUAL(*val1, 123);
+  
+  const int* val2 = tls.get();
+  BOOST_REQUIRE(val2 != nullptr);
+  BOOST_CHECK_EQUAL(*val2, 123);
+  
+  // Same pointer should be returned
+  BOOST_CHECK_EQUAL(val1, val2);
+}
+
+BOOST_AUTO_TEST_CASE(test_clear)
+{
+  ThreadLocal<int> tls;
+  
+  const int* val1 = tls.get_or([] { return 456; });
+  BOOST_REQUIRE(val1 != nullptr);
+  BOOST_CHECK_EQUAL(*val1, 456);
+  
+  tls.clear();
+  
+  const int* val2 = tls.get();
+  BOOST_CHECK(val2 == nullptr);
+}
+
+BOOST_AUTO_TEST_CASE(test_iteration_single_thread)
+{
+  ThreadLocal<int> tls;
+  tls.get_or([] { return 100; });
+  
+  int count = 0;
+  int sum = 0;
+  for (const auto& val : tls)
+  {
+    count++;
+    sum += val;
+  }
+  
+  BOOST_CHECK_EQUAL(count, 1);
+  BOOST_CHECK_EQUAL(sum, 100);
+}
+
+BOOST_AUTO_TEST_CASE(test_size)
+{
+  ThreadLocal<int> tls;
+  BOOST_CHECK_EQUAL(tls.size(), 0);
+  
+  tls.get_or([] { return 42; });
+  BOOST_CHECK_EQUAL(tls.size(), 1);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/libraries/utilities/test/thread_local_test.cpp
+++ b/libraries/utilities/test/thread_local_test.cpp
@@ -7,9 +7,9 @@
 // http://www.boost.org/LICENSE_1_0.txt)
 //
 
-#define BOOST_TEST_MODULE thread_local_test
+#define BOOST_AUTO_TEST_MAIN
+#include <boost/test/included/unit_test.hpp>
 
-#include <boost/test/unit_test.hpp>
 #include "mcrl2/utilities/thread_local.h"
 
 #include <thread>
@@ -18,8 +18,6 @@
 #include <atomic>
 
 using mcrl2::utilities::ThreadLocal;
-
-BOOST_AUTO_TEST_SUITE(thread_local_tests)
 
 BOOST_AUTO_TEST_CASE(test_basic_creation)
 {
@@ -138,5 +136,3 @@ BOOST_AUTO_TEST_CASE(test_size)
   tls.get_or([] { return 42; });
   BOOST_CHECK_EQUAL(tls.size(), 1);
 }
-
-BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Changed the block allocator to keep a per thread free list that are obtained from a global list of free list chunks. Similarly, each thread has a block that is filled locally. This means that the lock is only acquired every one thousand creations, seemingly improving the parallel performance for creation heavy benchmarks.