### PR TITLE
Fix two aterm cleanup issues.

### DIFF
--- a/libraries/atermpp/include/mcrl2/atermpp/detail/thread_aterm_pool.h
+++ b/libraries/atermpp/include/mcrl2/atermpp/detail/thread_aterm_pool.h
@@ -68,23 +68,17 @@ public:
       // Without the transfer those objects become invisible to the garbage
       // collector the moment this pool is unregistered, so the next GC cycle
       // would reclaim their underlying _aterm nodes.
+      //
+      // Take our own exclusive lock (not the main pool's) so this thread
+      // becomes the "stop the world" leader before absorb() touches the
+      // main pool's hashtables directly. A plain register_variable()/
+      // register_container() call here would only take a shared lock,
+      // which does not exclude the main thread's own concurrent use of
+      // its pool.
       if (g_main_thread_pool != nullptr)
       {
-        for (const aterm_core* v : *m_variables)
-        {
-          if (v != nullptr)
-          {
-            g_main_thread_pool->register_variable(const_cast<aterm_core*>(v));
-          }
-        }
-        for (const aterm_container* c : *m_containers)
-        {
-          if (c != nullptr)
-          {
-            g_main_thread_pool->register_container(
-                const_cast<aterm_container*>(c));
-          }
-        }
+        mcrl2::utilities::lock_guard guard = m_shared_mutex.lock();
+        g_main_thread_pool->absorb(*m_variables, *m_containers);
       }
       // We need to prematurely unregister this thread pool since we are going
       // to delete the reference-variable hashtables.
@@ -142,6 +136,13 @@ public:
 
   /// \brief Removes the given container from the active variables.
   inline void deregister_container(aterm_container* variable);
+
+  /// \brief Transfers the surviving variables and containers of a pool that is
+  ///        being destroyed into this pool.
+  /// \details Takes no lock itself; the caller must already hold its own
+  ///          exclusive lock (see ~thread_aterm_pool()).
+  inline void absorb(mcrl2::utilities::hashtable<aterm_core*>& variables,
+      mcrl2::utilities::hashtable<aterm_container*>& containers);
 
   // Implementation of thread_aterm_pool_interface
   inline void mark();

--- a/libraries/atermpp/include/mcrl2/atermpp/detail/thread_aterm_pool_implementation.h
+++ b/libraries/atermpp/include/mcrl2/atermpp/detail/thread_aterm_pool_implementation.h
@@ -172,6 +172,36 @@ void thread_aterm_pool::deregister_container(aterm_container* container)
   m_containers->erase(container);
 }
 
+void thread_aterm_pool::absorb(mcrl2::utilities::hashtable<aterm_core*>& variables,
+    mcrl2::utilities::hashtable<aterm_container*>& containers)
+{
+  // No locking here: the caller already holds the exclusive lock (see
+  // ~thread_aterm_pool()), which excludes all other pools including this one.
+  for (aterm_core* v : variables)
+  {
+    if (v != nullptr)
+    {
+      if (m_variables->must_resize())
+      {
+        m_variables->resize();
+      }
+      m_variables->insert(v);
+    }
+  }
+
+  for (aterm_container* c : containers)
+  {
+    if (c != nullptr)
+    {
+      if (m_containers->must_resize())
+      {
+        m_containers->resize();
+      }
+      m_containers->insert(c);
+    }
+  }
+}
+
 void thread_aterm_pool::mark()
 {
   for (const aterm_core* variable : *m_variables) 

--- a/libraries/atermpp/test/parallel_thread_pool_test.cpp
+++ b/libraries/atermpp/test/parallel_thread_pool_test.cpp
@@ -100,3 +100,67 @@ BOOST_AUTO_TEST_CASE(test_worker_thread_aterm_survives_gc)
     delete orphan;
   }
 }
