### PR TITLE
Ensure multi-actions and related structures are sorted by default

### DIFF
--- a/libraries/atermpp/include/mcrl2/atermpp/aterm_list.h
+++ b/libraries/atermpp/include/mcrl2/atermpp/aterm_list.h
@@ -527,14 +527,12 @@ using aterm_list = term_list<aterm>;
 /// \param ordering A total orderings relation on Term, by default the ordering relation on Terms. 
 /// \details This operator has linear complexity. 
 /// \return A boolean indicating whether the list is sorted. 
-template <typename Term>
+template <typename Term, typename Compare = std::less<Term>>
 inline
-bool is_sorted(const term_list<Term>& l,
-               const std::function<bool(const Term&, const Term&)>& ordering
-                                   = [](const Term& t1, const Term& t2){ return t1<t2;} )
+bool is_sorted(const term_list<Term>& l, Compare ordering = Compare{})
 {
   return std::is_sorted(l.begin(), l.end(), ordering);
-} 
+}
 
 
 /// \brief Returns the list with the elements sorted according to the given ordering which is by default standard ordering on Term. 
@@ -554,11 +552,9 @@ term_list<Term> reverse(const term_list<Term>& l);
 /// \param ordering An total orderings relation on Term, by default the ordering relation on Terms. 
 /// \details This operator has complexity nlog n where n is the size of the list.
 /// \return The sorted list.
-template <typename Term>
+template <typename Term, typename Compare = std::less<Term>>
 inline
-term_list<Term> sort_list(const term_list<Term>& l, 
-                          const std::function<bool(const Term&, const Term&)>& ordering 
-                                      = [](const Term& t1, const Term& t2){ return t1<t2;});
+term_list<Term> sort_list(const term_list<Term>& l, Compare ordering = Compare{});
 
 /// \brief Returns the list with element t inserted in l lexicographically according to the provided ordering. 
 /// \param t An element to be inserted.
@@ -566,11 +562,9 @@ term_list<Term> sort_list(const term_list<Term>& l,
 /// \param ordering A total orderings relation on Term, by default the ordering relation on Terms. 
 /// \details This operator has linear complexity. It is assumed that the list l is ordered for it to work. 
 /// \return The sorted list.
-template <typename Term>
+template <typename Term, typename Compare = std::less<Term>>
 inline
-term_list<Term> insert_sorted(const Term& t, const term_list<Term>& l,
-                              const std::function<bool(const Term&, const Term&)>& ordering
-                                       = [](const Term& t1, const Term& t2){ return t1<t2;} );
+term_list<Term> insert_sorted(const Term& t, const term_list<Term>& l, Compare ordering = Compare{});
 
 /// \brief Returns the merged list sorted according to the given ordering, which is by default the ordering of addresses of terms. 
 /// \param l1 An ordered list.
@@ -578,12 +572,9 @@ term_list<Term> insert_sorted(const Term& t, const term_list<Term>& l,
 /// \param ordering A total orderings relation on Term, by default the ordering relation on Terms. 
 /// \details This operator is linear in the cumulative length of l1 and l2. In debug mode it checks whether l1 and l2 are ordered.
 /// \return The sorted list.
-template <typename Term>
+template <typename Term, typename Compare = std::less<Term>>
 inline
-term_list<Term> merge_lists(const term_list<Term>& l1, 
-                            const term_list<Term>& l2,
-                            const std::function<bool(const Term&, const Term&)>& ordering 
-                                      = [](const Term& t1, const Term& t2){ return t1<t2;});
+term_list<Term> merge_lists(const term_list<Term>& l1, const term_list<Term>& l2, Compare ordering = Compare{});
 
 
 /// \brief Returns the concatenation of two lists with convertible element types.

--- a/libraries/atermpp/include/mcrl2/atermpp/detail/aterm_list_implementation.h
+++ b/libraries/atermpp/include/mcrl2/atermpp/detail/aterm_list_implementation.h
@@ -182,11 +182,13 @@ term_list<Term> insert_sorted(const Term& t, const term_list<Term>& l, Compare o
 {
   if (l.empty() || ordering(t,l.front()))
   {
-    return insert(t,l);
+    term_list<Term> result = l;
+    result.push_front(t);
+    return result;
   }
-  
+
   const std::size_t len = l.size();
- 
+
   // The resulting list
   term_list<Term> result=l;
 
@@ -199,18 +201,18 @@ term_list<Term> insert_sorted(const Term& t, const term_list<Term>& l, Compare o
     std::size_t j=0;
     while (!result.empty())
     {
-      if (ordering(t,l.front()))
+      if (ordering(t,result.front()))
       {
         break;
       }
       else
       {
-        new (buffer+j) Term(result.front()); // A mcrl2 stack allocator does not handle construction by default. 
+        new (buffer+j) Term(result.front()); // A mcrl2 stack allocator does not handle construction by default.
         result.pop_front();
         ++j;
       }
     }
-    
+
     result.push_front(t);
 
     // Insert elements at the front of the list.
@@ -229,7 +231,7 @@ term_list<Term> insert_sorted(const Term& t, const term_list<Term>& l, Compare o
 
     while (!result.empty())
     {
-      if (ordering(t,l.front()))
+      if (ordering(t,result.front()))
       {
         break;
       }

--- a/libraries/atermpp/include/mcrl2/atermpp/detail/aterm_list_implementation.h
+++ b/libraries/atermpp/include/mcrl2/atermpp/detail/aterm_list_implementation.h
@@ -117,11 +117,9 @@ term_list<Term> reverse(const term_list<Term>& l)
   return result;
 }
 
-template <typename Term>
+template <typename Term, typename Compare>
 inline
-term_list<Term> sort_list(const term_list<Term>& l, 
-                             const std::function<bool(const Term&, const Term&)>& ordering 
-                                  /* = [](const Term& t1, const Term& t2){ return t1<t2;}*/ )
+term_list<Term> sort_list(const term_list<Term>& l, Compare ordering)
 {
   const std::size_t len = l.size();
   if (len<=1)
@@ -178,11 +176,9 @@ term_list<Term> sort_list(const term_list<Term>& l,
   return result;
 }
 
-template <typename Term>
+template <typename Term, typename Compare>
 inline
-term_list<Term> insert_sorted(const Term& t, const term_list<Term>& l, 
-                             const std::function<bool(const Term&, const Term&)>& ordering 
-                                  /* = [](const Term& t1, const Term& t2){ return t1<t2;}*/ )
+term_list<Term> insert_sorted(const Term& t, const term_list<Term>& l, Compare ordering)
 {
   if (l.empty() || ordering(t,l.front()))
   {
@@ -259,12 +255,9 @@ term_list<Term> insert_sorted(const Term& t, const term_list<Term>& l,
 
 
 
-template <typename Term>
+template <typename Term, typename Compare>
 inline
-term_list<Term> merge_lists(const term_list<Term>& l1, 
-                            const term_list<Term>& l2,
-                            const std::function<bool(const Term&, const Term&)>& ordering 
-                                  /* = [](const Term& t1, const Term& t2){ return t1<t2;}*/ )
+term_list<Term> merge_lists(const term_list<Term>& l1, const term_list<Term>& l2, Compare ordering)
 {
   assert(is_sorted(l1,ordering));
   assert(is_sorted(l2,ordering));

--- a/libraries/atermpp/test/aterm_list_test.cpp
+++ b/libraries/atermpp/test/aterm_list_test.cpp
@@ -149,3 +149,31 @@ BOOST_AUTO_TEST_CASE(test_concatenation)
   term_list<aterm> l2;
   BOOST_CHECK(l2+l1 == l1+l2);
 }
+
+BOOST_AUTO_TEST_CASE(test_insert_sorted)
+{
+  // Ordering on aterm_int by integer value.
+  auto int_less = [](const aterm_int& a, const aterm_int& b) { return a.value() < b.value(); };
+
+  // Regression test: the inner comparison loop previously checked ordering(t, l.front())
+  // instead of ordering(t, result.front()). Because l.front() never changes, any t with
+  // t >= l.front() would cause the loop to drain the entire list and append t at the end.
+  // For example, insert_sorted(2, [1,3,4]) would produce [1,3,4,2] instead of [1,2,3,4].
+  term_list<aterm_int> l = { aterm_int(1), aterm_int(3), aterm_int(4) };
+  term_list<aterm_int> expected_middle = { aterm_int(1), aterm_int(2), aterm_int(3), aterm_int(4) };
+  BOOST_CHECK(insert_sorted(aterm_int(2), l, int_less) == expected_middle);
+
+  // Insert at the front (early-return path).
+  term_list<aterm_int> l2 = { aterm_int(2), aterm_int(3), aterm_int(4) };
+  term_list<aterm_int> expected_front = { aterm_int(1), aterm_int(2), aterm_int(3), aterm_int(4) };
+  BOOST_CHECK(insert_sorted(aterm_int(1), l2, int_less) == expected_front);
+
+  // Insert at the back.
+  term_list<aterm_int> l3 = { aterm_int(1), aterm_int(2), aterm_int(3) };
+  term_list<aterm_int> expected_back = { aterm_int(1), aterm_int(2), aterm_int(3), aterm_int(4) };
+  BOOST_CHECK(insert_sorted(aterm_int(4), l3, int_less) == expected_back);
+
+  // Insert into an empty list.
+  term_list<aterm_int> expected_single = { aterm_int(5) };
+  BOOST_CHECK(insert_sorted(aterm_int(5), term_list<aterm_int>(), int_less) == expected_single);
+}

--- a/libraries/lps/include/mcrl2/lps/linearise_allow_block.h
+++ b/libraries/lps/include/mcrl2/lps/linearise_allow_block.h
@@ -211,7 +211,7 @@ inline void allowblockcomposition(
   deadlock_summand_vector resultsimpledeltasumlist;
   deadlock_summands.swap(resultdeltasumlist);
 
-  process::action_name_multiset_list allowlist((is_allow) ? sort_multi_action_labels(allowlist1) : allowlist1);
+  process::action_name_multiset_list allowlist(allowlist1);
 
   std::size_t sourcesumlist_length = sourcesumlist.size();
   if (sourcesumlist_length > 2 || is_allow) // This condition prevents this message to be printed

--- a/libraries/lps/include/mcrl2/lps/linearise_allow_block.h
+++ b/libraries/lps/include/mcrl2/lps/linearise_allow_block.h
@@ -106,7 +106,7 @@ inline bool allow_(const detail::allow_list_cache& allow_cache,
     const process::action_list& multi_action,
     const process::action& termination_action)
 {
-  assert(std::is_sorted(multi_action.begin(), multi_action.end(), process::action_compare()));
+  assert(std::is_sorted(multi_action.begin(), multi_action.end()));
 
   // The empty multiaction and the termination action can never be blocked by allows.
   if (multi_action.empty() || multi_action == process::action_list({termination_action}))
@@ -129,7 +129,7 @@ bool encap(const Container& blocked_actions, const process::action_list& multiac
   static_assert(std::is_same_v<typename Container::value_type, core::identifier_string>, "Container must contain core::identifier_string");
 
   assert(std::is_sorted(blocked_actions.begin(), blocked_actions.end(), process::action_name_compare()));
-  assert(std::is_sorted(multiaction.begin(), multiaction.end(), process::action_compare()));
+  assert(std::is_sorted(multiaction.begin(), multiaction.end()));
 
   core::identifier_string_list::const_iterator blocked_actions_it = blocked_actions.begin();
   process::action_list::const_iterator multiaction_it = multiaction.begin();
@@ -165,7 +165,7 @@ bool encap(const Container& blocked_actions, const process::action_list& multiac
 inline bool encap(const process::action_name_multiset_list& encaplist, const process::action_list& multiaction)
 {
   assert(encaplist.size() == 1);
-  assert(std::is_sorted(multiaction.begin(), multiaction.end(), process::action_compare()));
+  assert(std::is_sorted(multiaction.begin(), multiaction.end()));
 
   const core::identifier_string_list& blocked_actions = encaplist.front().names();
   return encap(blocked_actions, multiaction);

--- a/libraries/lps/include/mcrl2/lps/linearise_communication.h
+++ b/libraries/lps/include/mcrl2/lps/linearise_communication.h
@@ -97,7 +97,7 @@ inline void addActionCondition(const process::action& a, const data::data_expres
   {
     for (process::action_list& m : L.actions)
     {
-      m = atermpp::insert_sorted(a, m, process::action_compare());
+      m = atermpp::insert_sorted(a, m);
       S.actions.emplace_back(std::move(m));
     }
   }
@@ -148,7 +148,7 @@ protected:
   /// NB: resets temporary data before performing computations.
   bool match_multiaction(const process::action_list& multi_action)
   {
-    assert(std::is_sorted(multi_action.begin(), multi_action.end(), process::action_compare()));
+    assert(std::is_sorted(multi_action.begin(), multi_action.end()));
 
     reset_temporary_data();
 
@@ -248,7 +248,7 @@ public:
   /// if \exists_{(b,c) \in C} b = \mu(m), return c, otherwise return action_label()
   process::action_label can_communicate(const process::action_list& m)
   {
-    assert(std::is_sorted(m.begin(), m.end(), process::action_compare()));
+    assert(std::is_sorted(m.begin(), m.end()));
 
     process::action_label result; // if no match found, return process::action_label()
 
@@ -281,8 +281,8 @@ public:
   /// a1|...|ak that are not in m are in n. I.e., there is a subbag o of n such that m+o can communicate.
   bool might_communicate(const process::action_list& m, const process::action_list& n)
   {
-    assert(std::is_sorted(m.begin(), m.end(), process::action_compare()));
-    assert(std::is_sorted(n.begin(), n.end(), process::action_compare()));
+    assert(std::is_sorted(m.begin(), m.end()));
+    assert(std::is_sorted(n.begin(), n.end()));
 
     /* this function indicates whether the actions in m
        consisting of actions and data occur in C, such that
@@ -398,7 +398,7 @@ public:
   /// \param RewriteTerm The rewriter that should be used to simplify the conditions.
   tuple_list apply(const process::action_list& m)
   {
-    assert(std::is_sorted(m.begin(), m.end(), process::action_compare()));
+    assert(std::is_sorted(m.begin(), m.end()));
     const process::action_list r;
     return makeMultiActionConditionList_aux(m, r);
   }
@@ -730,8 +730,8 @@ protected:
   /// \param RewriteTerm Data rewriter for simplifying expressions.
   inline tuple_list makeMultiActionConditionList_aux(const process::action_list& m, const process::action_list& r)
   {
-    assert(std::is_sorted(m.begin(), m.end(), process::action_compare()));
-    assert(std::is_sorted(r.begin(), r.end(), process::action_compare()));
+    assert(std::is_sorted(m.begin(), m.end()));
+    assert(std::is_sorted(r.begin(), r.end()));
 
     tuple_list S; // result
 
@@ -764,7 +764,7 @@ protected:
       if (maybe_allowed(a.label()))
       {
         // T = \overline{\gamma}(n, C, [a(d)] \oplus r)
-        tuple_list T = makeMultiActionConditionList_aux(m_tail, atermpp::insert_sorted(a, r, process::action_compare()));
+        tuple_list T = makeMultiActionConditionList_aux(m_tail, atermpp::insert_sorted(a, r));
 
         // S := S \cup \{ (a,true) \oplus t \mid t \in T \}
         // TODO: van Weerdenburg in his note only calculates S := S \cup T. Understand why that is not correct.
@@ -788,10 +788,10 @@ protected:
       const process::action_list& n,
       const process::action_list& r)
   {
-    assert(std::is_sorted(m.begin(), m.end(), process::action_compare()));
-    assert(std::is_sorted(w.begin(), w.end(), process::action_compare()));
-    assert(std::is_sorted(n.begin(), n.end(), process::action_compare()));
-    assert(std::is_sorted(r.begin(), r.end(), process::action_compare()));
+    assert(std::is_sorted(m.begin(), m.end()));
+    assert(std::is_sorted(w.begin(), w.end()));
+    assert(std::is_sorted(n.begin(), n.end()));
+    assert(std::is_sorted(r.begin(), r.end()));
 
     tuple_list S;
 
@@ -827,13 +827,13 @@ protected:
         {
           // a(f) cannot take part in communication as the arguments do not match. Move to w and continue with next
           // action
-          S = phi(m, d, atermpp::insert_sorted(a, w, process::action_compare()), n_tail, r);
+          S = phi(m, d, atermpp::insert_sorted(a, w), n_tail, r);
         }
         else
         {
-          tuple_list T = phi(atermpp::insert_sorted(a, m, process::action_compare()), d, w, n_tail, r);
+          tuple_list T = phi(atermpp::insert_sorted(a, m), d, w, n_tail, r);
 
-          S = phi(m, d, atermpp::insert_sorted(a, w, process::action_compare()), n_tail, r);
+          S = phi(m, d, atermpp::insert_sorted(a, w), n_tail, r);
           addActionCondition(process::action(), condition, std::move(T), S);
         }
       }
@@ -852,7 +852,7 @@ protected:
     }
     else
     {
-      const process::action_list alpha_ = atermpp::insert_sorted(beta.front(), alpha, process::action_compare());
+      const process::action_list alpha_ = atermpp::insert_sorted(beta.front(), alpha);
 
       if (m_comm_table.can_communicate(alpha_) != process::action_label())
       {
@@ -874,7 +874,7 @@ protected:
 
   data::data_expression psi(process::action_list alpha)
   {
-    assert(std::is_sorted(alpha.begin(), alpha.end(), process::action_compare()));
+    assert(std::is_sorted(alpha.begin(), alpha.end()));
     data::data_expression cond = data::sort_bool::false_();
 
     process::action_list actl; // used in inner loop.
@@ -885,8 +885,8 @@ protected:
       while (!beta.empty())
       {
         actl = process::action_list();
-        actl = atermpp::insert_sorted(alpha.front(), actl, process::action_compare());
-        actl = atermpp::insert_sorted(beta.front(), actl, process::action_compare());
+        actl = atermpp::insert_sorted(alpha.front(), actl);
+        actl = atermpp::insert_sorted(beta.front(), actl);
         const process::action_list& beta_tail = beta.tail();
         if (m_comm_table.might_communicate(actl, beta_tail) && xi(actl, beta_tail))
         {

--- a/libraries/lps/include/mcrl2/lps/linearise_communication.h
+++ b/libraries/lps/include/mcrl2/lps/linearise_communication.h
@@ -370,8 +370,8 @@ public:
       bool is_block)
       : m_terminationAction(termination_action),
         m_data_rewriter(data_rewriter),
-        m_communications(sort_communications(communications)),
-        m_allowlist(sort_multi_action_labels(allowlist)),
+        m_communications(communications),
+        m_allowlist(allowlist),
         m_allow_cache(is_allow ? detail::make_allow_list_cache(allowlist) : detail::allow_list_cache()),
         m_blocked_actions(is_block ? get_actions(allowlist) : std::vector<core::identifier_string>()),
         m_allowed_actions(init_allowed_actions(is_allow, allowlist, termination_action)),

--- a/libraries/lps/include/mcrl2/lps/linearise_communication.h
+++ b/libraries/lps/include/mcrl2/lps/linearise_communication.h
@@ -97,7 +97,7 @@ inline void addActionCondition(const process::action& a, const data::data_expres
   {
     for (process::action_list& m : L.actions)
     {
-      m = insert(a, m);
+      m = atermpp::insert_sorted(a, m, process::action_compare());
       S.actions.emplace_back(std::move(m));
     }
   }
@@ -764,7 +764,7 @@ protected:
       if (maybe_allowed(a.label()))
       {
         // T = \overline{\gamma}(n, C, [a(d)] \oplus r)
-        tuple_list T = makeMultiActionConditionList_aux(m_tail, insert(a, r));
+        tuple_list T = makeMultiActionConditionList_aux(m_tail, atermpp::insert_sorted(a, r, process::action_compare()));
 
         // S := S \cup \{ (a,true) \oplus t \mid t \in T \}
         // TODO: van Weerdenburg in his note only calculates S := S \cup T. Understand why that is not correct.
@@ -827,13 +827,13 @@ protected:
         {
           // a(f) cannot take part in communication as the arguments do not match. Move to w and continue with next
           // action
-          S = phi(m, d, insert(a, w), n_tail, r);
+          S = phi(m, d, atermpp::insert_sorted(a, w, process::action_compare()), n_tail, r);
         }
         else
         {
-          tuple_list T = phi(insert(a, m), d, w, n_tail, r);
+          tuple_list T = phi(atermpp::insert_sorted(a, m, process::action_compare()), d, w, n_tail, r);
 
-          S = phi(m, d, insert(a, w), n_tail, r);
+          S = phi(m, d, atermpp::insert_sorted(a, w, process::action_compare()), n_tail, r);
           addActionCondition(process::action(), condition, std::move(T), S);
         }
       }
@@ -852,7 +852,7 @@ protected:
     }
     else
     {
-      const process::action_list alpha_ = insert(beta.front(), alpha);
+      const process::action_list alpha_ = atermpp::insert_sorted(beta.front(), alpha, process::action_compare());
 
       if (m_comm_table.can_communicate(alpha_) != process::action_label())
       {
@@ -885,8 +885,8 @@ protected:
       while (!beta.empty())
       {
         actl = process::action_list();
-        actl = insert(alpha.front(), actl);
-        actl = insert(beta.front(), actl);
+        actl = atermpp::insert_sorted(alpha.front(), actl, process::action_compare());
+        actl = atermpp::insert_sorted(beta.front(), actl, process::action_compare());
         const process::action_list& beta_tail = beta.tail();
         if (m_comm_table.might_communicate(actl, beta_tail) && xi(actl, beta_tail))
         {

--- a/libraries/lps/include/mcrl2/lps/linearise_rename.h
+++ b/libraries/lps/include/mcrl2/lps/linearise_rename.h
@@ -56,6 +56,9 @@ namespace mcrl2::lps
     return action;
   }
 
+  /// Apply renamings to a list of actions.
+  ///
+  /// Note that the result is not sorted.
   inline
   process::action_list rename(const process::rename_expression_list& renamings,
                               const process::action_list& actions)
@@ -94,7 +97,7 @@ namespace mcrl2::lps
     const process::rename_expression_list& renamings,
     lps::stochastic_action_summand_vector& action_summands)
   {
-    [[maybe_unused]]    
+    [[maybe_unused]]
     lps_statistics_t lps_statistics_before = get_statistics(action_summands);
 
     for (stochastic_action_summand& action_summand: action_summands)

--- a/libraries/lps/include/mcrl2/lps/linearise_rename.h
+++ b/libraries/lps/include/mcrl2/lps/linearise_rename.h
@@ -67,7 +67,6 @@ namespace mcrl2::lps
       result.push_front(rename(renamings, a));
     }
 
-    result = sort_actions(result);
     return result;
   }
 

--- a/libraries/lps/include/mcrl2/lps/linearise_utility.h
+++ b/libraries/lps/include/mcrl2/lps/linearise_utility.h
@@ -78,52 +78,6 @@ lps_statistics_t get_statistics(const stochastic_action_summand_vector& action_s
   return statistics;
 }
 
-/// Insert action into an action_list, keeping the action list sorted w.r.t. action_compare.
-/// Complexity: O(n) for an action_list of length n.
-inline
-process::action_list insert(
-  const process::action& act,
-  process::action_list l)
-{
-  if (l.empty())
-  {
-    return process::action_list({ act });
-  }
-  const process::action& head = l.front();
-
-  if (process::action_compare()(act, head))
-  {
-    l.push_front(act);
-    return l;
-  }
-
-  process::action_list result = insert(act, l.tail());
-  result.push_front(head);
-  return result;
-}
-
-/// insert an action name into the list, while preserving the sorting of action names.
-inline
-core::identifier_string_list insert(
-  const core::identifier_string& s,
-  core::identifier_string_list l)
-{
-  if (l.empty())
-  {
-    return core::identifier_string_list({ s });
-  }
-  const core::identifier_string& head = l.front();
-
-  if (process::action_name_compare()(s, head))
-  {
-    l.push_front(s);
-    return l;
-  }
-
-  core::identifier_string_list result = insert(s, l.tail());
-  result.push_front(head);
-  return result;
-}
 
 inline
 process::action_list sort_actions(const process::action_list& actions,

--- a/libraries/lps/include/mcrl2/lps/linearise_utility.h
+++ b/libraries/lps/include/mcrl2/lps/linearise_utility.h
@@ -126,42 +126,11 @@ core::identifier_string_list insert(
 }
 
 inline
-process::action_name_multiset sort_action_names(const process::action_name_multiset& action_labels,
-  const std::function<bool(const core::identifier_string&, const core::identifier_string&)>& cmp
-                                    = [](const core::identifier_string& t1, const core::identifier_string& t2){ return process::action_name_compare()(t1, t2);})
-{
-  return process::action_name_multiset(atermpp::sort_list(action_labels.names(), cmp));
-}
-
-inline
-process::action_name_multiset_list sort_multi_action_labels(const process::action_name_multiset_list& l)
-{
-  return process::action_name_multiset_list(l.begin(),l.end(),[](const process::action_name_multiset& al){ return sort_action_names(al); });
-}
-
-inline
 process::action_list sort_actions(const process::action_list& actions,
   const std::function<bool(const process::action&, const process::action&)>& cmp
                                     = [](const process::action& t1, const process::action& t2){ return process::action_compare()(t1, t2);})
 {
   return process::action_list(atermpp::sort_list(actions, cmp));
-}
-
-
-/// Sort the left-hand sides of the communication expressions in communications
-///
-/// Sorting is done using sort_action_labels, so by default, the left-hand sides of the communications are sorted by names of the actions.
-inline
-process::communication_expression_list sort_communications(const process::communication_expression_list& communications)
-{
-  process::communication_expression_list result;
-
-  for (const process::communication_expression& comm: communications)
-  {
-    result.push_front(process::communication_expression(sort_action_names(comm.action_name()),comm.name()));
-  }
-
-  return result;
 }
 
 inline

--- a/libraries/lps/include/mcrl2/lps/linearise_utility.h
+++ b/libraries/lps/include/mcrl2/lps/linearise_utility.h
@@ -80,11 +80,9 @@ lps_statistics_t get_statistics(const stochastic_action_summand_vector& action_s
 
 
 inline
-process::action_list sort_actions(const process::action_list& actions,
-  const std::function<bool(const process::action&, const process::action&)>& cmp
-                                    = [](const process::action& t1, const process::action& t2){ return process::action_compare()(t1, t2);})
+process::action_list sort_actions(const process::action_list& actions)
 {
-  return process::action_list(atermpp::sort_list(actions, cmp));
+  return process::action_list(atermpp::sort_list(actions));
 }
 
 inline

--- a/libraries/lps/include/mcrl2/lps/multi_action.h
+++ b/libraries/lps/include/mcrl2/lps/multi_action.h
@@ -82,11 +82,6 @@ class multi_action: public atermpp::aterm
       return multi_action(actions() + other.actions(), time());
     }
 
-    bool operator==(const multi_action& other) const
-    {
-      return time() == other.time() && actions() == other.actions();
-    }
-
    //--- end user section multi_action ---//
 };
 

--- a/libraries/lps/include/mcrl2/lps/multi_action.h
+++ b/libraries/lps/include/mcrl2/lps/multi_action.h
@@ -48,7 +48,7 @@ class multi_action: public atermpp::aterm
     explicit multi_action(const process::action_list& actions = process::action_list(),
                           data::data_expression time = data::undefined_real())
       : atermpp::aterm(core::detail::function_symbol_TimedMultAct(),
-                       atermpp::sort_list(actions, process::action_compare()),
+                       atermpp::sort_list(actions),
                        time)
     {
       assert(data::sort_real::is_real(time.sort()));

--- a/libraries/lps/include/mcrl2/lps/multi_action.h
+++ b/libraries/lps/include/mcrl2/lps/multi_action.h
@@ -44,10 +44,12 @@ class multi_action: public atermpp::aterm
       return atermpp::down_cast<data::data_expression>((*this)[1]);
     }
 //--- start user section multi_action ---//
-    /// \brief Constructor
-    explicit multi_action(const process::action_list& actions = process::action_list(), 
+    /// \brief Constructor. Actions are sorted to establish the sorted-storage invariant.
+    explicit multi_action(const process::action_list& actions = process::action_list(),
                           data::data_expression time = data::undefined_real())
-      : atermpp::aterm(core::detail::function_symbol_TimedMultAct(), actions, time)
+      : atermpp::aterm(core::detail::function_symbol_TimedMultAct(),
+                       atermpp::sort_list(actions, process::action_compare()),
+                       time)
     {
       assert(data::sort_real::is_real(time.sort()));
     }
@@ -89,7 +91,7 @@ class multi_action: public atermpp::aterm
 
     bool operator==(const multi_action& other) const
     {
-      return time()==other.time() && atermpp::sort_list(actions())==atermpp::sort_list(other.actions());
+      return time() == other.time() && actions() == other.actions();
     }
 
    //--- end user section multi_action ---//

--- a/libraries/lps/include/mcrl2/lps/multi_action.h
+++ b/libraries/lps/include/mcrl2/lps/multi_action.h
@@ -196,23 +196,6 @@ struct compare_action_labels
   }
 };
 
-/// \brief Compares action labels and arguments
-struct compare_action_label_arguments
-{
-  /// \brief Function call operator
-  /// \param a An action
-  /// \param b An action
-  /// \return The function result
-  bool operator()(const process::action& a, const process::action& b) const
-  {
-    if (a.label() != b.label())
-    {
-      return a.label() < b.label();
-    }
-    return a < b;
-  }
-};
-
 /// \brief Used for building an expression for the comparison of data parameters.
 struct equal_data_parameters_builder
 {
@@ -304,11 +287,8 @@ inline data::data_expression equal_multi_actions(const multi_action& a, const mu
 {
   using namespace data::lazy;
 
-  // make copies of a and b and sort them
-  std::vector<process::action> va(a.actions().begin(), a.actions().end()); // protection not needed
-  std::vector<process::action> vb(b.actions().begin(), b.actions().end()); // protection not needed
-  std::sort(va.begin(), va.end(), detail::compare_action_label_arguments());
-  std::sort(vb.begin(), vb.end(), detail::compare_action_label_arguments());
+  std::vector<process::action> va(a.actions().begin(), a.actions().end());
+  std::vector<process::action> vb(b.actions().begin(), b.actions().end());
 
   if (!detail::equal_action_signatures(va, vb))
   {
@@ -342,11 +322,8 @@ inline data::data_expression not_equal_multi_actions(const multi_action& a, cons
 {
   using namespace data::lazy;
 
-  // make copies of a and b and sort them
   std::vector<process::action> va(a.actions().begin(), a.actions().end());
   std::vector<process::action> vb(b.actions().begin(), b.actions().end());
-  std::sort(va.begin(), va.end(), detail::compare_action_label_arguments());
-  std::sort(vb.begin(), vb.end(), detail::compare_action_label_arguments());
 
   if (!detail::equal_action_signatures(va, vb))
   {

--- a/libraries/lps/include/mcrl2/lps/multi_action.h
+++ b/libraries/lps/include/mcrl2/lps/multi_action.h
@@ -91,6 +91,10 @@ template <class... ARGUMENTS>
 inline void make_multi_action(atermpp::aterm& t, const ARGUMENTS&... args)
 {
   atermpp::make_term_appl(t, core::detail::function_symbol_TimedMultAct(), args...);
+  // Re-assign through the sorting constructor to maintain the sorted-storage invariant
+  // when the action list is rebuilt by a builder traversal (make_term_appl bypasses it).
+  t = multi_action(atermpp::down_cast<multi_action>(t).actions(),
+                   atermpp::down_cast<multi_action>(t).time());
 }
 
 /// \\brief list of multi_actions
@@ -287,6 +291,8 @@ inline data::data_expression equal_multi_actions(const multi_action& a, const mu
 {
   using namespace data::lazy;
 
+  assert(std::is_sorted(a.actions().begin(), a.actions().end()));
+  assert(std::is_sorted(b.actions().begin(), b.actions().end()));
   std::vector<process::action> va(a.actions().begin(), a.actions().end());
   std::vector<process::action> vb(b.actions().begin(), b.actions().end());
 
@@ -322,6 +328,8 @@ inline data::data_expression not_equal_multi_actions(const multi_action& a, cons
 {
   using namespace data::lazy;
 
+  assert(std::is_sorted(a.actions().begin(), a.actions().end()));
+  assert(std::is_sorted(b.actions().begin(), b.actions().end()));
   std::vector<process::action> va(a.actions().begin(), a.actions().end());
   std::vector<process::action> vb(b.actions().begin(), b.actions().end());
 

--- a/libraries/lps/include/mcrl2/lps/multi_action.h
+++ b/libraries/lps/include/mcrl2/lps/multi_action.h
@@ -82,13 +82,6 @@ class multi_action: public atermpp::aterm
       return multi_action(actions() + other.actions(), time());
     }
 
-    /// \brief Returns the multiaction in which the list of actions is sorted. 
-    /// \return A multi-action with a sorted list.
-    multi_action sort_actions() const
-    {
-      return multi_action(atermpp::sort_list(actions()),time());
-    }
-
     bool operator==(const multi_action& other) const
     {
       return time() == other.time() && actions() == other.actions();

--- a/libraries/lps/source/linearise.cpp
+++ b/libraries/lps/source/linearise.cpp
@@ -776,7 +776,7 @@ class specification_basic_type
       action_list result=ma2;
       for (const action& a: ma1)
       {
-        result = atermpp::insert_sorted(a, result, process::action_compare());
+        result = atermpp::insert_sorted(a, result);
       }
       return result;
     }
@@ -4546,7 +4546,7 @@ class specification_basic_type
     }
 
     /// Adapt multiactions to stack by traversing the list.
-    /// Note: the result is sorted w.r.t action_compare().
+    /// Note: the result is sorted w.r.t. operator< on action.
     action_list
     adapt_multiaction_to_stack(const action_list& multiAction, const stacklisttype& stack, const variable_list& vars)
     {
@@ -4561,7 +4561,7 @@ class specification_basic_type
 
       // As the arguments change, sort order w.r.t. action_label is preserved, but order w.r.t. arguments is changed.
       // resort the list.
-      std::sort(result.begin(), result.end(), action_compare());
+      std::sort(result.begin(), result.end());
 
       return action_list(result.begin(), result.end());
     }
@@ -5029,7 +5029,7 @@ class specification_basic_type
       const bool is_deadlock_summand)
     {
       assert(distribution != stochastic_distribution());
-      assert(std::is_sorted(multiAction.begin(), multiAction.end(), action_compare()));
+      assert(std::is_sorted(multiAction.begin(), multiAction.end()));
 
       const data_expression rewritten_condition=RewriteTerm(condition);
       if (rewritten_condition==sort_bool::false_())
@@ -7549,7 +7549,7 @@ class specification_basic_type
 
         variable_list sumvars1 = summand1.summation_variables() + sumvars;
         const action_list& multiaction1 = summand1.multi_action().actions();
-        assert(std::is_sorted(multiaction1.begin(), multiaction1.end(), action_compare()));
+        assert(std::is_sorted(multiaction1.begin(), multiaction1.end()));
         data_expression actiontime1 = summand1.multi_action().time();
         data_expression condition1 = summand1.condition();
         const assignment_list& nextstate1 = summand1.assignments();
@@ -7831,7 +7831,7 @@ class specification_basic_type
             condition3=RewriteTerm(condition3);
             if (condition3!=sort_bool::false_())
             {
-              assert(std::is_sorted(multiaction3.begin(), multiaction3.end(), action_compare()));
+              assert(std::is_sorted(multiaction3.begin(), multiaction3.end()));
               action_summands.emplace_back(allsums,
                   condition3,
                   has_time3 ? multi_action(multiaction3, action_time3) : multi_action(multiaction3),

--- a/libraries/lps/source/linearise.cpp
+++ b/libraries/lps/source/linearise.cpp
@@ -8059,7 +8059,7 @@ class specification_basic_type
 
       /* first we enumerate the summands of t1 */
 
-      action_name_multiset_list allowlist((is_allow)?sort_multi_action_labels(allowlist1):allowlist1);
+      action_name_multiset_list allowlist(allowlist1);
       calculate_left_merge(action_summands1, deadlock_summands1,
                            ultimate_delay_condition2, allowlist, is_allow, is_block,
                            action_summands, deadlock_summands);

--- a/libraries/lps/source/linearise.cpp
+++ b/libraries/lps/source/linearise.cpp
@@ -776,7 +776,7 @@ class specification_basic_type
       action_list result=ma2;
       for (const action& a: ma1)
       {
-        result=insert(a,result);
+        result = atermpp::insert_sorted(a, result, process::action_compare());
       }
       return result;
     }

--- a/libraries/lps/test/action_rename_test.cpp
+++ b/libraries/lps/test/action_rename_test.cpp
@@ -15,6 +15,7 @@
 #include "mcrl2/lps/remove.h"
 #include "mcrl2/lps/rewrite.h"
 #include <boost/test/included/unit_test.hpp>
+#include <set>
 
 using namespace mcrl2;
 using lps::stochastic_specification;
@@ -23,7 +24,35 @@ using lps::action_summand;
 using lps::action_summand_vector;
 using lps::deadlock_summand;
 
-void test1()
+inline
+std::multiset<std::string> multiaction_names(const lps::multi_action& ma)
+{
+  std::multiset<std::string> result;
+  for (const auto& a : ma.actions())
+  {
+    result.insert(std::string(a.label().name()));
+  }
+  return result;
+}
+
+inline
+bool has_action_label(const stochastic_specification& spec, const std::string& name)
+{
+  return std::any_of(spec.action_labels().begin(), spec.action_labels().end(),
+    [&name](const process::action_label& al){ return std::string(al.name()) == name; });
+}
+
+// Check whether a summand with the given names in its multi-action is present in the specification.
+// We use multisets to correctly handle duplicate action names and avoid ordering issues.
+inline
+bool has_summand_with_multiaction(const stochastic_specification& spec, std::initializer_list<std::string> names)
+{
+  const std::multiset<std::string> expected(names);
+  return std::any_of(spec.process().action_summands().begin(), spec.process().action_summands().end(),
+    [&expected](const action_summand& as){ return multiaction_names(as.multi_action()) == expected; });
+}
+
+BOOST_AUTO_TEST_CASE(multiple_rename_rules_per_action)
 {
   // Check a renaming when more than one renaming rule
   // for one action is present.
@@ -44,10 +73,10 @@ void test1()
   action_rename_specification ar_spec = parse_action_rename_specification(ar_spec_stream, spec);
   stochastic_specification new_spec = action_rename(ar_spec,spec,data::rewriter(),false);
   BOOST_CHECK(check_well_typedness(new_spec));
-  BOOST_CHECK(new_spec.process().summand_count()==3);
+  BOOST_CHECK_EQUAL(new_spec.process().summand_count(), 3u);
 }
 
-void test2()
+BOOST_AUTO_TEST_CASE(new_declarations_in_rename_spec)
 {
   // Check whether new declarations in the rename file
   // are read properly. Check for renamings of more than one action.
@@ -71,10 +100,10 @@ void test2()
   action_rename_specification ar_spec = parse_action_rename_specification(ar_spec_stream, spec);
   stochastic_specification new_spec = action_rename(ar_spec,spec,data::rewriter(),false);
   BOOST_CHECK(check_well_typedness(new_spec));
-  BOOST_CHECK(new_spec.process().summand_count()==2);
+  BOOST_CHECK_EQUAL(new_spec.process().summand_count(), 2u);
 }
 
-void test3()
+BOOST_AUTO_TEST_CASE(rename_constant_to_delta)
 {
   // Check whether constants in an action_rename file are properly translated.
   const std::string SPEC =
@@ -94,10 +123,10 @@ void test3()
   lps::rewrite(new_spec, R);
   lps::remove_trivial_summands(new_spec);
   BOOST_CHECK(check_well_typedness(new_spec));
-  BOOST_CHECK(new_spec.process().summand_count()==2);
+  BOOST_CHECK_EQUAL(new_spec.process().summand_count(), 2u);
 }
 
-void test4()
+BOOST_AUTO_TEST_CASE(conditional_rename_to_tau)
 {
   const std::string SPEC =
     "sort D = struct d1 | d2;\n"
@@ -122,11 +151,12 @@ void test4()
   lps::rewrite(new_spec, R);
   lps::remove_trivial_summands(new_spec);
   BOOST_CHECK(check_well_typedness(new_spec));
-  BOOST_CHECK(new_spec.process().summand_count()==2);
+  BOOST_CHECK_EQUAL(new_spec.process().summand_count(), 2u);
 }
 
-void test5() // Test whether partial renaming to delta is going well. See bug report #1009.
+BOOST_AUTO_TEST_CASE(partial_rename_to_delta)
 {
+  // Test whether partial renaming to delta is going well. See bug report #1009.
   const std::string SPEC =
     "sort Command = struct com1 | com2;\n"
     "sort State = struct st1 | st2;\n"
@@ -169,11 +199,11 @@ void test5() // Test whether partial renaming to delta is going well. See bug re
   lps::rewrite(new_spec, R);
   lps::remove_trivial_summands(new_spec);
   BOOST_CHECK(check_well_typedness(new_spec));
-  BOOST_CHECK(new_spec.process().summand_count()==8);
+  BOOST_CHECK_EQUAL(new_spec.process().summand_count(), 8u);
 }
 
 // Check whether renaming with a regular expression works well
-static void test_regex1()
+BOOST_AUTO_TEST_CASE(regex_rename)
 {
   const std::string SPEC =
   "act a_out, b_out, cout, ab_out, ac_out;\n"
@@ -184,22 +214,22 @@ static void test_regex1()
   stochastic_specification new_spec = action_rename(std::regex("^([^b]*)_out"), "out_$1", spec);
 
   BOOST_CHECK(check_well_typedness(new_spec));
-  BOOST_CHECK(std::string(new_spec.action_labels().front().name()) == "out_a");
-  BOOST_CHECK(std::string(new_spec.action_labels().tail().front().name()) == "b_out");
-  BOOST_CHECK(std::string(new_spec.action_labels().tail().tail().front().name()) == "cout");
-  BOOST_CHECK(std::string(new_spec.action_labels().tail().tail().tail().front().name()) == "ab_out");
-  BOOST_CHECK(std::string(new_spec.action_labels().tail().tail().tail().tail().front().name()) == "out_ac");
+  BOOST_CHECK_EQUAL(new_spec.action_labels().size(), 5u);
+  BOOST_CHECK( has_action_label(new_spec, "out_a"));
+  BOOST_CHECK( has_action_label(new_spec, "b_out"));
+  BOOST_CHECK( has_action_label(new_spec, "cout"));
+  BOOST_CHECK( has_action_label(new_spec, "ab_out"));
+  BOOST_CHECK( has_action_label(new_spec, "out_ac"));
+  BOOST_CHECK(!has_action_label(new_spec, "a_out"));
+  BOOST_CHECK(!has_action_label(new_spec, "ac_out"));
 
-  BOOST_CHECK(std::any_of(new_spec.process().action_summands().begin(), new_spec.process().action_summands().end(),
-                              [](const action_summand& as){ return lps::pp(as.multi_action()) == "ab_out|out_a"; }));
-  BOOST_CHECK(std::any_of(new_spec.process().action_summands().begin(), new_spec.process().action_summands().end(),
-                              [](const action_summand& as){ return lps::pp(as.multi_action()) == "b_out"; }));
-  BOOST_CHECK(std::any_of(new_spec.process().action_summands().begin(), new_spec.process().action_summands().end(),
-                              [](const action_summand& as){ return lps::pp(as.multi_action()) == "cout"; }));
+  BOOST_CHECK(has_summand_with_multiaction(new_spec, {"ab_out", "out_a"}));
+  BOOST_CHECK(has_summand_with_multiaction(new_spec, {"b_out"}));
+  BOOST_CHECK(has_summand_with_multiaction(new_spec, {"cout"}));
 }
 
 // Check whether renaming some actions to delta works
-void test_regex2()
+BOOST_AUTO_TEST_CASE(regex_rename_to_delta)
 {
   const std::string SPEC =
   "act a_out, b_out, cout, ab_out, ac_out;\n"
@@ -209,18 +239,22 @@ void test_regex2()
   // This should rename a_out, leaving the rest
   stochastic_specification new_spec = action_rename(std::regex("^a_out"), "delta", spec);
 
-  BOOST_CHECK(std::string(new_spec.action_labels().front().name()) == "b_out");
-  BOOST_CHECK(std::string(new_spec.action_labels().tail().front().name()) == "cout");
-  BOOST_CHECK(std::string(new_spec.action_labels().tail().tail().front().name()) == "ab_out");
+  BOOST_CHECK_EQUAL(new_spec.action_labels().size(), 4u);
+  BOOST_CHECK( has_action_label(new_spec, "b_out"));
+  BOOST_CHECK( has_action_label(new_spec, "cout"));
+  BOOST_CHECK( has_action_label(new_spec, "ab_out"));
+  BOOST_CHECK( has_action_label(new_spec, "ac_out"));  // declared but unused; kept since it was not renamed
+  BOOST_CHECK(!has_action_label(new_spec, "a_out"));
 
-  BOOST_CHECK(std::any_of(new_spec.process().action_summands().begin(), new_spec.process().action_summands().end(),
-                              [](const action_summand& as){ return lps::pp(as.multi_action()) == "b_out"; }));
-  BOOST_CHECK(std::any_of(new_spec.process().action_summands().begin(), new_spec.process().action_summands().end(),
-                              [](const action_summand& as){ return lps::pp(as.multi_action()) == "cout"; }));
+  BOOST_CHECK(has_summand_with_multiaction(new_spec, {"b_out"}));
+  BOOST_CHECK(has_summand_with_multiaction(new_spec, {"cout"}));
 
-  BOOST_CHECK(new_spec.process().deadlock_summands().size() == 2);
+  BOOST_CHECK_EQUAL(new_spec.process().deadlock_summands().size(), 2u);
   auto find_result = std::find_if(spec.process().action_summands().begin(), spec.process().action_summands().end(),
-    [](const action_summand& as){ return lps::pp(as.multi_action()) == "a_out|ab_out"; });
+    [](const action_summand& as)
+    {
+      return multiaction_names(as.multi_action()) == std::multiset<std::string>{"a_out", "ab_out"};
+    });
   BOOST_CHECK(find_result != spec.process().action_summands().end());
   if(find_result != spec.process().action_summands().end())
   {
@@ -230,7 +264,7 @@ void test_regex2()
 }
 
 // Check whether renaming some actions to tau works
-void test_regex3()
+BOOST_AUTO_TEST_CASE(regex_rename_to_tau)
 {
   const std::string SPEC =
   "act a_out, b_out, cout, ab_out, ac_out;\n"
@@ -240,21 +274,22 @@ void test_regex3()
   // This should rename a_out and cout, leaving the rest
   stochastic_specification new_spec = action_rename(std::regex("^(a_out|cout)$"), "tau", spec);
 
-  BOOST_CHECK(std::string(new_spec.action_labels().front().name()) == "b_out");
-  BOOST_CHECK(std::string(new_spec.action_labels().tail().front().name()) == "ab_out");
-  BOOST_CHECK(std::string(new_spec.action_labels().tail().tail().front().name()) == "ac_out");
+  BOOST_CHECK_EQUAL(new_spec.action_labels().size(), 3u);
+  BOOST_CHECK( has_action_label(new_spec, "b_out"));
+  BOOST_CHECK( has_action_label(new_spec, "ab_out"));
+  BOOST_CHECK( has_action_label(new_spec, "ac_out"));
+  BOOST_CHECK(!has_action_label(new_spec, "a_out"));
+  BOOST_CHECK(!has_action_label(new_spec, "cout"));
 
-  BOOST_CHECK(std::any_of(new_spec.process().action_summands().begin(), new_spec.process().action_summands().end(),
-                              [](const action_summand& as){ return lps::pp(as.multi_action()) == "ab_out"; }));
-  BOOST_CHECK(std::any_of(new_spec.process().action_summands().begin(), new_spec.process().action_summands().end(),
-                              [](const action_summand& as){ return lps::pp(as.multi_action()) == "b_out"; }));
-  BOOST_CHECK(std::any_of(new_spec.process().action_summands().begin(), new_spec.process().action_summands().end(),
-                              [](const action_summand& as){ return lps::pp(as.multi_action()) == "tau"; }));
+  BOOST_CHECK(has_summand_with_multiaction(new_spec, {"ab_out"}));
+  BOOST_CHECK(has_summand_with_multiaction(new_spec, {"b_out"}));
+  // tau is represented as an empty multi-action (no action names)
+  BOOST_CHECK(has_summand_with_multiaction(new_spec, {}));
 }
 
 // Check whether the list of actions contains no duplicates after renaming multiple actions
 // to one action.
-void test_regex4()
+BOOST_AUTO_TEST_CASE(regex_rename_no_duplicate_labels)
 {
   const std::string SPEC =
   "act a_out, b_out;\n"
@@ -264,8 +299,8 @@ void test_regex4()
   // This should rename both actions to 'out'
   stochastic_specification new_spec = action_rename(std::regex("^(a|b)_out$"), "out", spec);
 
-  BOOST_CHECK(new_spec.action_labels().size() == 1);
-  BOOST_CHECK(std::string(new_spec.action_labels().front().name()) == "out");
+  BOOST_CHECK_EQUAL(new_spec.action_labels().size(), 1u);
+  BOOST_CHECK(has_action_label(new_spec, "out"));
 }
 
 BOOST_AUTO_TEST_CASE(multiple_action_declarations)
@@ -286,19 +321,5 @@ BOOST_AUTO_TEST_CASE(multiple_action_declarations)
   action_rename_specification ar_spec = parse_action_rename_specification(ar_spec_stream, spec);
   stochastic_specification new_spec = action_rename(ar_spec,spec,data::rewriter(),false);
 
-  BOOST_CHECK(new_spec.action_labels().size() == 4);
-}
-
-BOOST_AUTO_TEST_CASE(test_main)
-{
-  test1();
-  test2();
-  test3();
-  test4();
-  test5();
-
-  test_regex1();
-  test_regex2();
-  test_regex3();
-  test_regex4();
+  BOOST_CHECK_EQUAL(new_spec.action_labels().size(), 4u);
 }

--- a/libraries/lps/test/action_rename_test.cpp
+++ b/libraries/lps/test/action_rename_test.cpp
@@ -191,7 +191,7 @@ static void test_regex1()
   BOOST_CHECK(std::string(new_spec.action_labels().tail().tail().tail().tail().front().name()) == "out_ac");
 
   BOOST_CHECK(std::any_of(new_spec.process().action_summands().begin(), new_spec.process().action_summands().end(),
-                              [](const action_summand& as){ return lps::pp(as.multi_action()) == "out_a|ab_out"; }));
+                              [](const action_summand& as){ return lps::pp(as.multi_action()) == "ab_out|out_a"; }));
   BOOST_CHECK(std::any_of(new_spec.process().action_summands().begin(), new_spec.process().action_summands().end(),
                               [](const action_summand& as){ return lps::pp(as.multi_action()) == "b_out"; }));
   BOOST_CHECK(std::any_of(new_spec.process().action_summands().begin(), new_spec.process().action_summands().end(),

--- a/libraries/lps/test/linearise_communication_test.cpp
+++ b/libraries/lps/test/linearise_communication_test.cpp
@@ -59,7 +59,7 @@ void run_test_case(const std::string& multiaction_str, const data::data_specific
   lps::detail::apply_communication_algorithm alg(terminate, R, comm_exprs, allow_set, true, false);
 
   const multi_action multiaction(parse_multi_action(multiaction_str, act_decls, data_spec));
-  const action_list actions = sort_actions(multiaction.actions());
+  const action_list actions = multiaction.actions();
 
   lps::detail::tuple_list result = alg.apply(actions);
   BOOST_CHECK_EQUAL(result.size(), expected_number_of_multiactions);
@@ -135,7 +135,7 @@ action_name_multiset_list allow_set_large()
     "  a54 | a64 | a68, a54 | a64 | a72, a55, a58, a59, a60, a61, a62, a64, a64 | a63, a64 | a63 | a65, a64 | a66 | a67,"
     "  a75, a77, a78, a79, a80, a81, a82, a83, b4, b5 }"
     );
-  return sort_multi_action_labels(process::detail::parse_allow_set(allow_string));
+  return process::detail::parse_allow_set(allow_string);
 }
 
 inline
@@ -156,7 +156,7 @@ communication_expression_list comm_set_large()
     "a72_r | a72_s -> a72, a73_r | a73_s -> a73, a74_r | a74_s -> a74, a75_r | a75_s -> a75, a76_r | a76_s -> a76, a77_r | a77_s -> a77,"
     "a78_r | a78_s -> a78, a79_r | a79_s -> a79, a80_r | a80_s -> a80, a81_r | a81_s -> a81, a82_r | a82_s -> a82, a83_r | a83_s -> a83 }");
 
-  return sort_communications(process::detail::parse_comm_set(comm_string));
+  return process::detail::parse_comm_set(comm_string);
 }
 
 // Show that the number of multiactions in the result can be dramatically reduced
@@ -181,7 +181,7 @@ BOOST_AUTO_TEST_CASE(test_multact_19a)
     "a56_r(d12)|a56_s(d13)|a57_r(d9)|a57_s(d14)|a64_r(d15)|a64_s(d47)|a82_r",
     data_spec_large(),
     action_declarations_large(),
-    sort_multi_action_labels(process::detail::parse_allow_set("{ a1|a4|a5|a9|a11|a13|a56|a57|a64|a82_r }")),
+    process::detail::parse_allow_set("{ a1|a4|a5|a9|a11|a13|a56|a57|a64|a82_r }"),
     comm_set_large(),
     1,
     1
@@ -196,7 +196,7 @@ BOOST_AUTO_TEST_CASE(test_multact_19b)
     "a56_r(d12)|a56_s(d13)|a57_r(d9)|a57_s(d14)|a64_r(d15)|a64_s(d47)|a82_r",
     data_spec_large(),
     action_declarations_large(),
-    sort_multi_action_labels(process::detail::parse_allow_set("{ a1|a4|a5|a9|a11|a13|a56|a57|a64|a82_r, a1|a4_r|a4_s|a5|a9|a11|a13|a56|a57|a64|a82_r }")),
+    process::detail::parse_allow_set("{ a1|a4|a5|a9|a11|a13|a56|a57|a64|a82_r, a1|a4_r|a4_s|a5|a9|a11|a13|a56|a57|a64|a82_r }"),
     comm_set_large(),
     2,
     2
@@ -210,7 +210,7 @@ BOOST_AUTO_TEST_CASE(test_multact_19c)
     "a56_r(d12)|a56_s(d13)|a57_r(d9)|a57_s(d14)|a64_r(d15)|a64_s(d47)|a82_r",
     data_spec_large(),
     action_declarations_large(),
-    sort_multi_action_labels(process::detail::parse_allow_set("{ a1|a4|a5|a9|a11|a13|a56|a57|a64|a82 }")),
+    process::detail::parse_allow_set("{ a1|a4|a5|a9|a11|a13|a56|a57|a64|a82 }"),
     comm_set_large(),
     0,
     0

--- a/libraries/lps/test/linearise_rename_test.cpp
+++ b/libraries/lps/test/linearise_rename_test.cpp
@@ -10,7 +10,6 @@
 /// \brief Test for applying rename operator
 
 #define BOOST_TEST_MODULE linearise_rename_test
-#include <boost/algorithm/string/predicate.hpp>
 #include <boost/test/included/unit_test.hpp>
 
 #include "../../process/include/mcrl2/process/rename_expression.h"
@@ -32,13 +31,13 @@ BOOST_GLOBAL_FIXTURE(LogDebug);
 inline
 process::action make_action(const std::string& name, const data::data_expression_list& arguments = data::data_expression_list())
 {
-  data::sort_expression_list sorts;
-  for(const auto& expression : arguments)
-  {
-    sorts.push_front(expression.sort());
-  }
-  sorts = atermpp::reverse(sorts);
-
+  const data::sort_expression_list sorts(
+    arguments.begin(),
+    arguments.end(),
+    [](const data::data_expression& expression)
+    {
+      return expression.sort();
+    });
   const action_label label(core::identifier_string(name), sorts);
   return process::action(label, arguments);
 }
@@ -46,26 +45,25 @@ process::action make_action(const std::string& name, const data::data_expression
 inline
 rename_expression_list rename_rule_ab()
 {
-  rename_expression_list result;
-  result.push_front(rename_expression("a", "b"));
-  return result;
+  return {rename_expression("a", "b")};
+}
+
+inline
+rename_expression_list rename_rule_ad()
+{
+  return {rename_expression("a", "d")};
 }
 
 inline
 rename_expression_list rename_rule_cd()
 {
-  rename_expression_list result;
-  result.push_front(rename_expression("c", "d"));
-  return result;
+  return {rename_expression("c", "d")};
 }
 
 inline
 rename_expression_list rename_rules_ab_cd()
 {
-  rename_expression_list result;
-  result.push_front(rename_expression("c", "d"));
-  result.push_front(rename_expression("a", "b"));
-  return result;
+  return {rename_expression("a", "b"), rename_expression("c", "d")};
 }
 
 BOOST_AUTO_TEST_CASE(test_rename_action)
@@ -122,6 +120,12 @@ BOOST_AUTO_TEST_CASE(test_rename_action_with_sort)
   BOOST_CHECK_EQUAL(lps::rename(rename_rules_ab_cd(), e), e);
 }
 
+inline
+action_list make_action_list(std::initializer_list<process::action> actions)
+{
+  return action_list(actions.begin(), actions.end());
+}
+
 BOOST_AUTO_TEST_CASE(test_rename_action_list)
 {
   auto a = make_action("a");
@@ -130,34 +134,6 @@ BOOST_AUTO_TEST_CASE(test_rename_action_list)
   auto d = make_action("d");
   auto e = make_action("e");
 
-  action_list ab;
-  ab.push_front(b);
-  ab.push_front(a);
-
-  action_list bb;
-  bb.push_front(b);
-  bb.push_front(b);
-
-  action_list bc;
-  bc.push_front(c);
-  bc.push_front(b);
-
-  action_list bd;
-  bd.push_front(d);
-  bd.push_front(b);
-
-  action_list cd;
-  cd.push_front(d);
-  cd.push_front(c);
-
-  action_list dd;
-  dd.push_front(d);
-  dd.push_front(d);
-
-  action_list de;
-  de.push_front(e);
-  de.push_front(d);
-
   // Rename on action_lists does not guarantee that the result is sorted,
   // so we sort the result before comparing it to the expected result.
   auto rename_and_sort = [](const rename_expression_list& renamings, const action_list& actions)
@@ -165,26 +141,117 @@ BOOST_AUTO_TEST_CASE(test_rename_action_list)
     return atermpp::sort_list(lps::rename(renamings, actions));
   };
 
-  BOOST_CHECK_EQUAL(rename_and_sort(rename_rule_ab(), ab), bb);
-  BOOST_CHECK_EQUAL(rename_and_sort(rename_rule_ab(), bb), bb);
-  BOOST_CHECK_EQUAL(rename_and_sort(rename_rule_ab(), bc), bc);
-  BOOST_CHECK_EQUAL(rename_and_sort(rename_rule_ab(), bd), bd);
-  BOOST_CHECK_EQUAL(rename_and_sort(rename_rule_ab(), cd), cd);
-  BOOST_CHECK_EQUAL(rename_and_sort(rename_rule_ab(), de), de);
+  BOOST_CHECK_EQUAL(rename_and_sort(rename_rule_ab(), make_action_list({a, b})), make_action_list({b, b}));
+  BOOST_CHECK_EQUAL(rename_and_sort(rename_rule_ab(), make_action_list({b, b})), make_action_list({b, b}));
+  BOOST_CHECK_EQUAL(rename_and_sort(rename_rule_ab(), make_action_list({b, c})), make_action_list({b, c}));
+  BOOST_CHECK_EQUAL(rename_and_sort(rename_rule_ab(), make_action_list({b, d})), make_action_list({b, d}));
+  BOOST_CHECK_EQUAL(rename_and_sort(rename_rule_ab(), make_action_list({c, d})), make_action_list({c, d}));
+  BOOST_CHECK_EQUAL(rename_and_sort(rename_rule_ab(), make_action_list({d, e})), make_action_list({d, e}));
 
-  BOOST_CHECK_EQUAL(rename_and_sort(rename_rule_cd(), ab), ab);
-  BOOST_CHECK_EQUAL(rename_and_sort(rename_rule_cd(), bb), bb);
-  BOOST_CHECK_EQUAL(rename_and_sort(rename_rule_cd(), bc), bd);
-  BOOST_CHECK_EQUAL(rename_and_sort(rename_rule_cd(), bd), bd);
-  BOOST_CHECK_EQUAL(rename_and_sort(rename_rule_cd(), cd), dd);
-  BOOST_CHECK_EQUAL(rename_and_sort(rename_rule_cd(), de), de);
+  BOOST_CHECK_EQUAL(rename_and_sort(rename_rule_cd(), make_action_list({a, b})), make_action_list({a, b}));
+  BOOST_CHECK_EQUAL(rename_and_sort(rename_rule_cd(), make_action_list({b, b})), make_action_list({b, b}));
+  BOOST_CHECK_EQUAL(rename_and_sort(rename_rule_cd(), make_action_list({b, c})), make_action_list({b, d}));
+  BOOST_CHECK_EQUAL(rename_and_sort(rename_rule_cd(), make_action_list({b, d})), make_action_list({b, d}));
+  BOOST_CHECK_EQUAL(rename_and_sort(rename_rule_cd(), make_action_list({c, d})), make_action_list({d, d}));
+  BOOST_CHECK_EQUAL(rename_and_sort(rename_rule_cd(), make_action_list({d, e})), make_action_list({d, e}));
 
-  BOOST_CHECK_EQUAL(rename_and_sort(rename_rules_ab_cd(), ab), bb);
-  BOOST_CHECK_EQUAL(rename_and_sort(rename_rules_ab_cd(), bb), bb);
-  BOOST_CHECK_EQUAL(rename_and_sort(rename_rules_ab_cd(), bc), bd);
-  BOOST_CHECK_EQUAL(rename_and_sort(rename_rules_ab_cd(), bd), bd);
-  BOOST_CHECK_EQUAL(rename_and_sort(rename_rules_ab_cd(), cd), dd);
-  BOOST_CHECK_EQUAL(rename_and_sort(rename_rules_ab_cd(), de), de);
+  BOOST_CHECK_EQUAL(rename_and_sort(rename_rules_ab_cd(), make_action_list({a, b})), make_action_list({b, b}));
+  BOOST_CHECK_EQUAL(rename_and_sort(rename_rules_ab_cd(), make_action_list({b, b})), make_action_list({b, b}));
+  BOOST_CHECK_EQUAL(rename_and_sort(rename_rules_ab_cd(), make_action_list({b, c})), make_action_list({b, d}));
+  BOOST_CHECK_EQUAL(rename_and_sort(rename_rules_ab_cd(), make_action_list({b, d})), make_action_list({b, d}));
+  BOOST_CHECK_EQUAL(rename_and_sort(rename_rules_ab_cd(), make_action_list({c, d})), make_action_list({d, d}));
+  BOOST_CHECK_EQUAL(rename_and_sort(rename_rules_ab_cd(), make_action_list({d, e})), make_action_list({d, e}));
 }
 
-// TODO: extend with tests for renaming multiactions, summands and lps.
+inline
+multi_action make_multi_action(std::initializer_list<process::action> actions)
+{
+  process::action_list action_list;
+  for (const auto& a : actions)
+  {
+    action_list.push_front(a);
+  }
+  return multi_action(action_list);
+}
+
+BOOST_AUTO_TEST_CASE(test_rename_multi_action)
+{
+  auto a = make_action("a");
+  auto b = make_action("b");
+  auto c = make_action("c");
+  auto d = make_action("d");
+  auto e = make_action("e");
+
+  // Single-action multi-actions
+  BOOST_CHECK_EQUAL(lps::rename(rename_rule_ab(), make_multi_action({a})), make_multi_action({b}));
+  BOOST_CHECK_EQUAL(lps::rename(rename_rule_ab(), make_multi_action({b})), make_multi_action({b}));
+  BOOST_CHECK_EQUAL(lps::rename(rename_rule_ab(), make_multi_action({e})), make_multi_action({e}));
+  BOOST_CHECK_EQUAL(lps::rename(rename_rule_ad(), make_multi_action({a})), make_multi_action({d}));
+
+  // Multi-action with two actions; the multi_action constructor sorts the result
+  BOOST_CHECK_EQUAL(lps::rename(rename_rule_ab(), make_multi_action({a, c})), make_multi_action({b, c}));
+  BOOST_CHECK_EQUAL(lps::rename(rename_rule_cd(), make_multi_action({a, c})), make_multi_action({a, d}));
+  BOOST_CHECK_EQUAL(lps::rename(rename_rules_ab_cd(), make_multi_action({a, c})), make_multi_action({b, d}));
+  BOOST_CHECK_EQUAL(lps::rename(rename_rule_ad(), make_multi_action({a, b})), make_multi_action({b, d}));
+  BOOST_CHECK_EQUAL(lps::rename(rename_rule_ad(), make_multi_action({a, c})), make_multi_action({c, d}));
+  BOOST_CHECK_EQUAL(lps::rename(rename_rule_ad(), make_multi_action({a, e})), make_multi_action({d, e}));
+  BOOST_CHECK_EQUAL(lps::rename(rename_rule_ad(), make_multi_action({b, c})), make_multi_action({b, c}));
+}
+
+inline
+stochastic_action_summand make_summand(const multi_action& action,
+                                       const data::variable_list& summation_variables = {},
+                                       const data::data_expression& condition = data::sort_bool::true_(),
+                                       const data::assignment_list& assignments = {})
+{
+  return stochastic_action_summand(summation_variables, condition, action, assignments, stochastic_distribution());
+}
+
+BOOST_AUTO_TEST_CASE(test_rename_summand)
+{
+  auto a = make_action("a");
+  auto b = make_action("b");
+  auto c = make_action("c");
+  auto d = make_action("d");
+  auto e = make_action("e");
+
+  // Summand with multi_action {a}: rename a→b gives multi_action {b}
+  auto summand_a = make_summand(make_multi_action({a}));
+  auto renamed_a = lps::rename(rename_rule_ab(), summand_a);
+  BOOST_CHECK_EQUAL(renamed_a.multi_action(), make_multi_action({b}));
+
+  // Other summand fields are unchanged
+  BOOST_CHECK_EQUAL(renamed_a.summation_variables(), summand_a.summation_variables());
+  BOOST_CHECK_EQUAL(renamed_a.condition(), summand_a.condition());
+  BOOST_CHECK_EQUAL(renamed_a.assignments(), summand_a.assignments());
+  BOOST_CHECK_EQUAL(renamed_a.distribution(), summand_a.distribution());
+
+  // Summand with multi_action {a, c}: rename a→b, c→d gives multi_action {b, d}
+  auto summand_ac = make_summand(make_multi_action({a, c}));
+  auto renamed_ac = lps::rename(rename_rules_ab_cd(), summand_ac);
+  BOOST_CHECK_EQUAL(renamed_ac.multi_action(), make_multi_action({b, d}));
+
+  // Summand whose action is not renamed
+  auto summand_e = make_summand(make_multi_action({e}));
+  BOOST_CHECK_EQUAL(lps::rename(rename_rule_ab(), summand_e).multi_action(), make_multi_action({e}));
+}
+
+BOOST_AUTO_TEST_CASE(test_rename_summand_vector)
+{
+  auto a = make_action("a");
+  auto b = make_action("b");
+  auto c = make_action("c");
+  auto d = make_action("d");
+  auto e = make_action("e");
+
+  stochastic_action_summand_vector summands;
+  summands.push_back(make_summand(make_multi_action({a})));
+  summands.push_back(make_summand(make_multi_action({c})));
+  summands.push_back(make_summand(make_multi_action({e})));
+
+  lps::rename(rename_rules_ab_cd(), summands);
+
+  BOOST_CHECK_EQUAL(summands[0].multi_action(), make_multi_action({b}));
+  BOOST_CHECK_EQUAL(summands[1].multi_action(), make_multi_action({d}));
+  BOOST_CHECK_EQUAL(summands[2].multi_action(), make_multi_action({e}));
+}

--- a/libraries/lps/test/linearise_rename_test.cpp
+++ b/libraries/lps/test/linearise_rename_test.cpp
@@ -158,26 +158,33 @@ BOOST_AUTO_TEST_CASE(test_rename_action_list)
   de.push_front(e);
   de.push_front(d);
 
-  BOOST_CHECK_EQUAL(lps::rename(rename_rule_ab(), ab), bb);
-  BOOST_CHECK_EQUAL(lps::rename(rename_rule_ab(), bb), bb);
-  BOOST_CHECK_EQUAL(lps::rename(rename_rule_ab(), bc), bc);
-  BOOST_CHECK_EQUAL(lps::rename(rename_rule_ab(), bd), bd);
-  BOOST_CHECK_EQUAL(lps::rename(rename_rule_ab(), cd), cd);
-  BOOST_CHECK_EQUAL(lps::rename(rename_rule_ab(), de), de);
+  // Rename on action_lists does not guarantee that the result is sorted,
+  // so we sort the result before comparing it to the expected result.
+  auto rename_and_sort = [](const rename_expression_list& renamings, const action_list& actions)
+  {
+    return atermpp::sort_list(lps::rename(renamings, actions));
+  };
 
-  BOOST_CHECK_EQUAL(lps::rename(rename_rule_cd(), ab), ab);
-  BOOST_CHECK_EQUAL(lps::rename(rename_rule_cd(), bb), bb);
-  BOOST_CHECK_EQUAL(lps::rename(rename_rule_cd(), bc), bd);
-  BOOST_CHECK_EQUAL(lps::rename(rename_rule_cd(), bd), bd);
-  BOOST_CHECK_EQUAL(lps::rename(rename_rule_cd(), cd), dd);
-  BOOST_CHECK_EQUAL(lps::rename(rename_rule_cd(), de), de);
+  BOOST_CHECK_EQUAL(rename_and_sort(rename_rule_ab(), ab), bb);
+  BOOST_CHECK_EQUAL(rename_and_sort(rename_rule_ab(), bb), bb);
+  BOOST_CHECK_EQUAL(rename_and_sort(rename_rule_ab(), bc), bc);
+  BOOST_CHECK_EQUAL(rename_and_sort(rename_rule_ab(), bd), bd);
+  BOOST_CHECK_EQUAL(rename_and_sort(rename_rule_ab(), cd), cd);
+  BOOST_CHECK_EQUAL(rename_and_sort(rename_rule_ab(), de), de);
 
-  BOOST_CHECK_EQUAL(lps::rename(rename_rules_ab_cd(), ab), bb);
-  BOOST_CHECK_EQUAL(lps::rename(rename_rules_ab_cd(), bb), bb);
-  BOOST_CHECK_EQUAL(lps::rename(rename_rules_ab_cd(), bc), bd);
-  BOOST_CHECK_EQUAL(lps::rename(rename_rules_ab_cd(), bd), bd);
-  BOOST_CHECK_EQUAL(lps::rename(rename_rules_ab_cd(), cd), dd);
-  BOOST_CHECK_EQUAL(lps::rename(rename_rules_ab_cd(), de), de);
+  BOOST_CHECK_EQUAL(rename_and_sort(rename_rule_cd(), ab), ab);
+  BOOST_CHECK_EQUAL(rename_and_sort(rename_rule_cd(), bb), bb);
+  BOOST_CHECK_EQUAL(rename_and_sort(rename_rule_cd(), bc), bd);
+  BOOST_CHECK_EQUAL(rename_and_sort(rename_rule_cd(), bd), bd);
+  BOOST_CHECK_EQUAL(rename_and_sort(rename_rule_cd(), cd), dd);
+  BOOST_CHECK_EQUAL(rename_and_sort(rename_rule_cd(), de), de);
+
+  BOOST_CHECK_EQUAL(rename_and_sort(rename_rules_ab_cd(), ab), bb);
+  BOOST_CHECK_EQUAL(rename_and_sort(rename_rules_ab_cd(), bb), bb);
+  BOOST_CHECK_EQUAL(rename_and_sort(rename_rules_ab_cd(), bc), bd);
+  BOOST_CHECK_EQUAL(rename_and_sort(rename_rules_ab_cd(), bd), bd);
+  BOOST_CHECK_EQUAL(rename_and_sort(rename_rules_ab_cd(), cd), dd);
+  BOOST_CHECK_EQUAL(rename_and_sort(rename_rules_ab_cd(), de), de);
 }
 
 // TODO: extend with tests for renaming multiactions, summands and lps.

--- a/libraries/lps/test/multi_action_test.cpp
+++ b/libraries/lps/test/multi_action_test.cpp
@@ -114,3 +114,44 @@ BOOST_AUTO_TEST_CASE(test_main)
   test_equal_multi_actions();
   test_pp();
 }
+
+// Invariant: multi_action always stores actions in sorted order.
+
+BOOST_AUTO_TEST_CASE(test_actions_sorted_on_construction)
+{
+  data_expression d1 = nat("d1");
+
+  process::action_label a_label(core::identifier_string("a"), sort_expression_list({ sort_nat::nat() }));
+  process::action_label b_label(core::identifier_string("b"), sort_expression_list({ sort_nat::nat() }));
+
+  process::action a_act(a_label, data_expression_list({ d1 }));
+  process::action b_act(b_label, data_expression_list({ d1 }));
+
+  // Construct with unsorted list (b before a).
+  multi_action ma(process::action_list({ b_act, a_act }));
+
+  // After construction the stored order must be sorted (a before b).
+  process::action_list expected({ a_act, b_act });
+  BOOST_CHECK_EQUAL(ma.actions(), expected);
+}
+
+BOOST_AUTO_TEST_CASE(test_hash_consistent_with_equality)
+{
+  data_expression d1 = nat("d1");
+
+  process::action_label a_label(core::identifier_string("a"), sort_expression_list({ sort_nat::nat() }));
+  process::action_label b_label(core::identifier_string("b"), sort_expression_list({ sort_nat::nat() }));
+
+  process::action a_act(a_label, data_expression_list({ d1 }));
+  process::action b_act(b_label, data_expression_list({ d1 }));
+
+  multi_action ma_ab(process::action_list({ a_act, b_act }));
+  multi_action ma_ba(process::action_list({ b_act, a_act }));
+
+  // Both must be equal since they contain the same actions.
+  BOOST_CHECK(ma_ab == ma_ba);
+
+  // Hash must be equal too (required for use in unordered containers).
+  std::hash<multi_action> hasher;
+  BOOST_CHECK_EQUAL(hasher(ma_ab), hasher(ma_ba));
+}

--- a/libraries/lps/test/multi_action_test.cpp
+++ b/libraries/lps/test/multi_action_test.cpp
@@ -155,3 +155,28 @@ BOOST_AUTO_TEST_CASE(test_hash_consistent_with_equality)
   std::hash<multi_action> hasher;
   BOOST_CHECK_EQUAL(hasher(ma_ab), hasher(ma_ba));
 }
+
+// Regression test: make_multi_action (used by builder.h) calls make_term_appl
+// directly and bypasses the sorting constructor.  Without a fix, the stored
+// action list is unsorted, breaking the class invariant.
+BOOST_AUTO_TEST_CASE(test_make_multi_action_preserves_sorted_invariant)
+{
+  data_expression d1 = nat("d1");
+
+  // b > a, so [b, a] is intentionally unsorted.
+  process::action b_act = act("b", data_expression_list({ d1 }));
+  process::action a_act = act("a", data_expression_list({ d1 }));
+  process::action_list unsorted({ b_act, a_act });
+  BOOST_REQUIRE(!std::is_sorted(unsorted.begin(), unsorted.end()));
+
+  // Replicate what builder.h does: call make_multi_action with the action list
+  // directly (not through the sorting constructor).
+  atermpp::aterm t;
+  make_multi_action(t, unsorted, data::undefined_real());
+
+  const multi_action& ma = atermpp::down_cast<multi_action>(t);
+  BOOST_CHECK_MESSAGE(std::is_sorted(ma.actions().begin(), ma.actions().end()),
+      "make_multi_action must maintain the sorted-storage invariant");
+  process::action_list expected({ a_act, b_act });
+  BOOST_CHECK_EQUAL(ma.actions(), expected);
+}

--- a/libraries/lts/include/mcrl2/lts/lts_builder.h
+++ b/libraries/lts/include/mcrl2/lts/lts_builder.h
@@ -40,11 +40,10 @@ struct lts_builder
 
   std::size_t add_action(const lps::multi_action& a)
   {
-    lps::multi_action sorted_multi_action(a.sort_actions());
-    auto i = m_actions.find(sorted_multi_action);
+    auto i = m_actions.find(a);
     if (i == m_actions.end())
     {
-      i = m_actions.emplace(std::make_pair(sorted_multi_action, m_actions.size())).first;
+      i = m_actions.emplace(std::make_pair(a, m_actions.size())).first;
     }
     return i->second;
   }

--- a/libraries/lts/include/mcrl2/lts/lts_lts.h
+++ b/libraries/lts/include/mcrl2/lts/lts_lts.h
@@ -153,7 +153,7 @@ class action_label_lts: public mcrl2::lps::multi_action
 
     /** \brief Constructor. */
     explicit action_label_lts(const mcrl2::lps::multi_action& a)
-     : mcrl2::lps::multi_action(sort_multiactions(a))
+     : mcrl2::lps::multi_action(a)
     {
     }
 
@@ -182,17 +182,6 @@ class action_label_lts: public mcrl2::lps::multi_action
       return tau_action;
     }
 
-  protected:
-    /// A function to sort a multi action to guarantee that multi-actions are compared properly. 
-    static mcrl2::lps::multi_action sort_multiactions(const mcrl2::lps::multi_action& a)
-    {
-      if (a.actions().size()<=1)
-      {
-        return a;
-      }
-      std::multiset<process::action> sorted_actions(a.actions().begin(), a.actions().end());
-      return  mcrl2::lps::multi_action(process::action_list(sorted_actions.begin(),sorted_actions.end()),a.time());
-    }
 };
 
 /** \brief Print the action label to string. */

--- a/libraries/process/include/mcrl2/process/action_label.h
+++ b/libraries/process/include/mcrl2/process/action_label.h
@@ -130,16 +130,6 @@ inline bool operator<(const action_label& a1, const action_label& a2)
   return s1 < s2 || (s1 == s2 && a1.sorts() < a2.sorts());
 }
 
-/// Determine if a1 < a2; the key requirement is that orderings of action labels and the actions in multiactions are
-/// consistent.
-struct action_label_compare
-{
-  bool operator()(const process::action_label& a1, const process::action_label& a2) const
-  {
-    return a1 < a2;
-  }
-};
-
 } // namespace mcrl2::process
 
 

--- a/libraries/process/include/mcrl2/process/action_label.h
+++ b/libraries/process/include/mcrl2/process/action_label.h
@@ -122,17 +122,21 @@ struct action_name_compare
   }
 };
 
+/// Total ordering on action labels: name first (string order), then sorts.
+inline bool operator<(const action_label& a1, const action_label& a2)
+{
+  const std::string& s1 = a1.name();
+  const std::string& s2 = a2.name();
+  return s1 < s2 || (s1 == s2 && a1.sorts() < a2.sorts());
+}
+
 /// Determine if a1 < a2; the key requirement is that orderings of action labels and the actions in multiactions are
 /// consistent.
 struct action_label_compare
 {
   bool operator()(const process::action_label& a1, const process::action_label& a2) const
   {
-    /* first compare the strings in the actions */
-    const core::identifier_string& a1_name = a1.name();
-    const core::identifier_string& a2_name = a2.name();
-
-    return action_name_compare()(a1_name, a2_name) || (a1_name == a2_name && a1.sorts() < a2.sorts());
+    return a1 < a2;
   }
 };
 

--- a/libraries/process/include/mcrl2/process/action_name_multiset.h
+++ b/libraries/process/include/mcrl2/process/action_name_multiset.h
@@ -63,6 +63,8 @@ template <class... ARGUMENTS>
 inline void make_action_name_multiset(atermpp::aterm& t, const ARGUMENTS&... args)
 {
   atermpp::make_term_appl(t, core::detail::function_symbol_MultActName(), args...);
+  // Re-assign through the sorting constructor to maintain the sorted-storage invariant.
+  t = action_name_multiset(atermpp::down_cast<action_name_multiset>(t).names());
 }
 
 /// \\brief list of action_name_multisets

--- a/libraries/process/include/mcrl2/process/action_name_multiset.h
+++ b/libraries/process/include/mcrl2/process/action_name_multiset.h
@@ -12,7 +12,8 @@
 #ifndef MCRL2_PROCESS_ACTION_NAME_MULTISET_H
 #define MCRL2_PROCESS_ACTION_NAME_MULTISET_H
 
-#include "mcrl2/data/data_specification.h"
+#include "mcrl2/atermpp/aterm_list.h"
+#include "mcrl2/process/action_label.h"
 
 namespace mcrl2::process
 {
@@ -22,23 +23,7 @@ namespace mcrl2::process
 class action_name_multiset: public atermpp::aterm
 {
   public:
-    /// \\brief Default constructor X3.
-    action_name_multiset()
-      : atermpp::aterm(core::detail::default_values::MultActName)
-    {}
 
-    /// \\brief Constructor Z9.
-    /// \\param term A term
-    explicit action_name_multiset(const atermpp::aterm& term)
-      : atermpp::aterm(term)
-    {
-      assert(core::detail::check_term_MultActName(*this));
-    }
-
-    /// \\brief Constructor Z12.
-    explicit action_name_multiset(const core::identifier_string_list& names)
-      : atermpp::aterm(core::detail::function_symbol_MultActName(), names)
-    {}
 
     /// Move semantics
     action_name_multiset(const action_name_multiset&) noexcept = default;
@@ -50,6 +35,26 @@ class action_name_multiset: public atermpp::aterm
     {
       return atermpp::down_cast<core::identifier_string_list>((*this)[0]);
     }
+//--- start user section action_name_multiset ---//
+    /// \brief Default constructor.
+    action_name_multiset()
+      : atermpp::aterm(core::detail::default_values::MultActName)
+    {}
+
+    /// \brief Constructor from aterm.
+    /// \param term A term
+    explicit action_name_multiset(const atermpp::aterm& term)
+      : atermpp::aterm(term)
+    {
+      assert(core::detail::check_term_MultActName(*this));
+    }
+
+    /// \brief Constructor. Names are sorted lexicographically to establish the sorted-storage invariant.
+    explicit action_name_multiset(const core::identifier_string_list& names)
+      : atermpp::aterm(core::detail::function_symbol_MultActName(),
+                       atermpp::sort_list(names, action_name_compare()))
+    {}
+//--- end user section action_name_multiset ---//
 };
 
 /// \\brief Make_action_name_multiset constructs a new term into a given address.

--- a/libraries/process/include/mcrl2/process/process_expression.h
+++ b/libraries/process/include/mcrl2/process/process_expression.h
@@ -597,6 +597,9 @@ template <class... ARGUMENTS>
 inline void make_block(atermpp::aterm& t, const ARGUMENTS&... args)
 {
   atermpp::make_term_appl(t, core::detail::function_symbol_Block(), args...);
+  // Re-assign through the sorting constructor to maintain the sorted-storage invariant.
+  t = block(atermpp::down_cast<block>(t).block_set(),
+             atermpp::down_cast<block>(t).operand());
 }
 
 /// \\brief Test for a block expression

--- a/libraries/process/include/mcrl2/process/process_expression.h
+++ b/libraries/process/include/mcrl2/process/process_expression.h
@@ -12,6 +12,7 @@
 #ifndef MCRL2_PROCESS_PROCESS_EXPRESSION_H
 #define MCRL2_PROCESS_PROCESS_EXPRESSION_H
 
+#include "mcrl2/atermpp/aterm_list.h"
 #include "mcrl2/data/assignment.h"
 #include "mcrl2/data/untyped_data_parameter.h"
 #include "mcrl2/process/action_label.h"
@@ -553,23 +554,7 @@ inline void swap(sum& t1, sum& t2) noexcept
 class block: public process_expression
 {
   public:
-    /// \\brief Default constructor X3.
-    block()
-      : process_expression(core::detail::default_values::Block)
-    {}
 
-    /// \\brief Constructor Z9.
-    /// \\param term A term
-    explicit block(const atermpp::aterm& term)
-      : process_expression(term)
-    {
-      assert(core::detail::check_term_Block(*this));
-    }
-
-    /// \\brief Constructor Z14.
-    block(const core::identifier_string_list& block_set, const process_expression& operand)
-      : process_expression(atermpp::aterm(core::detail::function_symbol_Block(), block_set, operand))
-    {}
 
     /// Move semantics
     block(const block&) noexcept = default;
@@ -586,6 +571,24 @@ class block: public process_expression
     {
       return atermpp::down_cast<process_expression>((*this)[1]);
     }
+//--- start user section block ---//
+    block()
+      : process_expression(core::detail::default_values::Block)
+    {}
+
+    explicit block(const atermpp::aterm& term)
+      : process_expression(term)
+    {
+      assert(core::detail::check_term_Block(*this));
+    }
+
+    /// \brief Constructor. block_set is sorted lexicographically to establish the sorted-storage invariant.
+    block(const core::identifier_string_list& block_set, const process_expression& operand)
+      : process_expression(atermpp::aterm(core::detail::function_symbol_Block(),
+                                         atermpp::sort_list(block_set, action_name_compare()),
+                                         operand))
+    {}
+//--- end user section block ---//
 };
 
 /// \\brief Make_block constructs a new term into a given address.

--- a/libraries/process/include/mcrl2/process/process_expression.h
+++ b/libraries/process/include/mcrl2/process/process_expression.h
@@ -174,7 +174,7 @@ class action: public process_expression
 };
 
 /// \\brief Make_action constructs a new term into a given address.
-/// \\ \param t The reference into which the new action is constructed. 
+/// \\ \param t The reference into which the new action is constructed.
 template <class... ARGUMENTS>
 inline void make_action(atermpp::aterm& t, const ARGUMENTS&... args)
 {
@@ -256,7 +256,7 @@ class process_instance: public process_expression
 };
 
 /// \\brief Make_process_instance constructs a new term into a given address.
-/// \\ \param t The reference into which the new process_instance is constructed. 
+/// \\ \param t The reference into which the new process_instance is constructed.
 template <class... ARGUMENTS>
 inline void make_process_instance(atermpp::aterm& t, const ARGUMENTS&... args)
 {
@@ -332,7 +332,7 @@ class process_instance_assignment: public process_expression
 };
 
 /// \\brief Make_process_instance_assignment constructs a new term into a given address.
-/// \\ \param t The reference into which the new process_instance_assignment is constructed. 
+/// \\ \param t The reference into which the new process_instance_assignment is constructed.
 template <class... ARGUMENTS>
 inline void make_process_instance_assignment(atermpp::aterm& t, const ARGUMENTS&... args)
 {
@@ -514,7 +514,7 @@ class sum: public process_expression
 };
 
 /// \\brief Make_sum constructs a new term into a given address.
-/// \\ \param t The reference into which the new sum is constructed. 
+/// \\ \param t The reference into which the new sum is constructed.
 template <class... ARGUMENTS>
 inline void make_sum(atermpp::aterm& t, const ARGUMENTS&... args)
 {
@@ -592,7 +592,7 @@ class block: public process_expression
 };
 
 /// \\brief Make_block constructs a new term into a given address.
-/// \\ \param t The reference into which the new block is constructed. 
+/// \\ \param t The reference into which the new block is constructed.
 template <class... ARGUMENTS>
 inline void make_block(atermpp::aterm& t, const ARGUMENTS&... args)
 {
@@ -668,7 +668,7 @@ class hide: public process_expression
 };
 
 /// \\brief Make_hide constructs a new term into a given address.
-/// \\ \param t The reference into which the new hide is constructed. 
+/// \\ \param t The reference into which the new hide is constructed.
 template <class... ARGUMENTS>
 inline void make_hide(atermpp::aterm& t, const ARGUMENTS&... args)
 {
@@ -744,7 +744,7 @@ class rename: public process_expression
 };
 
 /// \\brief Make_rename constructs a new term into a given address.
-/// \\ \param t The reference into which the new rename is constructed. 
+/// \\ \param t The reference into which the new rename is constructed.
 template <class... ARGUMENTS>
 inline void make_rename(atermpp::aterm& t, const ARGUMENTS&... args)
 {
@@ -820,7 +820,7 @@ class comm: public process_expression
 };
 
 /// \\brief Make_comm constructs a new term into a given address.
-/// \\ \param t The reference into which the new comm is constructed. 
+/// \\ \param t The reference into which the new comm is constructed.
 template <class... ARGUMENTS>
 inline void make_comm(atermpp::aterm& t, const ARGUMENTS&... args)
 {
@@ -896,7 +896,7 @@ class allow: public process_expression
 };
 
 /// \\brief Make_allow constructs a new term into a given address.
-/// \\ \param t The reference into which the new allow is constructed. 
+/// \\ \param t The reference into which the new allow is constructed.
 template <class... ARGUMENTS>
 inline void make_allow(atermpp::aterm& t, const ARGUMENTS&... args)
 {
@@ -972,7 +972,7 @@ class sync: public process_expression
 };
 
 /// \\brief Make_sync constructs a new term into a given address.
-/// \\ \param t The reference into which the new sync is constructed. 
+/// \\ \param t The reference into which the new sync is constructed.
 template <class... ARGUMENTS>
 inline void make_sync(atermpp::aterm& t, const ARGUMENTS&... args)
 {
@@ -1048,7 +1048,7 @@ class at: public process_expression
 };
 
 /// \\brief Make_at constructs a new term into a given address.
-/// \\ \param t The reference into which the new at is constructed. 
+/// \\ \param t The reference into which the new at is constructed.
 template <class... ARGUMENTS>
 inline void make_at(atermpp::aterm& t, const ARGUMENTS&... args)
 {
@@ -1124,7 +1124,7 @@ class seq: public process_expression
 };
 
 /// \\brief Make_seq constructs a new term into a given address.
-/// \\ \param t The reference into which the new seq is constructed. 
+/// \\ \param t The reference into which the new seq is constructed.
 template <class... ARGUMENTS>
 inline void make_seq(atermpp::aterm& t, const ARGUMENTS&... args)
 {
@@ -1200,7 +1200,7 @@ class if_then: public process_expression
 };
 
 /// \\brief Make_if_then constructs a new term into a given address.
-/// \\ \param t The reference into which the new if_then is constructed. 
+/// \\ \param t The reference into which the new if_then is constructed.
 template <class... ARGUMENTS>
 inline void make_if_then(atermpp::aterm& t, const ARGUMENTS&... args)
 {
@@ -1281,7 +1281,7 @@ class if_then_else: public process_expression
 };
 
 /// \\brief Make_if_then_else constructs a new term into a given address.
-/// \\ \param t The reference into which the new if_then_else is constructed. 
+/// \\ \param t The reference into which the new if_then_else is constructed.
 template <class... ARGUMENTS>
 inline void make_if_then_else(atermpp::aterm& t, const ARGUMENTS&... args)
 {
@@ -1357,7 +1357,7 @@ class bounded_init: public process_expression
 };
 
 /// \\brief Make_bounded_init constructs a new term into a given address.
-/// \\ \param t The reference into which the new bounded_init is constructed. 
+/// \\ \param t The reference into which the new bounded_init is constructed.
 template <class... ARGUMENTS>
 inline void make_bounded_init(atermpp::aterm& t, const ARGUMENTS&... args)
 {
@@ -1433,7 +1433,7 @@ class merge: public process_expression
 };
 
 /// \\brief Make_merge constructs a new term into a given address.
-/// \\ \param t The reference into which the new merge is constructed. 
+/// \\ \param t The reference into which the new merge is constructed.
 template <class... ARGUMENTS>
 inline void make_merge(atermpp::aterm& t, const ARGUMENTS&... args)
 {
@@ -1509,7 +1509,7 @@ class left_merge: public process_expression
 };
 
 /// \\brief Make_left_merge constructs a new term into a given address.
-/// \\ \param t The reference into which the new left_merge is constructed. 
+/// \\ \param t The reference into which the new left_merge is constructed.
 template <class... ARGUMENTS>
 inline void make_left_merge(atermpp::aterm& t, const ARGUMENTS&... args)
 {
@@ -1585,7 +1585,7 @@ class choice: public process_expression
 };
 
 /// \\brief Make_choice constructs a new term into a given address.
-/// \\ \param t The reference into which the new choice is constructed. 
+/// \\ \param t The reference into which the new choice is constructed.
 template <class... ARGUMENTS>
 inline void make_choice(atermpp::aterm& t, const ARGUMENTS&... args)
 {
@@ -1666,7 +1666,7 @@ class stochastic_operator: public process_expression
 };
 
 /// \\brief Make_stochastic_operator constructs a new term into a given address.
-/// \\ \param t The reference into which the new stochastic_operator is constructed. 
+/// \\ \param t The reference into which the new stochastic_operator is constructed.
 template <class... ARGUMENTS>
 inline void make_stochastic_operator(atermpp::aterm& t, const ARGUMENTS&... args)
 {
@@ -1747,7 +1747,7 @@ class untyped_process_assignment: public process_expression
 };
 
 /// \\brief Make_untyped_process_assignment constructs a new term into a given address.
-/// \\ \param t The reference into which the new untyped_process_assignment is constructed. 
+/// \\ \param t The reference into which the new untyped_process_assignment is constructed.
 template <class... ARGUMENTS>
 inline void make_untyped_process_assignment(atermpp::aterm& t, const ARGUMENTS&... args)
 {
@@ -1819,21 +1819,29 @@ bool equal_signatures(const action& a, const action& b)
   return std::equal(a_args.begin(), a_args.end(), b_args.begin(), [](const data::data_expression& x, const data::data_expression& y) { return x.sort() == y.sort(); });
 }
 
+/// Total ordering on actions: label first, then arguments.
+/// The label ordering uses action_label_compare (name, then sorts).
+/// Including arguments makes this a proper total order.
+///
+/// Note that the sort order must be consistent with that on
+/// action labels, e.g. for efficient application of process
+/// operators such as allow and comm.
+inline bool operator<(const action& a1, const action& a2)
+{
+  const action_label& l1 = a1.label();
+  const action_label& l2 = a2.label();
+  return l1 < l2 || (l1 == l2 && a1.arguments() < a2.arguments());
+}
+
 /// Determine if a1 < a2; the key requirement is that orderings of action labels and the actions in multiactions are
 /// consistent.
-///
-/// \returns true iff the label of a1 is less than the label of a2.
-/// The arguments are ignored in this comparison.
 /// The sort order is used for efficient application of process operators such as allow and comm
-/// which are defined in terms of  action names.
+/// which are defined in terms of action names.
 struct action_compare
 {
   bool operator()(const process::action& a1, const process::action& a2) const
   {
-    const process::action_label& a1_label = a1.label();
-    const process::action_label& a2_label = a2.label();
-
-    return action_label_compare()(a1_label, a2_label);
+    return a1 < a2;
   }
 };
 

--- a/libraries/process/include/mcrl2/process/process_expression.h
+++ b/libraries/process/include/mcrl2/process/process_expression.h
@@ -1820,7 +1820,7 @@ bool equal_signatures(const action& a, const action& b)
 }
 
 /// Total ordering on actions: label first, then arguments.
-/// The label ordering uses action_label_compare (name, then sorts).
+/// Consistent with the ordering on action labels (name, then sorts).
 /// Including arguments makes this a proper total order.
 ///
 /// Note that the sort order must be consistent with that on
@@ -1832,18 +1832,6 @@ inline bool operator<(const action& a1, const action& a2)
   const action_label& l2 = a2.label();
   return l1 < l2 || (l1 == l2 && a1.arguments() < a2.arguments());
 }
-
-/// Determine if a1 < a2; the key requirement is that orderings of action labels and the actions in multiactions are
-/// consistent.
-/// The sort order is used for efficient application of process operators such as allow and comm
-/// which are defined in terms of action names.
-struct action_compare
-{
-  bool operator()(const process::action& a1, const process::action& a2) const
-  {
-    return a1 < a2;
-  }
-};
 
 } // namespace mcrl2::process
 

--- a/libraries/process/test/action_name_multiset_test.cpp
+++ b/libraries/process/test/action_name_multiset_test.cpp
@@ -93,3 +93,42 @@ BOOST_AUTO_TEST_CASE(test_block_unsorted_input_stored_sorted)
   core::identifier_string_list expected = make_id_list({"a", "b", "c"});
   BOOST_CHECK_EQUAL(b.block_set(), expected);
 }