+
+// Regression test for a race condition in the #1934 transfer logic above.
+//
+// That fix transfers a dying worker's surviving entries into
+// g_main_thread_pool via register_variable()/register_container(), which
+// only take a *shared* lock. That excludes a concurrent GC, but not the main
+// thread's own (shared-locked) register/deregister calls on the very same
+// pool, nor another worker doing the same transfer concurrently. The
+// underlying hashtable has no internal synchronisation, so the concurrent
+// writes corrupt it, and a later, unrelated deregister_variable() call fails
+// to find its key: "hashtable::erase called for a key that is not present".
+//
+// This spawns worker threads that leak terms so ~thread_aterm_pool() must
+// transfer them on exit, while the main thread concurrently churns its own
+// terms -- reproducing the race directly.
+BOOST_AUTO_TEST_CASE(test_concurrent_worker_teardown_does_not_corrupt_main_pool)
+{
+  if constexpr (!mcrl2::utilities::detail::GlobalThreadSafe)
+  {
+    return;
+  }
+
+  constexpr std::size_t number_of_repetitions = 10;
+  constexpr std::size_t number_of_workers = 16;
+  constexpr std::size_t terms_per_worker = 128;
+
+  const atermpp::function_symbol orphan_sym("__test_worker_orphan__", 0);
+  const atermpp::function_symbol churn_sym("__test_main_churn__", 0);
+
+  for (std::size_t repetition = 0; repetition < number_of_repetitions; ++repetition)
+  {
+    std::atomic<std::size_t> workers_finished{ 0 };
+
+    std::vector<std::thread> workers;
+    workers.reserve(number_of_workers);
+    for (std::size_t i = 0; i < number_of_workers; ++i)
+    {
+      workers.emplace_back([&workers_finished, &orphan_sym]
+      {
+        // Leaked deliberately, so these are still registered when the
+        // thread exits below, forcing the transfer to g_main_thread_pool.
+        for (std::size_t j = 0; j < terms_per_worker; ++j)
+        {
+          new atermpp::aterm(orphan_sym);
+        }
+        ++workers_finished;
+      });
+    }
+
+    // Churn this (== main) thread's own pool while workers are exiting and
+    // transferring into it.
+    while (workers_finished.load() < number_of_workers)
+    {
+      atermpp::aterm term(churn_sym);
+    }
+
+    for (auto& worker : workers)
+    {
+      worker.join();
+    }
+  }
+
+  BOOST_CHECK(true);
+}

--- a/tools/release/lpsxsim/simulation.cpp
+++ b/tools/release/lpsxsim/simulation.cpp
@@ -13,9 +13,13 @@
 
 void Simulation::init(const QString& filename, bool do_not_use_dummies)
 {
+  // Constructed here (on this object's own worker thread), not as a
+  // Simulation member: see the comment at its declaration in simulation.h.
+  m_stochastic_spec = std::make_unique<mcrl2::lps::stochastic_specification>();
+
   try
   {
-    load_lps(m_stochastic_spec, filename.toStdString());
+    load_lps(*m_stochastic_spec, filename.toStdString());
   }
   catch (mcrl2::runtime_error& e)
   {
@@ -30,12 +34,12 @@ void Simulation::init(const QString& filename, bool do_not_use_dummies)
 
   if (!do_not_use_dummies)
   {
-    mcrl2::lps::detail::instantiate_global_variables(m_stochastic_spec);
+    mcrl2::lps::detail::instantiate_global_variables(*m_stochastic_spec);
   }
-    
-  m_simulation = new mcrl2::lps::simulation(m_stochastic_spec, m_strategy);
 
-  for (const mcrl2::data::variable& v: m_stochastic_spec.process().process_parameters())
+  m_simulation = new mcrl2::lps::simulation(*m_stochastic_spec, m_strategy);
+
+  for (const mcrl2::data::variable& v: m_stochastic_spec->process().process_parameters())
   {
     m_parameters += QString::fromStdString(mcrl2::data::pp(v));
   }

--- a/tools/release/lpsxsim/simulation.h
+++ b/tools/release/lpsxsim/simulation.h
@@ -9,6 +9,8 @@
 #ifndef LPSXSIM_SIMULATION_H
 #define LPSXSIM_SIMULATION_H
 
+#include <memory>
+
 #include <QList>
 #include <QMutex>
 #include <QObject>
@@ -79,7 +81,13 @@ class Simulation : public QObject
   private:
     mcrl2::data::rewrite_strategy m_strategy;
     bool m_initialized;
-    mcrl2::lps::stochastic_specification m_stochastic_spec;
+
+    // Constructed in init(), which runs on this object's own (worker) thread
+    // after moveToThread(): a value member here would instead be
+    // default-constructed on the main thread by Simulation's constructor,
+    // and later destroyed on the worker thread, violating atermpp's
+    // assumption that a term is destroyed on the thread that created it.
+    std::unique_ptr<mcrl2::lps::stochastic_specification> m_stochastic_spec;
 
     mcrl2::lps::simulation *m_simulation;
     QStringList m_parameters;


### PR DESCRIPTION
## Summary
- Fixes a data race in `~thread_aterm_pool()` where a dying worker thread transferred surviving terms into `g_main_thread_pool` using only a shared lock, letting it race with the main thread's own term (de)registration or another worker's concurrent transfer and corrupt the pool's hashtable.
- Fixes `lpsxsim` crashing on load (e.g. `lpsxsim abp.lps`) with `hashtable::erase` called for a key that is not present: `Simulation::m_stochastic_spec` was default-constructed on the main thread but later destroyed on the worker `atermThread`, violating `atermpp`'s single-owner-thread invariant for terms. Fixes #1955. Note that this issue was introduced with the change in 7e4f0d471e141e714646d1bca7bce85b23901eac

## Testing
- New `librarytest_mcrl2_atermpp_parallel_thread_pool_test` passes reliably (previously crashed deterministically without the first fix)
- `lpsxsim examples/academic/abp/abp.lps` no longer crashes across repeated runs, previously failed

Debugged and implemented with the aid of [Claude Code](https://claude.com/claude-code)