+
+// Regression tests: the make_* factory functions (used by builder.h) call
+// make_term_appl directly and bypass the sorting constructor.  This can break
+// the class invariant if the input is unsorted.
+BOOST_AUTO_TEST_CASE(test_make_action_name_multiset_preserves_sorted_invariant)
+{
+  // Pass an intentionally unsorted list directly to the factory.
+  core::identifier_string_list unsorted = make_id_list({"c", "a", "b"});
+  BOOST_REQUIRE(!std::is_sorted(unsorted.begin(), unsorted.end(),
+                                process::action_name_compare()));
+
+  atermpp::aterm t;
+  process::make_action_name_multiset(t, unsorted);
+
+  const process::action_name_multiset& ms =
+      atermpp::down_cast<process::action_name_multiset>(t);
+  BOOST_CHECK_MESSAGE(
+      std::is_sorted(ms.names().begin(), ms.names().end(),
+                     process::action_name_compare()),
+      "make_action_name_multiset must maintain the sorted-storage invariant");
+  BOOST_CHECK_EQUAL(ms.names(), make_id_list({"a", "b", "c"}));
+}
+
+BOOST_AUTO_TEST_CASE(test_make_block_preserves_sorted_invariant)
+{
+  core::identifier_string_list unsorted = make_id_list({"c", "a", "b"});
+  BOOST_REQUIRE(!std::is_sorted(unsorted.begin(), unsorted.end(),
+                                process::action_name_compare()));
+
+  atermpp::aterm t;
+  process::make_block(t, unsorted, process::delta());
+
+  const process::block& b = atermpp::down_cast<process::block>(t);
+  BOOST_CHECK_MESSAGE(
+      std::is_sorted(b.block_set().begin(), b.block_set().end(),
+                     process::action_name_compare()),
+      "make_block must maintain the sorted-storage invariant");
+  BOOST_CHECK_EQUAL(b.block_set(), make_id_list({"a", "b", "c"}));
+}

--- a/libraries/process/test/action_name_multiset_test.cpp
+++ b/libraries/process/test/action_name_multiset_test.cpp
@@ -1,0 +1,95 @@
+// Author(s): Jeroen Keiren
+// Copyright: see the accompanying file COPYING or copy at
+// https://github.com/mCRL2org/mCRL2/blob/master/COPYING
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+/// \file action_name_multiset_test.cpp
+/// \brief Tests for the sorted-storage invariant of action_name_multiset and block.
+
+#define BOOST_TEST_MODULE action_name_multiset_test
+#include <boost/test/included/unit_test.hpp>
+
+#include "mcrl2/process/action_name_multiset.h"
+#include "mcrl2/process/process_expression.h"
+
+using namespace mcrl2;
+
+// Helper to make a core::identifier_string_list from initializer list of strings.
+static core::identifier_string_list make_id_list(std::initializer_list<const char*> names)
+{
+  std::vector<core::identifier_string> v;
+  for (const char* s : names)
+  {
+    v.emplace_back(s);
+  }
+  return core::identifier_string_list(v.begin(), v.end());
+}
+
+// Invariant: action_name_multiset always stores names in sorted (lexicographic) order.
+
+BOOST_AUTO_TEST_CASE(test_empty)
+{
+  process::action_name_multiset ms(make_id_list({}));
+  BOOST_CHECK(ms.names().empty());
+}
+
+BOOST_AUTO_TEST_CASE(test_singleton)
+{
+  process::action_name_multiset ms(make_id_list({"a"}));
+  core::identifier_string_list expected = make_id_list({"a"});
+  BOOST_CHECK_EQUAL(ms.names(), expected);
+}
+
+BOOST_AUTO_TEST_CASE(test_already_sorted)
+{
+  process::action_name_multiset ms(make_id_list({"a", "b", "c"}));
+  core::identifier_string_list expected = make_id_list({"a", "b", "c"});
+  BOOST_CHECK_EQUAL(ms.names(), expected);
+}
+
+BOOST_AUTO_TEST_CASE(test_unsorted_input_stored_sorted)
+{
+  process::action_name_multiset ms(make_id_list({"c", "a", "b"}));
+  core::identifier_string_list expected = make_id_list({"a", "b", "c"});
+  BOOST_CHECK_EQUAL(ms.names(), expected);
+}
+
+BOOST_AUTO_TEST_CASE(test_reverse_sorted_input)
+{
+  process::action_name_multiset ms(make_id_list({"z", "m", "a"}));
+  core::identifier_string_list expected = make_id_list({"a", "m", "z"});
+  BOOST_CHECK_EQUAL(ms.names(), expected);
+}
+
+BOOST_AUTO_TEST_CASE(test_with_duplicates)
+{
+  // Multisets may contain duplicates; sorting should still work.
+  process::action_name_multiset ms(make_id_list({"b", "a", "b", "a"}));
+  core::identifier_string_list expected = make_id_list({"a", "a", "b", "b"});
+  BOOST_CHECK_EQUAL(ms.names(), expected);
+}
+
+// Invariant: block always stores block_set in sorted (lexicographic) order.
+
+BOOST_AUTO_TEST_CASE(test_block_empty)
+{
+  process::block b(make_id_list({}), process::delta());
+  BOOST_CHECK(b.block_set().empty());
+}
+
+BOOST_AUTO_TEST_CASE(test_block_singleton)
+{
+  process::block b(make_id_list({"a"}), process::delta());
+  core::identifier_string_list expected = make_id_list({"a"});
+  BOOST_CHECK_EQUAL(b.block_set(), expected);
+}
+
+BOOST_AUTO_TEST_CASE(test_block_unsorted_input_stored_sorted)
+{
+  process::block b(make_id_list({"c", "a", "b"}), process::delta());
+  core::identifier_string_list expected = make_id_list({"a", "b", "c"});
+  BOOST_CHECK_EQUAL(b.block_set(), expected);
+}

--- a/scripts/code_generation/mcrl2_classes.py
+++ b/scripts/code_generation/mcrl2_classes.py
@@ -178,7 +178,7 @@ process_identifier(const core::identifier_string& name, const data::variable_lis
 process_equation(const process_identifier& identifier, const data::variable_list& formal_parameters, const process_expression& expression)                                       : public atermpp::aterm | CI   | ProcEqn            | A process equation
 rename_expression(core::identifier_string& source, core::identifier_string& target)                                                                                              : public atermpp::aterm | CI   | RenameExpr         | A rename expression
 communication_expression(const action_name_multiset& action_name, const core::identifier_string& name)                                                                           : public atermpp::aterm | CI   | CommExpr           | A communication expression
-action_name_multiset(const core::identifier_string_list& names)                                                                                                                  : public atermpp::aterm | CI   | MultActName        | A multiset of action names
+action_name_multiset(const core::identifier_string_list& names)                                                                                                                  : public atermpp::aterm | CIUs | MultActName        | A multiset of action names
 untyped_multi_action(const data::untyped_data_parameter_list& actions)                                                                                                           : public atermpp::aterm | CI   | UntypedMultiAction | An untyped multi action or data application
 '''
 
@@ -190,7 +190,7 @@ process_instance_assignment(const process_identifier& identifier, const data::as
 delta()                                                                                                                                 : public process::process_expression | EI  | Delta                    | The value delta
 tau()                                                                                                                                   : public process::process_expression | EI  | Tau                      | The value tau
 sum(const data::variable_list& variables, const process_expression& operand)                                                            : public process::process_expression | EI  | Sum                      | The sum operator
-block(const core::identifier_string_list& block_set, const process_expression& operand)                                                 : public process::process_expression | EI  | Block                    | The block operator
+block(const core::identifier_string_list& block_set, const process_expression& operand)                                                 : public process::process_expression | EIUs | Block                    | The block operator
 hide(const core::identifier_string_list& hide_set, const process_expression& operand)                                                   : public process::process_expression | EI  | Hide                     | The hide operator
 rename(const rename_expression_list& rename_set, const process_expression& operand)                                                     : public process::process_expression | EI  | Rename                   | The rename operator
 comm(const communication_expression_list& comm_set, const process_expression& operand)                                                  : public process::process_expression | EI  | Comm                     | The communication operator

--- a/tools/experimental/ltscombine/lts_combine.cpp
+++ b/tools/experimental/ltscombine/lts_combine.cpp
@@ -195,8 +195,8 @@ lps::multi_action mcrl2::apply_communication(const lps::multi_action& label,
   }
 
   remaining_actions.insert(remaining_actions.end(), communicated_actions.begin(), communicated_actions.end());
-  std::sort(remaining_actions.begin(), remaining_actions.end(), process::action_compare());
 
+  // multi_action constructor sorts the action list, so no explicit sort needed here.
   return lps::multi_action(process::action_list(remaining_actions.begin(), remaining_actions.end()), label.time());
 }
 
@@ -506,8 +506,8 @@ private:
     auto filter_and_report = [this, state_index, &termination_action](const lps::multi_action& candidate_label,
                                                    const std::vector<state_t>& target_state)
     {
-      std::function<bool(const process::action&, const process::action&)> action_compare = process::action_compare();
-      lps::multi_action label(atermpp::sort_list(candidate_label.actions(), action_compare), candidate_label.time());
+      // candidate_label is a multi_action, so its actions are already sorted.
+      lps::multi_action label = candidate_label;
 
       mCRL2log(log::debug) << lps::pp(label) << std::endl;
 

--- a/tools/experimental/ltscombine/lts_combine.cpp
+++ b/tools/experimental/ltscombine/lts_combine.cpp
@@ -56,7 +56,7 @@ bool match_sorted_lhs(const std::vector<process::action>& actions,
                       const data::data_expression_list& arguments,
                       std::vector<std::size_t>& indices)
 {
-  assert(std::is_sorted(actions.begin(), actions.end(), process::action_compare()));
+  assert(std::is_sorted(actions.begin(), actions.end()));
   assert(std::is_sorted(lhs_names.begin(), lhs_names.end(), process::action_name_compare()));
   assert(!lhs_names.empty());
 
@@ -104,7 +104,7 @@ bool find_matching_indices(const std::vector<process::action>& actions,
                            const core::identifier_string_list& lhs_names,
                            std::vector<std::size_t>& indices)
 {
-  assert(std::is_sorted(actions.begin(), actions.end(), process::action_compare()));
+  assert(std::is_sorted(actions.begin(), actions.end()));
   assert(std::is_sorted(lhs_names.begin(), lhs_names.end(), process::action_name_compare()));
   assert(!lhs_names.empty());
 
@@ -165,7 +165,7 @@ void erase_indices(std::vector<process::action>& actions,
 lps::multi_action mcrl2::apply_communication(const lps::multi_action& label,
                                              const process::communication_expression_list& comm_set)
 {
-  assert(std::is_sorted(label.actions().begin(), label.actions().end(), process::action_compare()));
+  assert(std::is_sorted(label.actions().begin(), label.actions().end()));
   assert(std::all_of(comm_set.begin(), comm_set.end(), [](const process::communication_expression& comm_expr)
   {
     return std::is_sorted(comm_expr.action_name().names().begin(), comm_expr.action_name().names().end(),

--- a/tools/experimental/ltscombine/ltscombine.cpp
+++ b/tools/experimental/ltscombine/ltscombine.cpp
@@ -57,30 +57,11 @@ public:
       lts.push_back(new_lts);
     }
 
-    // Ensure that block and hide sets are sorted
-    std::function<bool(const core::identifier_string&, const core::identifier_string&)> action_name_compare = process::action_name_compare();
-    block_set = atermpp::sort_list(block_set, action_name_compare);
-
-    hide_set = atermpp::sort_list(hide_set, action_name_compare);
-    // Ensure that each of the multi actions names in the allow set is sorted.
-    allow_set = process::action_name_multiset_list(
-      allow_set.begin(),
-      allow_set.end(),
-      [&action_name_compare](const process::action_name_multiset& multi_action_name)
-      {
-        return process::action_name_multiset(atermpp::sort_list(multi_action_name.names(), action_name_compare));
-      });
-
-    // Ensure that the left-hand sides of the synchronisation rules are sorted.
-    comm_set = process::communication_expression_list(
-      comm_set.begin(),
-      comm_set.end(),
-      [&action_name_compare](const process::communication_expression& comm)
-      {
-        return process::communication_expression(
-          process::action_name_multiset(atermpp::sort_list(comm.action_name().names(), action_name_compare)),
-          comm.name());
-      });
+    // Ensure that block and hide sets are sorted (raw identifier_string_lists have no sorting constructor).
+    block_set = atermpp::sort_list(block_set, process::action_name_compare());
+    hide_set = atermpp::sort_list(hide_set, process::action_name_compare());
+    // action_name_multiset and communication_expression constructors sort their names on construction,
+    // so allow_set and comm_set are already sorted.
 
     allow_cache = lps::detail::make_allow_list_cache(allow_set);
 


### PR DESCRIPTION
This removes a lot of custom sorting code. Also it fixes the following bug (rightfully spotted by copilot).

1. multi_action hash/equality contract violation (latent bug)
`multi_action.h:90-93` defines equality by comparing sorted action lists:
```cpp
bool operator==(const multi_action& other) const { return time()==other.time() && atermpp::sort_list(actions())==atermpp::sort_list(other.actions()); }
```
but `multi_action.h:393-397` hashes the unsorted list:
```cpp
return hasher(ma.actions()) ^ (hasher(ma.time())<<1);
```
So `a|b` and `b|a` are `==` but get different hashes. `multi_action` is used as an `unordered_map` key in `lts_builder.h:33` and `stochastic_lts_builder.h:24`, where this breaks the container invariant — the same logical multi-action can land in two buckets and be assigned two distinct action indices. It only manifests when equal multisets reach the builder in different internal orders, which is why it has survived, but it's a genuine violation.

Co-authored by: Claude

